### PR TITLE
Fix problem of detected default values in wapiti-getcookie

### DIFF
--- a/wapitiCore/main/getcookie.py
+++ b/wapitiCore/main/getcookie.py
@@ -182,6 +182,8 @@ def getcookie_main():
                     field, value = post_param_tuple
                     if value:
                         new_value = input(field + " (" + value + ") : ")
+                        if not new_value:
+                            new_value = value
                     else:
                         new_value = input("{}: ".format(field))
                     post_params[i] = [field, new_value]


### PR DESCRIPTION
When "wapiti-getcookie" detect default values in forms the user have to copy-past those values and put them manually.
This MR fix this problem and "wapiti-getcookie" take thoses values by pressing "Enter" in the interactive terminal 