### PR TITLE
Add Github Action with docker build

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -23,6 +23,19 @@ jobs:
         run: |
           pylint --rcfile=.pylintrc *.py wapitiCore
 
+  docker:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up Docker
+        uses: docker/setup-buildx-action@v1
+        id: buildx
+        with:
+          install: true
+      - name: Build
+        run: |
+          docker build .
+
   build:
     runs-on: ubuntu-latest
     strategy:

--- a/setup.py
+++ b/setup.py
@@ -116,7 +116,8 @@ if a script is vulnerable.""",
         "markupsafe==1.1.1",
         "six>=1.15.0",
         "importlib_metadata==3.7.2",
-        "browser-cookie3==0.11.4"
+        "browser-cookie3==0.11.4",
+        "cryptography==3.3.2"
     ],
     extras_require={
         "NTLM": ["requests_ntlm"],


### PR DESCRIPTION
Add a new github action which will build the dockerfile to avoid breaking it again in the future.

Im using docker/setup_buildx_actions, which I found in https://docs.docker.com/ci-cd/github-actions/

I also fixed the Dockerfile with https://github.com/wapiti-scanner/wapiti/issues/115#issuecomment-826359573

Resolve #115 