### PR TITLE
Account for lowercase HttpOnly flag.

### DIFF
--- a/wapitiCore/attack/mod_cookieflags.py
+++ b/wapitiCore/attack/mod_cookieflags.py
@@ -35,7 +35,7 @@ class mod_cookieflags(Attack):
 
     @staticmethod
     def check_httponly_flag(cookie: object):
-        return "HttpOnly" in cookie._rest
+        return "HttpOnly" in cookie._rest or "httponly" in cookie._rest
 
     def must_attack(self, request: Request):
         if self.finished:


### PR DESCRIPTION
Wapiti produces false positive on ASP .Net Core applications. Reason for that is that ASP .Net Core sets HttpOnly cookie parameter in lowercase: 

https://github.com/dotnet/aspnetcore/blob/52eff90fbcfca39b7eb58baad597df6a99a542b0/src/Http/Headers/src/SetCookieHeaderValue.cs#L34

According to [RFC](https://tools.ietf.org/html/rfc6265#section-5.2.6) any cookie flags can be case insensitive 
> If the attribute-name case-insensitively matches the string
   "HttpOnly", the user agent MUST append an attribute to the cookie-
   attribute-list with an attribute-name of HttpOnly and an empty
   attribute-value.