### PR TITLE
Fix README.md to README.rst

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,4 +1,4 @@
-include README.md
+include README.rst
 include INSTALL.md
 include LICENSE
 include VERSION

--- a/setup.py
+++ b/setup.py
@@ -48,7 +48,7 @@ doc_and_conf_files = [
             "doc/xxe_module.md",
             "LICENSE",
             "INSTALL.md",
-            "README.md",
+            "README.rst",
             "VERSION"
         ]
     ),


### PR DESCRIPTION
Some README.md were still present in MANIFEST.in and setup.py, breaking the build process.