### PR TITLE
Add boolean-based blind SQL injection

### DIFF
--- a/make_exe.py
+++ b/make_exe.py
@@ -97,7 +97,7 @@ if a script is vulnerable.""",
             "includes": [
                 "wapitiCore.attack.mod_backup",
                 "wapitiCore.attack.mod_brute_login_form",
-                "wapitiCore.attack.mod_blindsql",
+                "wapitiCore.attack.mod_timesql",
                 "wapitiCore.attack.mod_buster",
                 "wapitiCore.attack.mod_cookieflags",
                 "wapitiCore.attack.mod_crlf",

--- a/tests/attack/test_mod_timesql.py
+++ b/tests/attack/test_mod_timesql.py
@@ -11,7 +11,7 @@ from requests.exceptions import ReadTimeout
 
 from wapitiCore.net.web import Request
 from wapitiCore.net.crawler import Crawler
-from wapitiCore.attack.mod_blindsql import mod_blindsql
+from wapitiCore.attack.mod_timesql import mod_timesql
 
 
 class FakePersister:
@@ -47,7 +47,7 @@ def run_around_tests():
     proc.terminate()
 
 
-def test_blindsql_detection():
+def test_timesql_detection():
     # It looks like php -S has serious limitations
     # so PHP script should wait a minimum amount of time for the test to succeed
     persister = FakePersister()
@@ -57,7 +57,7 @@ def test_blindsql_detection():
     options = {"timeout": 1, "level": 1}
     logger = Mock()
 
-    module = mod_blindsql(crawler, persister, logger, options)
+    module = mod_timesql(crawler, persister, logger, options)
     module.do_post = False
     module.attack(request)
 
@@ -66,7 +66,7 @@ def test_blindsql_detection():
     assert "sleep" in persister.vulnerabilities[0][1]
 
 
-def test_blindsql_false_positive():
+def test_timesql_false_positive():
     persister = FakePersister()
     request = Request("http://127.0.0.1:65082/blind_sql.php?vuln2=hello%20there")
     request.path_id = 42
@@ -74,7 +74,7 @@ def test_blindsql_false_positive():
     options = {"timeout": 1, "level": 1}
     logger = Mock()
 
-    module = mod_blindsql(crawler, persister, logger, options)
+    module = mod_timesql(crawler, persister, logger, options)
     module.do_post = False
     module.attack(request)
 
@@ -103,7 +103,7 @@ def test_false_positive_request_count():
     options = {"timeout": 1, "level": 1}
     logger = Mock()
 
-    module = mod_blindsql(crawler, persister, logger, options)
+    module = mod_timesql(crawler, persister, logger, options)
     module.verbose = 2
     module.do_post = False
     module.attack(request)
@@ -135,7 +135,7 @@ def test_true_positive_request_count():
     options = {"timeout": 1, "level": 1}
     logger = Mock()
 
-    module = mod_blindsql(crawler, persister, logger, options)
+    module = mod_timesql(crawler, persister, logger, options)
     module.verbose = 2
     module.do_post = False
     module.attack(request)

--- a/tests/parsers/test_html_parser.py
+++ b/tests/parsers/test_html_parser.py
@@ -156,7 +156,7 @@ def test_meta():
         assert page.description == "Meta page"
         assert page.keywords == ["this", "is", " dope"]
         assert page.generator == "YoloCMS 1.0"
-        assert page.text_only == "This is dope"
+        assert page.text_only == "  -  Title :)  This is dope"
         assert page.favicon_url == "http://perdu.com/custom.ico"
         assert page.md5 == "2778718d04cfa16ffd264bd76b0cf18b"
 

--- a/wapitiCore/attack/attack.py
+++ b/wapitiCore/attack/attack.py
@@ -45,7 +45,7 @@ modules = [
     "mod_backup",
     "mod_brute_login_form",
     "mod_htaccess",
-    "mod_blindsql",
+    "mod_timesql",
     "mod_permanentxss",
     "mod_nikto",
     "mod_buster",
@@ -59,7 +59,6 @@ modules = [
 
 # Modules that will be used if option -m isn't used
 commons = [
-    "blindsql",
     "cookieflags",
     "csp",
     "exec",

--- a/wapitiCore/attack/mod_sql.py
+++ b/wapitiCore/attack/mod_sql.py
@@ -487,7 +487,7 @@ class mod_sql(Attack):
             except RequestException:
                 self.network_errors += 1
                 # We need all cases to make sure SQLi is there
-                skip_till_next_parameter = True
+                test_results.append(False)
                 continue
 
             comparison = (

--- a/wapitiCore/attack/mod_sql.py
+++ b/wapitiCore/attack/mod_sql.py
@@ -479,6 +479,10 @@ class mod_sql(Attack):
                 # If parameter is vulnerable, just skip till next parameter
                 continue
 
+            if test_results and not all(test_results):
+                # No need to go further: one of the tests was wrong
+                continue
+
             if self.verbose == 2:
                 print("[¨] {0}".format(mutated_request))
 

--- a/wapitiCore/attack/mod_sql.py
+++ b/wapitiCore/attack/mod_sql.py
@@ -433,7 +433,7 @@ class mod_sql(Attack):
             good_status = good_response.status
             good_redirect = good_response.redirection_url
             # good_title = response.title
-            good_hash = good_response.md5
+            good_hash = good_response.text_only_md5
         except ReadTimeout:
             self.network_errors += 1
             return
@@ -517,9 +517,9 @@ class mod_sql(Attack):
                 continue
 
             comparison = (
-                response.status == good_status and
-                response.redirection_url == good_redirect and
-                response.md5 == good_hash
+                    response.status == good_status and
+                    response.redirection_url == good_redirect and
+                    response.text_only_md5 == good_hash
             )
 
             test_results.append(comparison == (flags.section == "True"))

--- a/wapitiCore/attack/mod_sql.py
+++ b/wapitiCore/attack/mod_sql.py
@@ -320,7 +320,6 @@ class mod_sql(Attack):
         self.boolean_based_attack(request, vulnerable_parameters)
 
     def error_based_attack(self, request: Request):
-        timeouted = False
         page = request.path
         saw_internal_error = False
         current_parameter = None
@@ -341,31 +340,6 @@ class mod_sql(Attack):
 
             try:
                 response = self.crawler.send(mutated_request)
-            except ReadTimeout:
-                self.network_errors += 1
-                if timeouted:
-                    continue
-
-                self.log_orange("---")
-                self.log_orange(Messages.MSG_TIMEOUT, page)
-                self.log_orange(Messages.MSG_EVIL_REQUEST)
-                self.log_orange(mutated_request.http_repr())
-                self.log_orange("---")
-
-                if parameter == "QUERY_STRING":
-                    anom_msg = Messages.MSG_QS_TIMEOUT
-                else:
-                    anom_msg = Messages.MSG_PARAM_TIMEOUT.format(parameter)
-
-                self.add_anom(
-                    request_id=request.path_id,
-                    category=Messages.RES_CONSUMPTION,
-                    level=MEDIUM_LEVEL,
-                    request=mutated_request,
-                    info=anom_msg,
-                    parameter=parameter
-                )
-                timeouted = True
             except RequestException:
                 self.network_errors += 1
             else:

--- a/wapitiCore/attack/mod_sql.py
+++ b/wapitiCore/attack/mod_sql.py
@@ -268,7 +268,7 @@ def generate_boolean_test_values(separator: str, parenthesis: bool):
 
 class mod_sql(Attack):
     """
-    Detect SQL (but also LDAP and XPath) injection vulnerabilities by triggering errors (error-based technique).
+    Detect SQL (also LDAP and XPath) injection vulnerabilities using error-based or boolean-based (blind) techniques.
     """
 
     time_to_sleep = 6

--- a/wapitiCore/attack/mod_timesql.py
+++ b/wapitiCore/attack/mod_timesql.py
@@ -24,14 +24,14 @@ from wapitiCore.definitions.blindsql import NAME
 from wapitiCore.net.web import Request
 
 
-class mod_blindsql(Attack):
+class mod_timesql(Attack):
     """
     Detect SQL injection vulnerabilities using blind time-based technique.
     """
 
     PAYLOADS_FILE = "blindSQLPayloads.txt"
     time_to_sleep = 6
-    name = "blindsql"
+    name = "timesql"
     PRIORITY = 6
 
     MSG_VULN = _("Blind SQL vulnerability")

--- a/wapitiCore/main/wapiti.py
+++ b/wapitiCore/main/wapiti.py
@@ -1148,7 +1148,6 @@ def wapiti_main():
         if "output" in args:
             wap.set_output_file(args.output)
 
-        found_generator = False
         if args.format not in GENERATORS:
             raise InvalidOptionValue("-f", args.format)
 

--- a/wapitiCore/net/page.py
+++ b/wapitiCore/net/page.py
@@ -34,7 +34,7 @@ from requests.models import Response
 from tld import get_fld
 from tld.exceptions import TldDomainNotFound, TldBadUrl
 from bs4 import BeautifulSoup
-from bs4.element import Comment
+from bs4.element import Comment, Doctype
 
 # Internal libraries
 from wapitiCore import parser_name
@@ -554,14 +554,14 @@ class Page:
     def text_only(self):
         """Returns the displayed text of a webpage (without HTML tags)"""
         if "text" in self.type and self.size:
-            texts = self.soup.findAll(text=True)
+            texts = self.soup.find_all(text=True)
 
             def is_visible(element):
                 if len(element.strip()) == 0:
                     return False
-                if isinstance(element, Comment):
+                if isinstance(element, (Comment, Doctype)):
                     return False
-                if element.parent.name in ["style", "script", "[document]", "head", "title"]:
+                if element.parent.name in ["style", "script", "head"]:
                     return False
                 return True
 

--- a/wapitiCore/net/page.py
+++ b/wapitiCore/net/page.py
@@ -569,6 +569,10 @@ class Page:
             return text
         return ""
 
+    @property
+    def text_only_md5(self) -> str:
+        return md5(self.text_only.encode(errors="ignore")).hexdigest()
+
     def empty(self):
         """Modify the current Page object to make it appears as if the content-length was 0."""
         self._is_empty = True

--- a/wapitiCore/net/web.py
+++ b/wapitiCore/net/web.py
@@ -22,7 +22,7 @@ from copy import deepcopy
 import sys
 
 
-def urlencode(query, safe='', encoding=None, errors=None, quote_via=quote_plus):
+def urlencode(query, safe='', encoding=None, errors=None, quote_via=quote):
     """Encode a dict or sequence of two-element tuples into a URL query string.
 
     If the query arg is a sequence of two-element tuples, the order of the


### PR DESCRIPTION
Currently Wapiti use two separate modules for SQL injection :
- sql for error-based sql injections
- blindsql for time based sql injections

Both have pros and cons (error-based is very fast but errors are hidden most of the time so detection rate is low while time-based is slow but works with silent errors). A boolean-based module should bring advantages of both:

- it is not that fast but the amount of payloads is reduced compared to time-based, also we don't have to wait for a timeout :+1: 
- works well for blind injection and is more dbms agnostic than time-based (which is using sleep() for mysql and waitfor for mssql for example while other dbms doesn't have such capability)

Also we can move the old blindsql module to a renamed timesql with will be more explicit and make it optional.

Encoding of values should also use Python's quote() function instead of quote_plus() as it seems the '+' sign in URL produces unexpected errors for ASP webpages (while %20 works well)