### PR TITLE
Changed hashing for FIPS mode

### DIFF
--- a/wapitiCore/main/wapiti.py
+++ b/wapitiCore/main/wapiti.py
@@ -30,7 +30,7 @@ from datetime import datetime
 import logging
 from uuid import uuid1
 from sqlite3 import OperationalError
-from hashlib import md5
+from hashlib import sha256
 from random import choice
 import codecs
 from inspect import getdoc
@@ -140,7 +140,7 @@ class Wapiti:
             "{}_{}_{}.db".format(
                 self.server.replace(':', '_'),
                 self.target_scope,
-                md5(root_url.encode(errors="replace")).hexdigest()[:8]
+                sha256(root_url.encode(errors="replace")).hexdigest()[:8]
             )
         )
 


### PR DESCRIPTION
FIPS mode is a government standard for encryption, and changing the hashing algorithm from md5 to sha256 here should allow you to run within a FIPS environment.

Curious if there was a reason to use md5 instead of sha256 here. There could also be a flag added into the args but since the hashing is set during init, it would take a bit of rework in that area.