### PR TITLE
Add arg '--max-attack-time'

### DIFF
--- a/wapitiCore/main/wapiti.py
+++ b/wapitiCore/main/wapiti.py
@@ -581,8 +581,8 @@ class Wapiti:
     def set_scan_force(self, force: str):
         self._scan_force = force
 
-    def set_max_scan_time(self, minutes: float):
-        self._max_scan_time = minutes * 60
+    def set_max_scan_time(self, seconds: float):
+        self._max_scan_time = seconds
 
     def set_color(self):
         """Put colors in the console output (terminal must support colors)"""
@@ -881,8 +881,10 @@ def wapiti_main():
 
     parser.add_argument(
         "--max-scan-time",
-        metavar="MINUTES",
-        help=_("Set how many minutes you want the scan to last (floats accepted)"),
+        metavar="SECONDS",
+        help=_("Set how many seconds you want the scan to last (floats accepted)"),
+        type=float, default=0
+    )
         type=float, default=0
     )
 


### PR DESCRIPTION
Hello,

First, I changed the way '--max-scan-time' works as I don't understand why we apply a '*60' on the argument to force it to be in minutes.

'--max-scan-time' is now in seconds.

Then I added a new arg '--max-attack-time' which cause the module to stop if it's duration is superior.

The good thing is that the vulnerabilities found are not lost and the execution continue normally (the next module is executed with the same 'timeout' constraint)

wapiti-scanner/wapiti-scanner.github.io#1

Close #48 