### PR TITLE
Fix dependencies breaking errors

### DIFF
--- a/tests/attack/test_mod_nikto.py
+++ b/tests/attack/test_mod_nikto.py
@@ -38,7 +38,7 @@ class FakePersister:
 @responses.activate
 def test_whole_stuff():
     # Test attacking all kind of parameter without crashing
-    responses.add_passthru("https://raw.githubusercontent.com/sullo/nikto/master/program/databases/db_tests")
+    responses.add_passthru("https://raw.githubusercontent.com/wapiti-scanner/nikto/master/program/databases/db_tests")
 
     responses.add(
         responses.GET,

--- a/tests/attack/test_mod_wapp.py
+++ b/tests/attack/test_mod_wapp.py
@@ -35,7 +35,7 @@ class FakePersister:
 @responses.activate
 def test_false_positive():
     # Test for false positive
-    responses.add_passthru("https://raw.githubusercontent.com/AliasIO/wappalyzer/master/src/technologies.json")
+    responses.add_passthru("https://raw.githubusercontent.com/wapiti-scanner/wappalyzer/master/src/technologies.json")
 
     responses.add(
         responses.GET,

--- a/wapitiCore/attack/mod_nikto.py
+++ b/wapitiCore/attack/mod_nikto.py
@@ -57,7 +57,7 @@ class mod_nikto(Attack):
 
     name = "nikto"
     NIKTO_DB = "nikto_db"
-    NIKTO_DB_URL = "https://raw.githubusercontent.com/sullo/nikto/master/program/databases/db_tests"
+    NIKTO_DB_URL = "https://raw.githubusercontent.com/wapiti-scanner/nikto/master/program/databases/db_tests"
 
     do_get = False
     do_post = False

--- a/wapitiCore/attack/mod_wapp.py
+++ b/wapitiCore/attack/mod_wapp.py
@@ -31,7 +31,7 @@ class mod_wapp(Attack):
 
     name = "wapp"
     WAPP_DB = "apps.json"
-    WAPP_DB_URL = "https://raw.githubusercontent.com/AliasIO/wappalyzer/master/src/technologies.json"
+    WAPP_DB_URL = "https://raw.githubusercontent.com/wapiti-scanner/wappalyzer/master/src/technologies.json"
 
     do_get = False
     do_post = False

--- a/wapitiCore/wappalyzer/wappalyzer.py
+++ b/wapitiCore/wappalyzer/wappalyzer.py
@@ -22,7 +22,7 @@ class ApplicationDataException(Exception):
 class ApplicationData:
     """
     Store application database.
-    For instance https://raw.githubusercontent.com/AliasIO/wappalyzer/master/src/technologies.json.
+    For instance https://raw.githubusercontent.com/wapiti-scanner/wappalyzer/master/src/technologies.json.
     """
 
     def __init__(self, data_filename=None):


### PR DESCRIPTION
Dependencies can break wapiti. We have detected 2 times where wappalyzer has changed the format of its json file.

For more stability, let's use forks from the nikto and wappalyzer projects. 