### PR TITLE
Remove support for python3.5 and add support for python3.9

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -13,7 +13,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v1
         with:
-          python-version: "3.8"
+          python-version: "3.9"
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
@@ -26,7 +26,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.5, 3.6, 3.7, 3.8]
+        python-version: [3.6, 3.7, 3.8, 3.9]
     steps:
     - uses: actions/checkout@v2
     - name: Set up Python ${{ matrix.python-version }}

--- a/Dockerfile.test
+++ b/Dockerfile.test
@@ -1,4 +1,4 @@
-FROM python:3.5
+FROM python:3.6
 ENV DEBIAN_FRONTEND noninteractive
 RUN apt-get update
 RUN apt-get install php7.3-cli php7.3-xml -y

--- a/Pipfile
+++ b/Pipfile
@@ -18,4 +18,4 @@ yaswfp = ">=0.9.3"
 six = ">=1.15.0"
 
 [requires]
-python_version = "3.8"
+python_version = "3.9"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -5,7 +5,7 @@
         },
         "pipfile-spec": 6,
         "requires": {
-            "python_version": "3.8"
+            "python_version": "3.9"
         },
         "sources": [
             {

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Requirements
 ============
 In order to work correctly, Wapiti needs :
 
-+ Python 3.x where x is >= 5 (3.5, 3.6, 3.7...)
++ Python 3.x where x is >= 6 (3.6, 3.7, 3.8...)
 + python-requests ( http://docs.python-requests.org/en/latest/ )
 + BeautifulSoup ( http://www.crummy.com/software/BeautifulSoup/ )
 + yaswfp ( https://github.com/facundobatista/yaswfp )


### PR DESCRIPTION
Python3.5 end of life : 13 sep 2020
Python3.9 release : 5 oct. 2020