### PR TITLE
Move http_headers, csp and cookieflags results in vulnerability

### DIFF
--- a/wapitiCore/attack/mod_cookieflags.py
+++ b/wapitiCore/attack/mod_cookieflags.py
@@ -44,7 +44,7 @@ class mod_cookieflags(Attack):
             self.log_blue(_("Checking cookie : {}").format(cookie.name))
             if not self.check_httponly_flag(cookie):
                 self.log_red(INFO_COOKIE_HTTPONLY.format(cookie.name))
-                self.add_addition(
+                self.add_vuln(
                     category=COOKIE_HTTPONLY_DISABLED,
                     level=LOW_LEVEL,
                     request=request,
@@ -53,7 +53,7 @@ class mod_cookieflags(Attack):
 
             if not self.check_secure_flag(cookie):
                 self.log_red(INFO_COOKIE_SECURE.format(cookie.name))
-                self.add_addition(
+                self.add_vuln(
                     category=COOKIE_SECURE_DISABLED,
                     level=LOW_LEVEL,
                     request=request,

--- a/wapitiCore/attack/mod_csp.py
+++ b/wapitiCore/attack/mod_csp.py
@@ -37,7 +37,7 @@ class mod_csp(Attack):
 
         if "Content-Security-Policy" not in response.headers:
             self.log_red(MSG_NO_CSP)
-            self.add_addition(
+            self.add_vuln(
                 category=NAME,
                 level=LOW_LEVEL,
                 request=request,
@@ -51,7 +51,7 @@ class mod_csp(Attack):
 
                 if result == -1:
                     self.log_red(MSG_CSP_MISSING.format(policy_name))
-                    self.add_addition(
+                    self.add_vuln(
                         category=NAME,
                         level=LOW_LEVEL,
                         request=request,
@@ -59,7 +59,7 @@ class mod_csp(Attack):
                     )
                 elif result == 0:
                     self.log_red(MSG_CSP_UNSAFE.format(policy_name))
-                    self.add_addition(
+                    self.add_vuln(
                         category=NAME,
                         level=LOW_LEVEL,
                         request=request,

--- a/wapitiCore/attack/mod_http_headers.py
+++ b/wapitiCore/attack/mod_http_headers.py
@@ -47,7 +47,7 @@ class mod_http_headers(Attack):
         self.log_blue(_("Checking X-Frame-Options :"))
         if not self.is_set(response, "X-Frame-Options", self.check_list_xframe):
             self.log_red(INFO_XFRAME_OPTIONS)
-            self.add_addition(
+            self.add_vuln(
                 category=NAME,
                 level=LOW_LEVEL,
                 request=request,
@@ -59,7 +59,7 @@ class mod_http_headers(Attack):
         self.log_blue(_("Checking X-XSS-Protection :"))
         if not self.is_set(response, "X-XSS-Protection", self.check_list_xss):
             self.log_red(INFO_XSS_PROTECTION)
-            self.add_addition(
+            self.add_vuln(
                 category=NAME,
                 level=LOW_LEVEL,
                 request=request,
@@ -71,7 +71,7 @@ class mod_http_headers(Attack):
         self.log_blue(_("Checking X-Content-Type-Options :"))
         if not self.is_set(response, "X-Content-Type-Options", self.check_list_xcontent):
             self.log_red(INFO_XCONTENT_TYPE)
-            self.add_addition(
+            self.add_vuln(
                 category=NAME,
                 level=LOW_LEVEL,
                 request=request,
@@ -83,7 +83,7 @@ class mod_http_headers(Attack):
         self.log_blue(_("Checking Strict-Transport-Security :"))
         if not self.is_set(response, "Strict-Transport-Security", self.check_list_hsts):
             self.log_red(INFO_HSTS)
-            self.add_addition(
+            self.add_vuln(
                 category=NAME,
                 level=LOW_LEVEL,
                 request=request,

--- a/wapitiCore/definitions/csp.py
+++ b/wapitiCore/definitions/csp.py
@@ -19,7 +19,7 @@
 # Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 from wapitiCore.language.language import _
 
-TYPE = "additional"
+TYPE = "vulnerability"
 
 NAME = _("Content Security Policy Configuration")
 SHORT_NAME = _("CSP Configuration")

--- a/wapitiCore/definitions/http_headers.py
+++ b/wapitiCore/definitions/http_headers.py
@@ -19,7 +19,7 @@
 # Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 from wapitiCore.language.language import _
 
-TYPE = "additional"
+TYPE = "vulnerability"
 
 NAME = _("HTTP Secure Headers")
 SHORT_NAME = NAME

--- a/wapitiCore/definitions/http_only.py
+++ b/wapitiCore/definitions/http_only.py
@@ -19,7 +19,7 @@
 # Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 from wapitiCore.language.language import _
 
-TYPE = "additional"
+TYPE = "vulnerability"
 
 NAME = _("HttpOnly Flag cookie")
 SHORT_NAME = NAME

--- a/wapitiCore/definitions/secure_cookie.py
+++ b/wapitiCore/definitions/secure_cookie.py
@@ -19,7 +19,7 @@
 # Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 from wapitiCore.language.language import _
 
-TYPE = "additional"
+TYPE = "vulnerability"
 
 NAME = _("Secure Flag cookie")
 SHORT_NAME = NAME


### PR DESCRIPTION
Replace add_anom by add_vuln in http_headers, csp and cookieflags modules.
Change TYPE value in definitions.