### PR TITLE
Persister: Use SQLAlchemy in order to support other DBMS / asyncio mode / Remove FakePersister

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -19,6 +19,9 @@ six = ">=1.15.0"
 browser-cookie3 = "==0.11.4"
 importlib_metadata = "==3.7.2"
 brotli = ">=1.0.9"
+sqlalchemy = ">=1.4.17"
+aiocache = "==0.11.1"
+aiosqlite = "==0.17.0"
 
 [requires]
 python_version = "3.8"

--- a/setup.py
+++ b/setup.py
@@ -118,7 +118,10 @@ if a script is vulnerable.""",
         "importlib_metadata==3.7.2",
         "browser-cookie3==0.11.4",
         "cryptography==3.3.2",
-        "brotli>=1.0.9"
+        "brotli>=1.0.9",
+        "sqlalchemy>=1.4.17",
+        "aiocache==0.11.1",
+        "aiosqlite==0.17.0"
     ],
     extras_require={
         "NTLM": ["httpx-ntlm"],

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,20 @@
+from unittest.mock import MagicMock
+
+
+class AsyncMock(MagicMock):
+    async def __call__(self, *args, **kwargs):
+        return super(AsyncMock, self).__call__(*args, **kwargs)
+
+
+class AsyncIterator:
+    def __init__(self, seq):
+        self.iter = iter(seq)
+
+    def __aiter__(self):
+        return self
+
+    async def __anext__(self):
+        try:
+            return next(self.iter)
+        except StopIteration:
+            raise StopAsyncIteration

--- a/tests/attack/test_mod_buster.py
+++ b/tests/attack/test_mod_buster.py
@@ -5,11 +5,12 @@ import httpx
 import respx
 import pytest
 
-from tests.attack.fake_persister import FakePersister
 from wapitiCore.net.web import Request
 from wapitiCore.net.crawler import AsyncCrawler
 from wapitiCore.attack.mod_buster import mod_buster
 from wapitiCore.attack.attack import Flags
+from tests import AsyncIterator
+
 
 @pytest.mark.asyncio
 @respx.mock
@@ -24,13 +25,13 @@ async def test_whole_stuff():
     respx.get("http://perdu.com/admin/authconfig.php").mock(return_value=httpx.Response(200, text="Hello there"))
     respx.get(url__regex=r"http://perdu\.com/.*").mock(return_value=httpx.Response(404))
 
-    persister = FakePersister()
+    persister = Mock()
 
     request = Request("http://perdu.com/")
     request.path_id = 1
     request.set_headers({"content-type": "text/html"})
     # Buster module will get requests from the persister
-    persister.requests.append(request)
+    persister.get_links.return_value = AsyncIterator([request])
 
     crawler = AsyncCrawler("http://perdu.com/", timeout=1)
     options = {"timeout": 10, "level": 2}

--- a/tests/attack/test_mod_csrf.py
+++ b/tests/attack/test_mod_csrf.py
@@ -7,11 +7,12 @@ from asyncio import Event
 
 import pytest
 
-from tests.attack.fake_persister import FakePersister
 from wapitiCore.net.web import Request
 from wapitiCore.net.crawler import AsyncCrawler
 from wapitiCore.attack.mod_csrf import mod_csrf
 from wapitiCore.language.vulnerability import _
+from tests import AsyncMock
+
 
 @pytest.fixture(autouse=True)
 def run_around_tests():
@@ -26,11 +27,12 @@ def run_around_tests():
 
 @pytest.mark.asyncio
 async def test_csrf_cases():
-    persister = FakePersister()
+    persister = AsyncMock()
+    all_requests = []
 
     request = Request("http://127.0.0.1:65086/")
     request.path_id = 1
-    persister.requests.append(request)
+    all_requests.append(request)
 
     request = Request(
         "http://127.0.0.1:65086/",
@@ -38,7 +40,7 @@ async def test_csrf_cases():
         post_params=[["email", "wapiti2021@mailinator.com"], ["xsrf_token", "weak"]],
     )
     request.path_id = 2
-    persister.requests.append(request)
+    all_requests.append(request)
 
     request = Request(
         "http://127.0.0.1:65086/?check=true",
@@ -46,7 +48,7 @@ async def test_csrf_cases():
         post_params=[["email", "wapiti2021@mailinator.com"], ["xsrf_token", "weak"]],
     )
     request.path_id = 3
-    persister.requests.append(request)
+    all_requests.append(request)
 
     request = Request(
         "http://127.0.0.1:65086/?check=true",
@@ -54,7 +56,7 @@ async def test_csrf_cases():
         post_params=[["name", "Obiwan"]],
     )
     request.path_id = 4
-    persister.requests.append(request)
+    all_requests.append(request)
 
     crawler = AsyncCrawler("http://127.0.0.1:65086/", timeout=1)
     options = {"timeout": 10, "level": 1}
@@ -63,20 +65,20 @@ async def test_csrf_cases():
     module = mod_csrf(crawler, persister, logger, options, Event())
     module.do_post = True
     module.verbose = 2
-    for request in persister.requests:
-        if module.must_attack(request):
+    for request in all_requests:
+        if await module.must_attack(request):
             await module.attack(request)
         else:
             # Not attacked because of GET verb
             assert request.path_id == 1
 
-    assert persister.module == "csrf"
-    assert persister.vulnerabilities[0]["category"] == _("Cross Site Request Forgery")
-    assert persister.vulnerabilities[0]["request_id"] == 2
-    assert persister.vulnerabilities[0]["info"] == \
-        _("CSRF token '{}' is not properly checked in backend").format("xsrf_token")
-    assert persister.vulnerabilities[1]["request_id"] == 3
-    assert persister.vulnerabilities[1]["info"] == _("CSRF token '{}' might be easy to predict").format("xsrf_token")
-    assert persister.vulnerabilities[2]["request_id"] == 4
-    assert persister.vulnerabilities[2]["info"] == _("Lack of anti CSRF token")
+    vulnerabilities = set()
+    for call in persister.add_payload.call_args_list:
+        vulnerabilities.add((call[1]["request_id"], call[1]["info"]))
+
+    assert vulnerabilities == {
+        (2, _("CSRF token '{}' is not properly checked in backend").format("xsrf_token")),
+        (3, _("CSRF token '{}' might be easy to predict").format("xsrf_token")),
+        (4, _("Lack of anti CSRF token"))
+    }
     await crawler.close()

--- a/tests/attack/test_mod_htaccess.py
+++ b/tests/attack/test_mod_htaccess.py
@@ -5,11 +5,12 @@ import httpx
 import respx
 import pytest
 
-from tests.attack.fake_persister import FakePersister
 from wapitiCore.net.web import Request
 from wapitiCore.net.crawler import AsyncCrawler
-from wapitiCore.attack.mod_htaccess import mod_htaccess
 from wapitiCore.language.vulnerability import _
+from wapitiCore.attack.mod_htaccess import mod_htaccess
+from tests import AsyncMock
+
 
 @pytest.mark.asyncio
 @respx.mock
@@ -23,19 +24,20 @@ async def test_whole_stuff():
         return_value=httpx.Response(200, text="Hello there")
     )
 
-    persister = FakePersister()
+    persister = AsyncMock()
+    all_requests = []
 
     request = Request("http://perdu.com/")
     request.path_id = 1
     request.status = 200
     request.set_headers({"content-type": "text/html"})
-    persister.requests.append(request)
+    all_requests.append(request)
 
     request = Request("http://perdu.com/admin/")
     request.path_id = 2
     request.status = 401
     request.set_headers({"content-type": "text/html"})
-    persister.requests.append(request)
+    all_requests.append(request)
 
     crawler = AsyncCrawler("http://perdu.com/", timeout=1)
     options = {"timeout": 10, "level": 2}
@@ -44,14 +46,14 @@ async def test_whole_stuff():
     module = mod_htaccess(crawler, persister, logger, options, Event())
     module.verbose = 2
     module.do_get = True
-    for request in persister.requests:
-        if module.must_attack(request):
+    for request in all_requests:
+        if await module.must_attack(request):
             await module.attack(request)
         else:
             assert request.path_id == 1
 
-    assert persister.module == "htaccess"
-    assert persister.vulnerabilities
-    assert persister.vulnerabilities[0]["category"] == _("Htaccess Bypass")
-    assert persister.vulnerabilities[0]["request"].url == "http://perdu.com/admin/"
+    assert persister.add_payload.call_count == 1
+    assert persister.add_payload.call_args_list[0][1]["module"] == "htaccess"
+    assert persister.add_payload.call_args_list[0][1]["category"] == _("Htaccess Bypass")
+    assert persister.add_payload.call_args_list[0][1]["request"].url == "http://perdu.com/admin/"
     await crawler.close()

--- a/tests/attack/test_mod_methods.py
+++ b/tests/attack/test_mod_methods.py
@@ -1,23 +1,14 @@
 from asyncio import Event
+from unittest.mock import Mock
 
 import httpx
 import respx
 import pytest
 
-from tests.attack.fake_persister import FakePersister
 from wapitiCore.net.web import Request
 from wapitiCore.net.crawler import AsyncCrawler
 from wapitiCore.attack.mod_methods import mod_methods
-from wapitiCore.language.logger import ConsoleLogger
-
-class FakeLogger(ConsoleLogger):
-    def __init__(self):
-        super().__init__()
-        self.message = ""
-
-    def log_orange(self, fmt_string, *args):
-        if fmt_string != "---":
-            self.message = fmt_string
+from tests import AsyncMock
 
 
 @pytest.mark.asyncio
@@ -32,29 +23,31 @@ async def test_whole_stuff():
         return_value=httpx.Response(200, text="Private section", headers={"Allow": "GET,POST,HEAD,PUT"})
     )
 
-    persister = FakePersister()
+    persister = AsyncMock()
+    all_requests = []
 
     request = Request("http://perdu.com/")
     request.path_id = 1
     request.status = 200
     request.set_headers({"content-type": "text/html"})
-    persister.requests.append(request)
+    all_requests.append(request)
 
     request = Request("http://perdu.com/dav/")
     request.path_id = 2
     request.status = 200
     request.set_headers({"content-type": "text/html"})
-    persister.requests.append(request)
+    all_requests.append(request)
 
     crawler = AsyncCrawler("http://perdu.com/", timeout=1)
     options = {"timeout": 10, "level": 2}
-    logger = FakeLogger()
+    logger = Mock()
 
     module = mod_methods(crawler, persister, logger, options, Event())
     module.verbose = 2
     module.do_get = True
-    for request in persister.requests:
+    for request in all_requests:
         await module.attack(request)
 
-    assert "http://perdu.com/dav/" in logger.message
+    assert logger.log_orange.call_count == 3
+    assert "http://perdu.com/dav/" in logger.log_orange.call_args_list[1][0][0]
     await crawler.close()

--- a/tests/attack/test_mod_nikto.py
+++ b/tests/attack/test_mod_nikto.py
@@ -1,15 +1,18 @@
 from unittest.mock import Mock
+import os
 from asyncio import Event
+from itertools import chain
 
 import httpx
 import respx
 import pytest
 
-from tests.attack.fake_persister import FakePersister
 from wapitiCore.net.web import Request
 from wapitiCore.net.crawler import AsyncCrawler
-from wapitiCore.attack.mod_nikto import mod_nikto
 from wapitiCore.language.vulnerability import _
+from wapitiCore.attack.mod_nikto import mod_nikto
+from tests import AsyncMock
+
 
 @pytest.mark.asyncio
 @respx.mock
@@ -25,13 +28,16 @@ async def test_whole_stuff():
         return_value=httpx.Response(404, text="Not found")
     )
 
-    persister = FakePersister()
+    persister = AsyncMock()
+    home_dir = os.getenv("HOME") or os.getenv("USERPROFILE")
+    base_dir = os.path.join(home_dir, ".wapiti")
+    persister.CONFIG_DIR = os.path.join(base_dir, "config")
 
     request = Request("http://perdu.com/")
     request.path_id = 1
     request.status = 200
     request.set_headers({"content-type": "text/html"})
-    persister.requests.append(request)
+    persister.get_links.return_value = chain([request])
 
     crawler = AsyncCrawler("http://perdu.com/", timeout=1)
     options = {"timeout": 10, "level": 2}
@@ -42,11 +48,13 @@ async def test_whole_stuff():
     module.do_get = True
     await module.attack(request)
 
-    assert persister.module == "nikto"
-    assert len(persister.vulnerabilities) == 1
-    assert persister.vulnerabilities[0]["category"] == _("Potentially dangerous file")
-    assert persister.vulnerabilities[0]["request"].url == (
+    assert persister.add_payload.call_count == 1
+    assert persister.add_payload.call_args_list[0][1]["module"] == "nikto"
+    assert persister.add_payload.call_args_list[0][1]["category"] == _("Potentially dangerous file")
+    assert persister.add_payload.call_args_list[0][1]["request"].url == (
         "http://perdu.com/cgi-bin/a1disp3.cgi?..%2F..%2F..%2F..%2F..%2F..%2F..%2F..%2F..%2F..%2Fetc%2Fpasswd"
     )
-    assert "This CGI allows attackers read arbitrary files on the host" in persister.vulnerabilities[0]["info"]
+    assert (
+               "This CGI allows attackers read arbitrary files on the host"
+           ) in persister.add_payload.call_args_list[0][1]["info"]
     await crawler.close()

--- a/tests/attack/test_mod_shellshock.py
+++ b/tests/attack/test_mod_shellshock.py
@@ -7,11 +7,12 @@ import httpx
 import respx
 import pytest
 
-from tests.attack.fake_persister import FakePersister
 from wapitiCore.net.web import Request
 from wapitiCore.net.crawler import AsyncCrawler
-from wapitiCore.attack.mod_shellshock import mod_shellshock
 from wapitiCore.language.vulnerability import _
+from wapitiCore.attack.mod_shellshock import mod_shellshock
+from tests import AsyncMock
+
 
 def shellshock_callback(request):
     if "user-agent" in request.headers:
@@ -29,19 +30,20 @@ async def test_whole_stuff():
 
     respx.get(url__regex=r"http://perdu.com/.*").mock(side_effect=shellshock_callback)
 
-    persister = FakePersister()
+    persister = AsyncMock()
+    all_requests = []
 
     request = Request("http://perdu.com/")
     request.path_id = 1
     request.status = 200
     request.set_headers({"content-type": "text/html"})
-    persister.requests.append(request)
+    all_requests.append(request)
 
     request = Request("http://perdu.com/vuln/")
     request.path_id = 2
     request.status = 200
     request.set_headers({"content-type": "text/html"})
-    persister.requests.append(request)
+    all_requests.append(request)
 
     crawler = AsyncCrawler("http://perdu.com/", timeout=1)
     options = {"timeout": 10, "level": 2}
@@ -50,13 +52,11 @@ async def test_whole_stuff():
     module = mod_shellshock(crawler, persister, logger, options, Event())
     module.verbose = 2
     module.do_get = True
-    for request in persister.requests:
+    for request in all_requests:
         await module.attack(request)
 
-    assert persister.module == "shellshock"
-    assert len(persister.vulnerabilities) == 1
-    assert persister.vulnerabilities[0]["category"] == _("Command execution")
-    assert persister.vulnerabilities[0]["request"].url == (
-        "http://perdu.com/vuln/"
-    )
+    assert persister.add_payload.call_count == 1
+    assert persister.add_payload.call_args_list[0][1]["module"] == "shellshock"
+    assert persister.add_payload.call_args_list[0][1]["category"] == _("Command execution")
+    assert persister.add_payload.call_args_list[0][1]["request"].url == "http://perdu.com/vuln/"
     await crawler.close()

--- a/tests/attack/test_mod_ssrf.py
+++ b/tests/attack/test_mod_ssrf.py
@@ -5,11 +5,12 @@ import httpx
 import respx
 import pytest
 
-from tests.attack.fake_persister import FakePersister
 from wapitiCore.net.web import Request
 from wapitiCore.net.crawler import AsyncCrawler
-from wapitiCore.attack.mod_ssrf import mod_ssrf
 from wapitiCore.language.vulnerability import _
+from wapitiCore.attack.mod_ssrf import mod_ssrf
+from tests import AsyncMock
+
 
 @pytest.mark.asyncio
 @respx.mock
@@ -17,15 +18,16 @@ async def test_whole_stuff():
     # Test attacking all kind of parameter without crashing
     respx.route(host="perdu.com").mock(return_value=httpx.Response(200, text="Hello there"))
 
-    persister = FakePersister()
+    persister = AsyncMock()
+    all_requests = []
 
     request = Request("http://perdu.com/")
     request.path_id = 1
-    persister.requests.append(request)
+    all_requests.append(request)
 
     request = Request("http://perdu.com/?foo=bar")
     request.path_id = 2
-    persister.requests.append(request)
+    all_requests.append(request)
 
     request = Request(
         "http://perdu.com/?foo=bar",
@@ -33,7 +35,15 @@ async def test_whole_stuff():
         file_params=[["file", ("calendar.xml", "<xml>Hello there</xml", "application/xml")]]
     )
     request.path_id = 3
-    persister.requests.append(request)
+    all_requests.append(request)
+
+    def get_path_by_id(request_id):
+        for req in all_requests:
+            if req.path_id == int(request_id):
+                return req
+        return None
+
+    persister.get_path_by_id.side_effect = get_path_by_id
 
     crawler = AsyncCrawler("http://perdu.com/", timeout=1)
     options = {"timeout": 10, "level": 2}
@@ -61,17 +71,18 @@ async def test_whole_stuff():
         )
     )
 
-    for request in persister.requests:
+    for request in all_requests:
         await module.attack(request)
 
-    assert not persister.vulnerabilities
-    # We must trigger finish(à normally called by wapiti.py
+    assert not persister.add_payload.call_count
+    # We must trigger finish() normally called by wapiti.py
     await module.finish()
 
-    assert persister.module == "ssrf"
-    assert persister.vulnerabilities
-    assert persister.vulnerabilities[0]["category"] == _("Server Side Request Forgery")
-    assert persister.vulnerabilities[0]["parameter"] == "file"
-    file_params = persister.vulnerabilities[0]["request"].file_params
-    assert file_params[0][1][0] == "http://external.url/page"
+    assert persister.add_payload.call_count
+    assert persister.add_payload.call_args_list[0][1]["module"] == "ssrf"
+    assert persister.add_payload.call_args_list[0][1]["category"] == _("Server Side Request Forgery")
+    assert persister.add_payload.call_args_list[0][1]["parameter"] == "file"
+    assert persister.add_payload.call_args_list[0][1]["request"].file_params == [
+        ['file', ('http://external.url/page', '<xml>Hello there</xml', 'application/xml')]
+    ]
     await crawler.close()

--- a/tests/attack/test_mod_xss_advanced.py
+++ b/tests/attack/test_mod_xss_advanced.py
@@ -7,11 +7,12 @@ from asyncio import Event
 
 import pytest
 
-from tests.attack.fake_persister import FakePersister
 from wapitiCore.net.web import Request
 from wapitiCore.net.crawler import AsyncCrawler
 from wapitiCore.attack.mod_xss import mod_xss
 from wapitiCore.language.vulnerability import _
+from tests import AsyncMock
+
 
 @pytest.fixture(autouse=True)
 def run_around_tests():
@@ -27,7 +28,7 @@ def run_around_tests():
 @pytest.mark.asyncio
 async def test_title_false_positive():
     # We should fail at escaping the title tag and we should be aware of it
-    persister = FakePersister()
+    persister = AsyncMock()
     request = Request("http://127.0.0.1:65081/title_false_positive.php?title=yolo&fixed=yes")
     request.path_id = 42
     crawler = AsyncCrawler("http://127.0.0.1:65081/")
@@ -38,14 +39,14 @@ async def test_title_false_positive():
     module.do_post = False
     await module.attack(request)
 
-    assert persister.vulnerabilities == []
+    assert not persister.add_payload.call_count
     await crawler.close()
 
 
 @pytest.mark.asyncio
 async def test_title_positive():
     # We should succeed at escaping the title tag
-    persister = FakePersister()
+    persister = AsyncMock()
     request = Request("http://127.0.0.1:65081/title_false_positive.php?title=yolo")
     request.path_id = 42
     crawler = AsyncCrawler("http://127.0.0.1:65081/")
@@ -56,19 +57,21 @@ async def test_title_positive():
     module.do_post = False
     await module.attack(request)
 
-    assert persister.module == "xss"
-    assert persister.vulnerabilities
-    assert persister.vulnerabilities[0]["category"] == _("Cross Site Scripting")
-    assert persister.vulnerabilities[0]["parameter"] == "title"
-    assert persister.vulnerabilities[0]["request"].get_params[0][1].startswith("</title>")
-    assert _("Warning: Content-Security-Policy is present!") not in persister.vulnerabilities[0]["info"]
+    assert persister.add_payload.call_count
+    assert persister.add_payload.call_args_list[0][1]["module"] == "xss"
+    assert persister.add_payload.call_args_list[0][1]["category"] == _("Cross Site Scripting")
+    assert persister.add_payload.call_args_list[0][1]["parameter"] == "title"
+    assert persister.add_payload.call_args_list[0][1]["request"].get_params[0][1].startswith("</title>")
+    assert _(
+        "Warning: Content-Security-Policy is present!"
+    ) not in persister.add_payload.call_args_list[0][1]["info"]
     await crawler.close()
 
 
 @pytest.mark.asyncio
 async def test_script_filter_bypass():
     # We should succeed at bypass the <script filter
-    persister = FakePersister()
+    persister = AsyncMock()
     request = Request("http://127.0.0.1:65081/script_tag_filter.php?name=kenobi")
     request.path_id = 42
     crawler = AsyncCrawler("http://127.0.0.1:65081/")
@@ -79,16 +82,16 @@ async def test_script_filter_bypass():
     module.do_post = False
     await module.attack(request)
 
-    assert persister.vulnerabilities
-    assert persister.vulnerabilities[0]["parameter"] == "name"
-    assert persister.vulnerabilities[0]["request"].get_params[0][1].lower().startswith("<svg")
+    assert persister.add_payload.call_count
+    assert persister.add_payload.call_args_list[0][1]["parameter"] == "name"
+    assert persister.add_payload.call_args_list[0][1]["request"].get_params[0][1].lower().startswith("<svg")
     await crawler.close()
 
 
 @pytest.mark.asyncio
 async def test_attr_quote_escape():
     # We should succeed at closing the attribute value and the opening tag
-    persister = FakePersister()
+    persister = AsyncMock()
     request = Request("http://127.0.0.1:65081/attr_quote_escape.php?class=custom")
     request.path_id = 42
     crawler = AsyncCrawler("http://127.0.0.1:65081/")
@@ -99,16 +102,16 @@ async def test_attr_quote_escape():
     module.do_post = False
     await module.attack(request)
 
-    assert persister.vulnerabilities
-    assert persister.vulnerabilities[0]["parameter"] == "class"
-    assert persister.vulnerabilities[0]["request"].get_params[0][1].lower().startswith("'></pre>")
+    assert persister.add_payload.call_count
+    assert persister.add_payload.call_args_list[0][1]["parameter"] == "class"
+    assert persister.add_payload.call_args_list[0][1]["request"].get_params[0][1].lower().startswith("'></pre>")
     await crawler.close()
 
 
 @pytest.mark.asyncio
 async def test_attr_double_quote_escape():
     # We should succeed at closing the attribute value and the opening tag
-    persister = FakePersister()
+    persister = AsyncMock()
     request = Request("http://127.0.0.1:65081/attr_double_quote_escape.php?class=custom")
     request.path_id = 42
     crawler = AsyncCrawler("http://127.0.0.1:65081/")
@@ -119,16 +122,16 @@ async def test_attr_double_quote_escape():
     module.do_post = False
     await module.attack(request)
 
-    assert persister.vulnerabilities
-    assert persister.vulnerabilities[0]["parameter"] == "class"
-    assert persister.vulnerabilities[0]["request"].get_params[0][1].lower().startswith("\"></pre>")
+    assert persister.add_payload.call_count
+    assert persister.add_payload.call_args_list[0][1]["parameter"] == "class"
+    assert persister.add_payload.call_args_list[0][1]["request"].get_params[0][1].lower().startswith("\"></pre>")
     await crawler.close()
 
 
 @pytest.mark.asyncio
 async def test_attr_escape():
     # We should succeed at closing the attribute value and the opening tag
-    persister = FakePersister()
+    persister = AsyncMock()
     request = Request("http://127.0.0.1:65081/attr_escape.php?state=checked")
     request.path_id = 42
     crawler = AsyncCrawler("http://127.0.0.1:65081/")
@@ -139,16 +142,16 @@ async def test_attr_escape():
     module.do_post = False
     await module.attack(request)
 
-    assert persister.vulnerabilities
-    assert persister.vulnerabilities[0]["parameter"] == "state"
-    assert persister.vulnerabilities[0]["request"].get_params[0][1].lower().startswith("><script>")
+    assert persister.add_payload.call_count
+    assert persister.add_payload.call_args_list[0][1]["parameter"] == "state"
+    assert persister.add_payload.call_args_list[0][1]["request"].get_params[0][1].lower().startswith("><script>")
     await crawler.close()
 
 
 @pytest.mark.asyncio
 async def test_tag_name_escape():
     # We should succeed at closing the attribute value and the opening tag
-    persister = FakePersister()
+    persister = AsyncMock()
     request = Request("http://127.0.0.1:65081/tag_name_escape.php?tag=textarea")
     request.path_id = 42
     crawler = AsyncCrawler("http://127.0.0.1:65081/")
@@ -159,16 +162,16 @@ async def test_tag_name_escape():
     module.do_post = False
     await module.attack(request)
 
-    assert persister.vulnerabilities
-    assert persister.vulnerabilities[0]["parameter"] == "tag"
-    assert persister.vulnerabilities[0]["request"].get_params[0][1].lower().startswith("script>")
+    assert persister.add_payload.call_count
+    assert persister.add_payload.call_args_list[0][1]["parameter"] == "tag"
+    assert persister.add_payload.call_args_list[0][1]["request"].get_params[0][1].lower().startswith("script>")
     await crawler.close()
 
 
 @pytest.mark.asyncio
 async def test_partial_tag_name_escape():
     # We should succeed at closing the attribute value and the opening tag
-    persister = FakePersister()
+    persister = AsyncMock()
     request = Request("http://127.0.0.1:65081/partial_tag_name_escape.php?importance=2")
     request.path_id = 42
     crawler = AsyncCrawler("http://127.0.0.1:65081/")
@@ -179,15 +182,15 @@ async def test_partial_tag_name_escape():
     module.do_post = False
     await module.attack(request)
 
-    assert persister.vulnerabilities
-    assert persister.vulnerabilities[0]["parameter"] == "importance"
-    assert persister.vulnerabilities[0]["request"].get_params[0][1].lower().startswith("/><script>")
+    assert persister.add_payload.call_count
+    assert persister.add_payload.call_args_list[0][1]["parameter"] == "importance"
+    assert persister.add_payload.call_args_list[0][1]["request"].get_params[0][1].lower().startswith("/><script>")
     await crawler.close()
 
 
 @pytest.mark.asyncio
 async def test_xss_inside_tag_input():
-    persister = FakePersister()
+    persister = AsyncMock()
     request = Request("http://127.0.0.1:65081/input_text_strip_tags.php?uid=5")
     request.path_id = 42
     crawler = AsyncCrawler("http://127.0.0.1:65081/")
@@ -198,16 +201,16 @@ async def test_xss_inside_tag_input():
     module.do_post = False
     await module.attack(request)
 
-    assert persister.vulnerabilities
-    assert persister.vulnerabilities[0]["parameter"] == "uid"
-    used_payload = persister.vulnerabilities[0]["request"].get_params[0][1].lower()
+    assert persister.add_payload.call_count
+    assert persister.add_payload.call_args_list[0][1]["parameter"] == "uid"
+    used_payload = persister.add_payload.call_args_list[0][1]["request"].get_params[0][1].lower()
     assert "<" not in used_payload and ">" not in used_payload and "autofocus/onfocus" in used_payload
     await crawler.close()
 
 
 @pytest.mark.asyncio
 async def test_xss_inside_tag_link():
-    persister = FakePersister()
+    persister = AsyncMock()
     request = Request("http://127.0.0.1:65081/link_href_strip_tags.php?url=http://perdu.com/")
     request.path_id = 42
     crawler = AsyncCrawler("http://127.0.0.1:65081/")
@@ -218,16 +221,16 @@ async def test_xss_inside_tag_link():
     module.do_post = False
     await module.attack(request)
 
-    assert persister.vulnerabilities
-    assert persister.vulnerabilities[0]["parameter"] == "url"
-    used_payload = persister.vulnerabilities[0]["request"].get_params[0][1].lower()
+    assert persister.add_payload.call_count
+    assert persister.add_payload.call_args_list[0][1]["parameter"] == "url"
+    used_payload = persister.add_payload.call_args_list[0][1]["request"].get_params[0][1].lower()
     assert "<" not in used_payload and ">" not in used_payload and "autofocus href onfocus" in used_payload
     await crawler.close()
 
 
 @pytest.mark.asyncio
 async def test_xss_uppercase_no_script():
-    persister = FakePersister()
+    persister = AsyncMock()
     request = Request("http://127.0.0.1:65081/uppercase_no_script.php?name=obiwan")
     request.path_id = 42
     crawler = AsyncCrawler("http://127.0.0.1:65081/")
@@ -238,16 +241,16 @@ async def test_xss_uppercase_no_script():
     module.do_post = False
     await module.attack(request)
 
-    assert persister.vulnerabilities
-    assert persister.vulnerabilities[0]["parameter"] == "name"
-    used_payload = persister.vulnerabilities[0]["request"].get_params[0][1].lower()
+    assert persister.add_payload.call_count
+    assert persister.add_payload.call_args_list[0][1]["parameter"] == "name"
+    used_payload = persister.add_payload.call_args_list[0][1]["request"].get_params[0][1].lower()
     assert used_payload.startswith("<svg onload=&")
     await crawler.close()
 
 
 @pytest.mark.asyncio
 async def test_frame_src_escape():
-    persister = FakePersister()
+    persister = AsyncMock()
     request = Request("http://127.0.0.1:65081/frame_src_escape.php?url=https://wapiti.sourceforge.io/")
     request.path_id = 42
     crawler = AsyncCrawler("http://127.0.0.1:65081/")
@@ -258,16 +261,16 @@ async def test_frame_src_escape():
     module.do_post = False
     await module.attack(request)
 
-    assert persister.vulnerabilities
-    assert persister.vulnerabilities[0]["parameter"] == "url"
-    used_payload = persister.vulnerabilities[0]["request"].get_params[0][1].lower()
+    assert persister.add_payload.call_count
+    assert persister.add_payload.call_args_list[0][1]["parameter"] == "url"
+    used_payload = persister.add_payload.call_args_list[0][1]["request"].get_params[0][1].lower()
     assert used_payload.startswith('"><frame src="javascript:alert(/w')
     await crawler.close()
 
 
 @pytest.mark.asyncio
 async def test_frame_src_no_escape():
-    persister = FakePersister()
+    persister = AsyncMock()
     request = Request("http://127.0.0.1:65081/frame_src_no_escape.php?url=https://wapiti.sourceforge.io/")
     request.path_id = 42
     crawler = AsyncCrawler("http://127.0.0.1:65081/")
@@ -278,16 +281,16 @@ async def test_frame_src_no_escape():
     module.do_post = False
     await module.attack(request)
 
-    assert persister.vulnerabilities
-    assert persister.vulnerabilities[0]["parameter"] == "url"
-    used_payload = persister.vulnerabilities[0]["request"].get_params[0][1].lower()
+    assert persister.add_payload.call_count
+    assert persister.add_payload.call_args_list[0][1]["parameter"] == "url"
+    used_payload = persister.add_payload.call_args_list[0][1]["request"].get_params[0][1].lower()
     assert used_payload.startswith("javascript:alert(/w")
     await crawler.close()
 
 
 @pytest.mark.asyncio
 async def test_bad_separator_used():
-    persister = FakePersister()
+    persister = AsyncMock()
     request = Request("http://127.0.0.1:65081/confuse_separator.php?number=42")
     request.path_id = 42
     crawler = AsyncCrawler("http://127.0.0.1:65081/")
@@ -298,15 +301,15 @@ async def test_bad_separator_used():
     module.do_post = False
     await module.attack(request)
 
-    assert persister.vulnerabilities
-    used_payload = persister.vulnerabilities[0]["request"].get_params[0][1].lower()
+    assert persister.add_payload.call_count
+    used_payload = persister.add_payload.call_args_list[0][1]["request"].get_params[0][1].lower()
     assert used_payload.startswith("\">")
     await crawler.close()
 
 
 @pytest.mark.asyncio
 async def test_escape_with_style():
-    persister = FakePersister()
+    persister = AsyncMock()
     request = Request("http://127.0.0.1:65081/escape_with_style.php?color=green")
     request.path_id = 42
     crawler = AsyncCrawler("http://127.0.0.1:65081/")
@@ -317,15 +320,15 @@ async def test_escape_with_style():
     module.do_post = False
     await module.attack(request)
 
-    assert persister.vulnerabilities
-    used_payload = persister.vulnerabilities[0]["request"].get_params[0][1].lower()
+    assert persister.add_payload.call_count
+    used_payload = persister.add_payload.call_args_list[0][1]["request"].get_params[0][1].lower()
     assert used_payload.startswith("</style>")
     await crawler.close()
 
 
 @pytest.mark.asyncio
 async def test_rare_tag_and_event():
-    persister = FakePersister()
+    persister = AsyncMock()
     request = Request("http://127.0.0.1:65081/filter_common_keywords.php?msg=test")
     request.path_id = 42
     crawler = AsyncCrawler("http://127.0.0.1:65081/")
@@ -336,15 +339,15 @@ async def test_rare_tag_and_event():
     module.do_post = False
     await module.attack(request)
 
-    assert persister.vulnerabilities
-    used_payload = persister.vulnerabilities[0]["request"].get_params[0][1].lower()
+    assert persister.add_payload.call_count
+    used_payload = persister.add_payload.call_args_list[0][1]["request"].get_params[0][1].lower()
     assert used_payload.startswith("<custom\nchecked\nonpointerenter=")
     await crawler.close()
 
 
 @pytest.mark.asyncio
 async def test_xss_with_strong_csp():
-    persister = FakePersister()
+    persister = AsyncMock()
     request = Request("http://127.0.0.1:65081/strong_csp.php?content=Hello%20there")
     request.path_id = 42
     crawler = AsyncCrawler("http://127.0.0.1:65081/")
@@ -355,14 +358,14 @@ async def test_xss_with_strong_csp():
     module.do_post = False
     await module.attack(request)
 
-    assert persister.vulnerabilities
-    assert _("Warning: Content-Security-Policy is present!") in persister.vulnerabilities[0]["info"]
+    assert persister.add_payload.call_count
+    assert _("Warning: Content-Security-Policy is present!") in persister.add_payload.call_args_list[0][1]["info"]
     await crawler.close()
 
 
 @pytest.mark.asyncio
 async def test_xss_with_weak_csp():
-    persister = FakePersister()
+    persister = AsyncMock()
     request = Request("http://127.0.0.1:65081/weak_csp.php?content=Hello%20there")
     request.path_id = 42
     crawler = AsyncCrawler("http://127.0.0.1:65081/")
@@ -373,6 +376,8 @@ async def test_xss_with_weak_csp():
     module.do_post = False
     await module.attack(request)
 
-    assert persister.vulnerabilities
-    assert _("Warning: Content-Security-Policy is present!") not in persister.vulnerabilities[0]["info"]
+    assert persister.add_payload.call_count
+    assert _(
+        "Warning: Content-Security-Policy is present!"
+    ) not in persister.add_payload.call_args_list[0][1]["info"]
     await crawler.close()

--- a/tests/attack/test_mod_xss_basics.py
+++ b/tests/attack/test_mod_xss_basics.py
@@ -5,10 +5,11 @@ import respx
 import httpx
 import pytest
 
-from tests.attack.fake_persister import FakePersister
 from wapitiCore.net.web import Request
 from wapitiCore.net.crawler import AsyncCrawler
 from wapitiCore.attack.mod_xss import mod_xss
+from tests import AsyncMock
+
 
 @pytest.mark.asyncio
 @respx.mock
@@ -17,15 +18,16 @@ async def test_whole_stuff():
     respx.get(url__regex=r"http://perdu\.com/.*").mock(return_value=httpx.Response(200, text="Hello there"))
     respx.post(url__regex=r"http://perdu\.com/.*").mock(return_value=httpx.Response(200, text="Hello there"))
 
-    persister = FakePersister()
+    persister = AsyncMock()
+    all_requests = []
 
     request = Request("http://perdu.com/")
     request.path_id = 1
-    persister.requests.append(request)
+    all_requests.append(request)
 
     request = Request("http://perdu.com/?foo=bar")
     request.path_id = 2
-    persister.requests.append(request)
+    all_requests.append(request)
 
     request = Request(
         "http://perdu.com/?foo=bar",
@@ -33,7 +35,7 @@ async def test_whole_stuff():
         file_params=[["file", ("calendar.xml", "<xml>Hello there</xml", "application/xml")]]
     )
     request.path_id = 3
-    persister.requests.append(request)
+    all_requests.append(request)
 
     crawler = AsyncCrawler("http://perdu.com/", timeout=1)
     options = {"timeout": 10, "level": 2}
@@ -42,7 +44,7 @@ async def test_whole_stuff():
     module = mod_xss(crawler, persister, logger, options, Event())
     module.verbose = 2
     module.do_post = True
-    for request in persister.requests:
+    for request in all_requests:
         await module.attack(request)
 
     assert True

--- a/tests/parsers/test_http_parser.py
+++ b/tests/parsers/test_http_parser.py
@@ -33,7 +33,7 @@ def test_http():
     assert page.delay > 0
     assert isinstance(page.bytes, bytes) and page.bytes
     assert page.type == "text/html; charset=iso-8859-1"
-    assert page.encoding == "ISO-8859-1" # see https://github.com/encode/httpx/pull/1269
+    assert page.encoding == "ISO-8859-1"  # see https://github.com/encode/httpx/pull/1269
 
 
 @respx.mock

--- a/tests/web/test_persister.py
+++ b/tests/web/test_persister.py
@@ -5,7 +5,7 @@ import pytest
 import httpx
 import respx
 
-from wapitiCore.net.sqlite_persister import SqlitePersister
+from wapitiCore.net.sql_persister import SqlPersister
 from wapitiCore.net.web import Request
 from wapitiCore.net.crawler import AsyncCrawler, Page
 
@@ -23,7 +23,7 @@ async def test_persister_basic():
     except FileNotFoundError:
         pass
 
-    persister = SqlitePersister("/tmp/crawl.db")
+    persister = SqlPersister("/tmp/crawl.db")
     await persister.create()
     await persister.set_root_url("http://httpbin.org/")
 
@@ -118,7 +118,7 @@ async def test_persister_upload():
     except FileNotFoundError:
         pass
 
-    persister = SqlitePersister("/tmp/crawl.db")
+    persister = SqlPersister("/tmp/crawl.db")
     await persister.create()
     await persister.set_root_url("http://httpbin.org/")
 
@@ -195,7 +195,7 @@ async def test_persister_forms():
         except FileNotFoundError:
             pass
 
-        persister = SqlitePersister("/tmp/crawl.db")
+        persister = SqlPersister("/tmp/crawl.db")
         await persister.create()
         await persister.set_root_url("http://httpbin.org/")
         await persister.set_to_browse(forms)
@@ -226,7 +226,7 @@ async def test_raw_post():
     except FileNotFoundError:
         pass
 
-    persister = SqlitePersister("/tmp/crawl.db")
+    persister = SqlPersister("/tmp/crawl.db")
     await persister.create()
     await persister.set_root_url("http://httpbin.org/")
     await persister.set_to_browse([json_req])

--- a/wapitiCore/attack/attack.py
+++ b/wapitiCore/attack/attack.py
@@ -200,9 +200,6 @@ class Attack:
         self.crawler = crawler
         self.persister = persister
         self._stop_event = stop_event
-        # self.add_vuln = persister.add_vulnerability
-        # self.add_anom = persister.add_anomaly
-        # self.add_addition = persister.add_additional
         self.payload_reader = PayloadReader(attack_options)
         self.options = attack_options
 

--- a/wapitiCore/attack/mod_backup.py
+++ b/wapitiCore/attack/mod_backup.py
@@ -27,7 +27,7 @@ from urllib.parse import urljoin
 from httpx import RequestError
 
 from wapitiCore.attack.attack import Attack
-from wapitiCore.language.vulnerability import _
+from wapitiCore.language.vulnerability import LOW_LEVEL, _
 from wapitiCore.definitions.backup import NAME
 from wapitiCore.net.web import Request
 
@@ -44,7 +44,7 @@ class mod_backup(Attack):
     do_get = False
     do_post = False
 
-    def must_attack(self, request: Request):
+    async def must_attack(self, request: Request):
         page = request.path
         headers = request.headers
 
@@ -96,7 +96,7 @@ class mod_backup(Attack):
             if response and response.status == 200:
                 self.log_red(_("Found backup file {}".format(evil_req.url)))
 
-                self.add_vuln_low(
+                await self.add_vuln_low(
                     request_id=request.path_id,
                     category=NAME,
                     request=evil_req,

--- a/wapitiCore/attack/mod_brute_login_form.py
+++ b/wapitiCore/attack/mod_brute_login_form.py
@@ -89,7 +89,7 @@ class mod_brute_login_form(Attack):
 
         return login_response.content
 
-    def must_attack(self, request: Request):
+    async def must_attack(self, request: Request):
         # We leverage the fact that the crawler will fill password entries with a known placeholder
         if "Letm3in_" not in request.encoded_data + request.encoded_params:
             return False
@@ -166,7 +166,7 @@ class mod_brute_login_form(Attack):
                     link_depth=login_form.link_depth
                 )
 
-                self.add_vuln_low(
+                await self.add_vuln_low(
                     request_id=request.path_id,
                     category=NAME,
                     request=evil_request,

--- a/wapitiCore/attack/mod_buster.py
+++ b/wapitiCore/attack/mod_buster.py
@@ -85,10 +85,11 @@ class mod_buster(Attack):
 
     async def attack(self, request: Request):
         self.finished = True
-        urls = self.persister.get_links(attack_module=self.name) if self.do_get else []
+        if not self.do_get:
+            return
 
         # First we make a list of unique webdirs and webpages without parameters
-        for resource in urls:
+        async for resource in self.persister.get_links(attack_module=self.name):
             path = resource.path
             if path.endswith("/"):
                 if path not in self.known_dirs:

--- a/wapitiCore/attack/mod_cookieflags.py
+++ b/wapitiCore/attack/mod_cookieflags.py
@@ -37,14 +37,14 @@ class mod_cookieflags(Attack):
     def check_httponly_flag(cookie: object):
         return "HttpOnly" in cookie._rest or "httponly" in cookie._rest
 
-    def must_attack(self, request: Request):
+    async def must_attack(self, request: Request):
         if self.finished:
             return False
 
         if request.method == "POST":
             return False
 
-        return request.url == self.persister.get_root_url()
+        return request.url == await self.persister.get_root_url()
 
     async def attack(self, request: Request):
         self.finished = True
@@ -54,7 +54,7 @@ class mod_cookieflags(Attack):
             self.log_blue(_("Checking cookie : {}").format(cookie.name))
             if not self.check_httponly_flag(cookie):
                 self.log_red(INFO_COOKIE_HTTPONLY.format(cookie.name))
-                self.add_vuln_low(
+                await self.add_vuln_low(
                     category=COOKIE_HTTPONLY_DISABLED,
                     request=request,
                     info=INFO_COOKIE_HTTPONLY.format(cookie.name)
@@ -62,7 +62,7 @@ class mod_cookieflags(Attack):
 
             if not self.check_secure_flag(cookie):
                 self.log_red(INFO_COOKIE_SECURE.format(cookie.name))
-                self.add_vuln_low(
+                await self.add_vuln_low(
                     category=COOKIE_SECURE_DISABLED,
                     request=request,
                     info=INFO_COOKIE_SECURE.format(cookie.name)

--- a/wapitiCore/attack/mod_crlf.py
+++ b/wapitiCore/attack/mod_crlf.py
@@ -51,7 +51,7 @@ class mod_crlf(Attack):
                 response = await self.crawler.async_send(mutated_request)
             except ReadTimeout:
                 self.network_errors += 1
-                self.add_anom_medium(
+                await self.add_anom_medium(
                     request_id=request.path_id,
                     category=Messages.RES_CONSUMPTION,
                     request=mutated_request,
@@ -71,7 +71,7 @@ class mod_crlf(Attack):
                 self.network_errors += 1
             else:
                 if "wapiti" in response.headers:
-                    self.add_vuln_low(
+                    await self.add_vuln_low(
                         request_id=request.path_id,
                         category=NAME,
                         request=mutated_request,

--- a/wapitiCore/attack/mod_csp.py
+++ b/wapitiCore/attack/mod_csp.py
@@ -32,14 +32,14 @@ class mod_csp(Attack):
     """Evaluate the security level of Content Security Policies of the web server."""
     name = "csp"
 
-    def must_attack(self, request: Request):
+    async def must_attack(self, request: Request):
         if self.finished:
             return False
 
         if request.method == "POST":
             return False
 
-        return request.url == self.persister.get_root_url()
+        return request.url == await self.persister.get_root_url()
 
     async def attack(self, request: Request):
         self.finished = True
@@ -53,7 +53,7 @@ class mod_csp(Attack):
 
         if "Content-Security-Policy" not in response.headers:
             self.log_red(MSG_NO_CSP)
-            self.add_vuln_low(
+            await self.add_vuln_low(
                 category=NAME,
                 request=request_to_root,
                 info=MSG_NO_CSP
@@ -64,16 +64,14 @@ class mod_csp(Attack):
             for policy_name in CSP_CHECK_LISTS:
                 result = check_policy_values(policy_name, csp_dict)
 
-                info = ""
                 if result <= 0:
                     if result == -1:
                         info = MSG_CSP_MISSING.format(policy_name)
-
-                    else: # result == 0
+                    else:  # result == 0
                         info = MSG_CSP_UNSAFE.format(policy_name)
 
                     self.log_red(info)
-                    self.add_vuln_low(
+                    await self.add_vuln_low(
                         category=NAME,
                         request=request_to_root,
                         info=info

--- a/wapitiCore/attack/mod_csrf.py
+++ b/wapitiCore/attack/mod_csrf.py
@@ -153,7 +153,7 @@ class mod_csrf(Attack):
 
         return True
 
-    def must_attack(self, request: Request):
+    async def must_attack(self, request: Request):
         if request.method != "POST":
             return False
 
@@ -182,7 +182,7 @@ class mod_csrf(Attack):
         self.log_red(request.http_repr())
         self.log_red("---")
 
-        self.add_vuln_medium(
+        await self.add_vuln_medium(
             request_id=request.path_id,
             category=NAME,
             request=request,

--- a/wapitiCore/attack/mod_drupal_enum.py
+++ b/wapitiCore/attack/mod_drupal_enum.py
@@ -54,13 +54,13 @@ class mod_drupal_enum(Attack):
                 return True
         return False
 
-    def must_attack(self, request: Request):
+    async def must_attack(self, request: Request):
         if self.finished:
             return False
 
         if request.method == "POST":
             return False
-        return request.url == self.persister.get_root_url()
+        return request.url == await self.persister.get_root_url()
 
     async def attack(self, request: Request):
         self.finished = True
@@ -79,7 +79,7 @@ class mod_drupal_enum(Attack):
                 "Drupal",
                 self.versions
             )
-            self.add_addition(
+            await self.add_addition(
                 category=TECHNO_DETECTED,
                 request=request_to_root,
                 info=json.dumps(drupal_detected),

--- a/wapitiCore/attack/mod_exec.py
+++ b/wapitiCore/attack/mod_exec.py
@@ -117,7 +117,7 @@ class mod_exec(Attack):
                     else:
                         vuln_message = _("{0} via injection in the parameter {1}").format(vuln_info, parameter)
 
-                    self.add_vuln_critical(
+                    await self.add_vuln_critical(
                         request_id=request.path_id,
                         category=NAME,
                         request=mutated_request,
@@ -154,7 +154,7 @@ class mod_exec(Attack):
                 else:
                     anom_msg = Messages.MSG_PARAM_TIMEOUT.format(parameter)
 
-                self.add_anom_medium(
+                await self.add_anom_medium(
                     request_id=request.path_id,
                     category=Messages.RES_CONSUMPTION,
                     request=mutated_request,
@@ -177,7 +177,7 @@ class mod_exec(Attack):
                         vuln_message = _("{0} via injection in the parameter {1}").format(vuln_info, parameter)
                         log_message = Messages.MSG_PARAM_INJECT
 
-                    self.add_vuln_critical(
+                    await self.add_vuln_critical(
                         request_id=request.path_id,
                         category=NAME,
                         request=mutated_request,
@@ -208,7 +208,7 @@ class mod_exec(Attack):
                     else:
                         anom_msg = Messages.MSG_PARAM_500.format(parameter)
 
-                    self.add_anom_high(
+                    await self.add_anom_high(
                         request_id=request.path_id,
                         category=Messages.ERROR_500,
                         request=mutated_request,

--- a/wapitiCore/attack/mod_file.py
+++ b/wapitiCore/attack/mod_file.py
@@ -197,7 +197,7 @@ class mod_file(Attack):
                 else:
                     anom_msg = Messages.MSG_PARAM_TIMEOUT.format(parameter)
 
-                self.add_anom_medium(
+                await self.add_anom_medium(
                     request_id=request.path_id,
                     category=Messages.RES_CONSUMPTION,
                     request=mutated_request,
@@ -256,7 +256,7 @@ class mod_file(Attack):
                             constraint_message += _("Constraints: {}").format(", ".join(constraints))
                             vuln_message += " (" + constraint_message + ")"
 
-                    self.add_vuln_critical(
+                    await self.add_vuln_critical(
                         request_id=request.path_id,
                         category=NAME,
                         request=mutated_request,
@@ -291,7 +291,7 @@ class mod_file(Attack):
                     else:
                         anom_msg = Messages.MSG_PARAM_500.format(parameter)
 
-                    self.add_anom_high(
+                    await self.add_anom_high(
                         request_id=request.path_id,
                         category=Messages.ERROR_500,
                         request=mutated_request,

--- a/wapitiCore/attack/mod_htaccess.py
+++ b/wapitiCore/attack/mod_htaccess.py
@@ -39,7 +39,7 @@ class mod_htaccess(Attack):
     do_get = False
     do_post = False
 
-    def must_attack(self, request: Request):
+    async def must_attack(self, request: Request):
         if request.path in self.attacked_get:
             return False
 
@@ -65,7 +65,7 @@ class mod_htaccess(Attack):
             unblocked_content = response.content
 
             self.log_red("---")
-            self.add_vuln_medium(
+            await self.add_vuln_medium(
                 request_id=request.path_id,
                 category=NAME,
                 request=evil_req,

--- a/wapitiCore/attack/mod_http_headers.py
+++ b/wapitiCore/attack/mod_http_headers.py
@@ -35,6 +35,7 @@ class mod_http_headers(Attack):
     check_list_xss = ['1']
     check_list_xcontent = ['nosniff']
     check_list_hsts = ['max-age=']
+
     headers_to_check = {
         "X-Frame-Options": {
             "list": check_list_xframe, "info": INFO_XFRAME_OPTIONS, "log": "Checking X-Frame-Options :"},
@@ -53,11 +54,11 @@ class mod_http_headers(Attack):
 
         return any(element in response.headers[header_name].lower() for element in check_list)
 
-    def check_header(self, response, request, header, check_list, info, log):
+    async def check_header(self, response, request, header, check_list, info, log):
         self.log_blue(_(log))
         if not self.is_set(response, header, check_list):
             self.log_red(info)
-            self.add_vuln_low(
+            await self.add_vuln_low(
                 category=NAME,
                 request=request,
                 info=info
@@ -65,14 +66,14 @@ class mod_http_headers(Attack):
         else:
             self.log_green("OK")
 
-    def must_attack(self, request: Request):
+    async def must_attack(self, request: Request):
         if self.finished:
             return False
 
         if request.method == "POST":
             return False
 
-        return request.url == self.persister.get_root_url()
+        return request.url == await self.persister.get_root_url()
 
     async def attack(self, request: Request):
         request_to_root = Request(request.url)
@@ -85,4 +86,4 @@ class mod_http_headers(Attack):
             return
 
         for header, value in self.headers_to_check.items():
-            self.check_header(response, request_to_root, header, value["list"], value["info"], value["log"])
+            await self.check_header(response, request_to_root, header, value["list"], value["info"], value["log"])

--- a/wapitiCore/attack/mod_methods.py
+++ b/wapitiCore/attack/mod_methods.py
@@ -34,7 +34,7 @@ class mod_methods(Attack):
     do_post = False
     excluded_path = set()
 
-    def must_attack(self, request: Request):
+    async def must_attack(self, request: Request):
         return request.path not in self.excluded_path
 
     async def attack(self, request: Request):

--- a/wapitiCore/attack/mod_permanentxss.py
+++ b/wapitiCore/attack/mod_permanentxss.py
@@ -50,7 +50,7 @@ class mod_permanentxss(Attack):
 
     MSG_VULN = _("Stored XSS vulnerability")
 
-    def must_attack(self, request: Request):
+    async def must_attack(self, request: Request):
         if not valid_xss_content_type(request) or request.status in (301, 302, 303):
             # If that content-type can't be interpreted as HTML by browsers then it is useless
             # Same goes for redirections
@@ -107,7 +107,7 @@ class mod_permanentxss(Attack):
                         # The following trick may seems dirty but it allows to treat GET and POST requests
                         # the same way.
                         for params_list in [get_params, post_params, file_params]:
-                            for i, _ in enumerate(params_list):
+                            for i, __ in enumerate(params_list):
                                 parameter, value = params_list[i]
                                 parameter = quote(parameter)
                                 if value != taint:
@@ -145,7 +145,7 @@ class mod_permanentxss(Attack):
                                 if has_strong_csp(response):
                                     description += ".\n" + _("Warning: Content-Security-Policy is present!")
 
-                                self.add_vuln_high(
+                                await self.add_vuln_high(
                                     request_id=request.path_id,
                                     category=NAME,
                                     request=evil_request,
@@ -233,7 +233,7 @@ class mod_permanentxss(Attack):
                 else:
                     anom_msg = Messages.MSG_PARAM_TIMEOUT.format(xss_param)
 
-                self.add_anom_medium(
+                await self.add_anom_medium(
                     request_id=injection_request.path_id,
                     category=Messages.RES_CONSUMPTION,
                     request=evil_request,
@@ -274,7 +274,7 @@ class mod_permanentxss(Attack):
                     if has_strong_csp(response):
                         description += ".\n" + _("Warning: Content-Security-Policy is present!")
 
-                    self.add_vuln_high(
+                    await self.add_vuln_high(
                         request_id=injection_request.path_id,
                         category=NAME,
                         request=evil_request,
@@ -311,7 +311,7 @@ class mod_permanentxss(Attack):
                     else:
                         anom_msg = Messages.MSG_PARAM_500.format(xss_param)
 
-                    self.add_anom_high(
+                    await self.add_anom_high(
                         request_id=injection_request.path_id,
                         category=Messages.ERROR_500,
                         request=evil_request,

--- a/wapitiCore/attack/mod_redirect.py
+++ b/wapitiCore/attack/mod_redirect.py
@@ -52,7 +52,7 @@ class mod_redirect(Attack):
                 continue
 
             if any([url.startswith("https://openbugbounty.org/") for url in response.all_redirections]):
-                self.add_vuln_low(
+                await self.add_vuln_low(
                     request_id=request.path_id,
                     category=NAME,
                     request=mutated_request,

--- a/wapitiCore/attack/mod_shellshock.py
+++ b/wapitiCore/attack/mod_shellshock.py
@@ -56,7 +56,7 @@ class mod_shellshock(Attack):
             "cookie": empty_func + cmd
         }
 
-    def must_attack(self, request: Request):
+    async def must_attack(self, request: Request):
         # We attempt to attach each script once whatever the method
         return request.path not in self.attacked_get
 
@@ -78,7 +78,7 @@ class mod_shellshock(Attack):
             if self.rand_string in data:
                 self.log_red(_("URL {0} seems vulnerable to Shellshock attack!").format(url))
 
-                self.add_vuln_high(
+                await self.add_vuln_high(
                     request_id=request.path_id,
                     category=NAME,
                     request=evil_req,

--- a/wapitiCore/attack/mod_sql.py
+++ b/wapitiCore/attack/mod_sql.py
@@ -352,7 +352,7 @@ class mod_sql(Attack):
                     else:
                         vuln_message = _("{0} via injection in the parameter {1}").format(vuln_info, parameter)
 
-                    self.add_vuln_critical(
+                    await self.add_vuln_critical(
                         request_id=request.path_id,
                         category=NAME,
                         request=mutated_request,
@@ -382,7 +382,7 @@ class mod_sql(Attack):
                     else:
                         anom_msg = Messages.MSG_PARAM_500.format(parameter)
 
-                    self.add_anom_high(
+                    await self.add_anom_high(
                         request_id=request.path_id,
                         category=Messages.ERROR_500,
                         request=mutated_request,
@@ -444,7 +444,7 @@ class mod_sql(Attack):
                     else:
                         vuln_message = _("{0} via injection in the parameter {1}").format(vuln_info, current_parameter)
 
-                    self.add_vuln_critical(
+                    await self.add_vuln_critical(
                         request_id=request.path_id,
                         category=NAME,
                         request=last_mutated_request,

--- a/wapitiCore/attack/mod_ssrf.py
+++ b/wapitiCore/attack/mod_ssrf.py
@@ -58,7 +58,7 @@ class SsrfMutator(Mutator):
         # self._attacks_per_url_pattern[request.hash_params] += estimation
 
         for params_list in [get_params, post_params, file_params]:
-            for i, _ in enumerate(params_list):
+            for i, __ in enumerate(params_list):
                 param_name = quote(params_list[i][0])
 
                 if self._skip_list and param_name in self._skip_list:
@@ -199,7 +199,7 @@ class mod_ssrf(Attack):
             data = response.json
             if isinstance(data, dict):
                 for request_id in data:
-                    original_request = self.persister.get_path_by_id(request_id)
+                    original_request = await self.persister.get_path_by_id(request_id)
                     if original_request is None:
                         raise ValueError("Could not find the original request with that ID")
 
@@ -241,7 +241,7 @@ class mod_ssrf(Attack):
 
                             mutated_request, __, __, __ = next(mutator.mutate(original_request))
 
-                            self.add_vuln_critical(
+                            await self.add_vuln_critical(
                                 request_id=original_request.path_id,
                                 category=NAME,
                                 request=mutated_request,

--- a/wapitiCore/attack/mod_timesql.py
+++ b/wapitiCore/attack/mod_timesql.py
@@ -77,7 +77,7 @@ class mod_timesql(Attack):
                     vuln_message = _("{0} via injection in the parameter {1}").format(self.MSG_VULN, parameter)
                     log_message = Messages.MSG_PARAM_INJECT
 
-                self.add_vuln_critical(
+                await self.add_vuln_critical(
                     request_id=request.path_id,
                     category=NAME,
                     request=mutated_request,
@@ -110,7 +110,7 @@ class mod_timesql(Attack):
                     else:
                         anom_msg = Messages.MSG_PARAM_500.format(parameter)
 
-                    self.add_anom_high(
+                    await self.add_anom_high(
                         request_id=request.path_id,
                         category=Messages.ERROR_500,
                         request=mutated_request,

--- a/wapitiCore/attack/mod_wapp.py
+++ b/wapitiCore/attack/mod_wapp.py
@@ -64,14 +64,14 @@ class mod_wapp(Attack):
         except IOError:
             print(_("Error downloading wapp database."))
 
-    def must_attack(self, request: Request):
+    async def must_attack(self, request: Request):
         if self.finished:
             return False
 
         if request.method == "POST":
             return False
 
-        return request.url == self.persister.get_root_url()
+        return request.url == await self.persister.get_root_url()
 
     async def attack(self, request: Request):
         self.finished = True
@@ -117,7 +117,8 @@ class mod_wapp(Attack):
                 application_name,
                 versions
             )
-            self.add_addition(
+
+            await self.add_addition(
                 category=TECHNO_DETECTED,
                 request=request_to_root,
                 info=json.dumps(detected_applications[application_name])
@@ -125,13 +126,13 @@ class mod_wapp(Attack):
 
             if versions:
                 if "Web servers" in categories:
-                    self.add_vuln_info(
+                    await self.add_vuln_info(
                         category=WEB_SERVER_VERSIONED,
                         request=request_to_root,
                         info=json.dumps(detected_applications[application_name])
                     )
                 else:
-                    self.add_vuln_info(
+                    await self.add_vuln_info(
                         category=WEB_APP_VERSIONED,
                         request=request_to_root,
                         info=json.dumps(detected_applications[application_name])

--- a/wapitiCore/attack/mod_wp_enum.py
+++ b/wapitiCore/attack/mod_wp_enum.py
@@ -61,7 +61,7 @@ class mod_wp_enum(Attack):
                     version
                 )
 
-                self.add_addition(
+                await self.add_addition(
                     category=TECHNO_DETECTED,
                     request=req,
                     info=json.dumps(plugin_detected)
@@ -77,7 +77,7 @@ class mod_wp_enum(Attack):
                     plugin,
                     [""]
                 )
-                self.add_addition(
+                await self.add_addition(
                     category=TECHNO_DETECTED,
                     request=req,
                     info=json.dumps(plugin_detected)
@@ -107,7 +107,7 @@ class mod_wp_enum(Attack):
                     theme,
                     version
                 )
-                self.add_addition(
+                await self.add_addition(
                     category=TECHNO_DETECTED,
                     request=req,
                     info=json.dumps(theme_detected)
@@ -123,7 +123,7 @@ class mod_wp_enum(Attack):
                     theme,
                     [""]
                 )
-                self.add_addition(
+                await self.add_addition(
                     category=TECHNO_DETECTED,
                     request=req,
                     info=json.dumps(theme_detected)
@@ -135,13 +135,13 @@ class mod_wp_enum(Attack):
             return True
         return False
 
-    def must_attack(self, request: Request):
+    async def must_attack(self, request: Request):
         if self.finished:
             return False
 
         if request.method == "POST":
             return False
-        return request.url == self.persister.get_root_url()
+        return request.url == await self.persister.get_root_url()
 
     async def attack(self, request: Request):
 

--- a/wapitiCore/attack/mod_xss.py
+++ b/wapitiCore/attack/mod_xss.py
@@ -132,7 +132,7 @@ class mod_xss(Attack):
                 else:
                     anom_msg = Messages.MSG_PARAM_TIMEOUT.format(xss_param)
 
-                self.add_anom_medium(
+                await self.add_anom_medium(
                     request_id=original_request.path_id,
                     category=Messages.RES_CONSUMPTION,
                     request=evil_request,
@@ -153,7 +153,7 @@ class mod_xss(Attack):
                     if has_strong_csp(response):
                         message += ".\n" + _("Warning: Content-Security-Policy is present!")
 
-                    self.add_vuln_medium(
+                    await self.add_vuln_medium(
                         request_id=original_request.path_id,
                         category=NAME,
                         request=evil_request,
@@ -190,7 +190,7 @@ class mod_xss(Attack):
                     else:
                         anom_msg = Messages.MSG_PARAM_500.format(xss_param)
 
-                    self.add_anom_high(
+                    await self.add_anom_high(
                         request_id=original_request.path_id,
                         category=Messages.ERROR_500,
                         request=evil_request,

--- a/wapitiCore/attack/mod_xxe.py
+++ b/wapitiCore/attack/mod_xxe.py
@@ -157,7 +157,7 @@ class mod_xxe(Attack):
                 else:
                     anom_msg = Messages.MSG_PARAM_TIMEOUT.format(parameter)
 
-                self.add_anom_medium(
+                await self.add_anom_medium(
                     request_id=request.path_id,
                     category=Messages.RES_CONSUMPTION,
                     request=mutated_request,
@@ -178,7 +178,7 @@ class mod_xxe(Attack):
                         vuln_message = _("{0} via injection in the parameter {1}").format(
                             self.MSG_VULN, parameter)
 
-                    self.add_vuln_high(
+                    await self.add_vuln_high(
                         request_id=request.path_id,
                         category=NAME,
                         request=mutated_request,
@@ -208,7 +208,7 @@ class mod_xxe(Attack):
                     else:
                         anom_msg = Messages.MSG_PARAM_500.format(parameter)
 
-                    self.add_anom_high(
+                    await self.add_anom_high(
                         request_id=request.path_id,
                         category=Messages.ERROR_500,
                         request=mutated_request,
@@ -239,7 +239,7 @@ class mod_xxe(Attack):
             else:
                 pattern = search_pattern(response.content, self.flag_to_patterns(tags))
                 if pattern and not await self.false_positive(original_request, pattern):
-                    self.add_vuln_high(
+                    await self.add_vuln_high(
                         request_id=original_request.path_id,
                         category=NAME,
                         request=mutated_request,
@@ -283,7 +283,7 @@ class mod_xxe(Attack):
             else:
                 pattern = search_pattern(response.content, self.flag_to_patterns(flags))
                 if pattern and not await self.false_positive(original_request, pattern):
-                    self.add_vuln_high(
+                    await self.add_vuln_high(
                         request_id=original_request.path_id,
                         category=NAME,
                         request=mutated_request,
@@ -322,7 +322,7 @@ class mod_xxe(Attack):
             return
 
         for request_id in data:
-            original_request = self.persister.get_path_by_id(request_id)
+            original_request = await self.persister.get_path_by_id(request_id)
             if original_request is None:
                 continue
                 # raise ValueError("Could not find the original request with ID {}".format(request_id))
@@ -410,7 +410,7 @@ class mod_xxe(Attack):
                         )
                         mutated_request, __, __, __ = next(mutator.mutate(original_request))
 
-                    self.add_vuln_high(
+                    await self.add_vuln_high(
                         request_id=original_request.path_id,
                         category=NAME,
                         request=mutated_request,

--- a/wapitiCore/main/wapiti.py
+++ b/wapitiCore/main/wapiti.py
@@ -46,7 +46,7 @@ from wapitiCore.definitions import anomalies, additionals, vulnerabilities, flat
 from wapitiCore.net import crawler, jsoncookie
 from wapitiCore.net.web import Request
 from wapitiCore.report import get_report_generator_instance, GENERATORS
-from wapitiCore.net.sqlite_persister import SqlitePersister
+from wapitiCore.net.sql_persister import SqlPersister
 from wapitiCore.moon import phase
 
 from wapitiCore.attack import attack
@@ -139,13 +139,13 @@ class Wapiti:
         self._bug_report = True
 
         if session_dir:
-            SqlitePersister.CRAWLER_DATA_DIR = session_dir
+            SqlPersister.CRAWLER_DATA_DIR = session_dir
 
         if config_dir:
-            SqlitePersister.CONFIG_DIR = config_dir
+            SqlPersister.CONFIG_DIR = config_dir
 
         self._history_file = os.path.join(
-            SqlitePersister.CRAWLER_DATA_DIR,
+            SqlPersister.CRAWLER_DATA_DIR,
             "{}_{}_{}.db".format(
                 self.server.replace(':', '_'),
                 self.target_scope,
@@ -153,10 +153,10 @@ class Wapiti:
             )
         )
 
-        if not os.path.isdir(SqlitePersister.CRAWLER_DATA_DIR):
-            os.makedirs(SqlitePersister.CRAWLER_DATA_DIR)
+        if not os.path.isdir(SqlPersister.CRAWLER_DATA_DIR):
+            os.makedirs(SqlPersister.CRAWLER_DATA_DIR)
 
-        self.persister = SqlitePersister(self._history_file)
+        self.persister = SqlPersister(self._history_file)
 
     async def init_persister(self):
         await self.persister.create()
@@ -692,7 +692,7 @@ class Wapiti:
             os.unlink(self.persister.output_file[:-2] + "pkl")
         except FileNotFoundError:
             pass
-        self.persister = SqlitePersister(self._history_file)
+        self.persister = SqlPersister(self._history_file)
         await self.persister.create()
 
     async def count_resources(self) -> int:

--- a/wapitiCore/net/crawler.py
+++ b/wapitiCore/net/crawler.py
@@ -827,6 +827,7 @@ class Explorer:
                     page.clean()
                     return False, []
 
+            await asyncio.sleep(0)
             resources = self.extract_links(page, request)
             # TODO: there's more situations where we would not want to attack the resource... must check this
             if page.is_directory_redirection:

--- a/wapitiCore/net/sql_persister.py
+++ b/wapitiCore/net/sql_persister.py
@@ -82,7 +82,7 @@ attack_logs = Table(
 )
 
 
-class SqlitePersister:
+class SqlPersister:
     """This class makes the persistence tasks for persisting the crawler parameters
     in other to can continue the process in the future.
     """

--- a/wapitiCore/net/sqlite_persister.py
+++ b/wapitiCore/net/sqlite_persister.py
@@ -17,14 +17,69 @@
 # along with this program; if not, write to the Free Software
 # Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 import os
-import json
-import sqlite3
 from collections import namedtuple
+from typing import Iterable
+
+from aiocache import cached
+from sqlalchemy.ext.asyncio import create_async_engine
+from sqlalchemy import Table, Column, Integer, String, Boolean, Text, MetaData, ForeignKey, select, \
+    PickleType, func, and_, or_, literal_column
 
 from wapitiCore.net import web
 
-
 Payload = namedtuple("Payload", "evil_request,original_request,category,level,parameter,info,type,module")
+
+metadata = MetaData()
+
+scan_infos = Table(
+    "scan_infos", metadata,
+    Column("key", String(255), nullable=False),
+    Column("value", Text, nullable=False)  # We keep the root URL here. With URL scope it may be big
+)
+
+paths = Table(
+    'paths', metadata,
+    Column('path_id', Integer, primary_key=True),
+    Column('path', Text, nullable=False),  # URL, can be huge
+    Column('method', String(length=16), nullable=False),  # HTTP method
+    Column('enctype', String(length=255), nullable=False),  # HTTP request encoding (like multipart...)
+    Column('depth', Integer, nullable=False),
+    Column('encoding', String(length=255)),  # page encoding (like UTF-8...)
+    Column('http_status', Integer),
+    Column('headers', PickleType),  # Pickled HTTP headers, can be huge
+    Column('referer', Text),  # Another URL so potentially huge
+    Column('evil', Boolean, nullable=False),
+)
+
+params = Table(
+    'params', metadata,
+    Column('param_id', Integer, primary_key=True),
+    Column('path_id', None, ForeignKey("paths.path_id")),
+    Column('type', String(length=16), nullable=False),  # HTTP method or "FILE" for multipart
+    Column('position', Integer, nullable=False),
+    Column('name', Text, nullable=False),  # Name of the parameter. Encountered some above 1000 characters
+    Column('value1', Text),  # Can be really huge
+    Column('value2', Text),  # File content. Will be short most of the time but we plan on more usage
+    Column('meta', String(255))  # File mime-type
+)
+
+payloads = Table(
+    'payloads', metadata,
+    Column('evil_path_id', None, ForeignKey("paths.path_id"), nullable=False),
+    Column('original_path_id', None, ForeignKey("paths.path_id"), nullable=False),
+    Column('module', String(255), nullable=False),
+    Column('category', String(255), nullable=False),  # Vulnerability category, should not be that long
+    Column('level', Integer, nullable=False),
+    Column('parameter', Text, nullable=False),  # Vulnerable parameter, can be huge
+    Column('info', Text, nullable=False),  # Vulnerability description. If it contains the parameter name then huge.
+    Column('type', String(255), nullable=False)  # Something like additional/anomaly/vulnerability
+)
+
+attack_logs = Table(
+    'attack_logs', metadata,
+    Column('path_id', None, ForeignKey("paths.path_id"), nullable=False),
+    Column('module', String(255), nullable=False)
+)
 
 
 class SqlitePersister:
@@ -85,130 +140,229 @@ class SqlitePersister:
         self.depth = 0
         self.output_file = output_file
 
-        must_create = not os.path.exists(self.output_file)
-        self._conn = sqlite3.connect(self.output_file)
+        self._must_create = not os.path.exists(self.output_file)
+        self._engine = create_async_engine(f'sqlite+aiosqlite:///{self.output_file}')
 
-        cursor = self._conn.cursor()
+    async def create(self):
+        if self._must_create:
+            async with self._engine.begin() as conn:
+                await conn.run_sync(metadata.create_all)
 
-        if must_create:
-            cursor.execute("""CREATE TABLE scan_infos (key TEXT, value TEXT)""")
-            cursor.execute(
-                """CREATE TABLE paths (
-                     path_id INTEGER PRIMARY KEY,
-                     path TEXT,
-                     method TEXT,
-                     enctype TEXT,
-                     depth INTEGER,
-                     encoding TEXT,
-                     http_status INTEGER,
-                     headers TEXT,
-                     referer TEXT,
-                     evil INTEGER
-                )"""
-            )
+    async def close(self):
+        await self._engine.dispose()
 
-            cursor.execute(
-                """CREATE TABLE params (
-                    path_id INTEGER,
-                    type TEXT,
-                    param_order INTEGER,
-                    name TEXT,
-                    value1 TEXT,
-                    value2 TEXT,
-                    meta TEXT,
-                    FOREIGN KEY(path_id) REFERENCES paths(path_id)
-                )"""
-            )
-
-            cursor.execute(
-                """CREATE TABLE attack_log (path_id INTEGER, module_name TEXT)"""
-            )
-
-            cursor.execute(
-                """CREATE TABLE payloads (
-                    evil_path INTEGER PRIMARY KEY,
-                    original_path INTEGER,
-                    category TEXT,
-                    level INTEGER,
-                    parameter TEXT,
-                    info TEXT,
-                    type TEXT,
-                    module TEXT
-                )"""
-            )
-
-            self._conn.commit()
-
-    def close(self):
-        self._conn.close()
-
-    def set_root_url(self, root_url):
-        cursor = self._conn.cursor()
-        cursor.execute("""INSERT INTO scan_infos VALUES (?, ?)""", ("root_url", root_url))
-        self._conn.commit()
+    async def set_root_url(self, root_url):
+        async with self._engine.begin() as conn:
+            await conn.execute(scan_infos.insert().values(
+                key="root_url",
+                value=root_url
+            ))
         self.root_url = root_url
 
-    def get_root_url(self):
-        cursor = self._conn.cursor()
-        cursor.execute("SELECT value FROM scan_infos WHERE key = 'root_url'")
-        return cursor.fetchone()[0]
+    @cached()
+    async def get_root_url(self):
+        statement = select(scan_infos).where(scan_infos.c.key == "root_url").limit(1)
+        async with self._engine.begin() as conn:
+            result = await conn.execute(statement)
+            return result.fetchone().value
 
-    def set_to_browse(self, to_browse):
-        self._set_paths(to_browse)
+    async def set_to_browse(self, to_browse):
+        await self._set_paths(to_browse)
 
-    def get_to_browse(self):
-        yield from self._get_paths(method=None, crawled=False)
+    async def get_to_browse(self):
+        async for path in self._get_paths(method=None, crawled=False):
+            yield path
 
-    def _set_paths(self, paths):
-        cursor = self._conn.cursor()
-        for http_resource in paths:
+    async def _set_paths(self, paths_list):
+        if not paths_list:
+            return
+
+        if len(paths_list) == 1:
+            await self.add_request(paths_list[0])
+            return
+
+        bigest_id = 0
+        all_path_values = []
+        all_param_values = []
+
+        async with self._engine.begin() as conn:
+            for http_resource in paths_list:
+                if http_resource.path_id:
+                    # Request was already saved but not fetched, just update to set HTTP code and headers
+                    statement = paths.update().where(
+                        paths.c.path_id == http_resource.path_id
+                    ).values(
+                        http_status=http_resource.status if isinstance(http_resource.status, int) else None,
+                        headers=http_resource.headers
+                    )
+                    await conn.execute(statement)
+                    continue
+
+                if bigest_id == 0:
+                    # This is a trick to be able to insert all paths and params in bulk
+                    # instead of inserting path and get the new returned ID to then insert params
+                    result = await conn.execute(select(func.max(paths.c.path_id)))
+                    result = result.scalar()
+                    if result is not None:
+                        bigest_id = result
+
+                bigest_id += 1
+
+                # Save the request along with its parameters
+                # Beware: https://docs.sqlalchemy.org/en/14/core/tutorial.html#executing-multiple-statements
+                # When executing multiple sets of parameters, each dictionary must have the same set of keys;
+                # i.e. you cant have fewer keys in some dictionaries than others.
+                # This is because the Insert statement is compiled against the first dictionary in the list,
+                # and it’s assumed that all subsequent argument dictionaries are compatible with that statement.
+                all_path_values.append(
+                    {
+                        "path_id": bigest_id,
+                        "path": http_resource.path,
+                        "method": http_resource.method,
+                        "enctype": http_resource.enctype,
+                        "depth": http_resource.link_depth,
+                        "encoding": http_resource.encoding,
+                        "http_status": http_resource.status if isinstance(http_resource.status, int) else None,
+                        "headers": http_resource.headers,
+                        "referer": http_resource.referer,
+                        "evil": False
+                    }
+                )
+
+                for i, (get_param_key, get_param_value) in enumerate(http_resource.get_params):
+                    all_param_values.append(
+                        {
+                            "path_id": bigest_id,
+                            "type": "GET",
+                            "position": i,
+                            "name": get_param_key,
+                            "value1": get_param_value,
+                            "value2": None,
+                            "meta": None
+                        }
+                    )
+
+                post_params = http_resource.post_params
+                if isinstance(post_params, list):
+                    for i, (post_param_key, post_param_value) in enumerate(http_resource.post_params):
+                        all_param_values.append(
+                            {
+                                "path_id": bigest_id,
+                                "type": "POST",
+                                "position": i,
+                                "name": post_param_key,
+                                "value1": post_param_value,
+                                "value2": None,
+                                "meta": None
+                            }
+                        )
+                elif post_params:
+                    all_param_values.append(
+                        {
+                            "path_id": bigest_id,
+                            "type": "POST",
+                            "position": 0,
+                            "name": "__RAW__",
+                            "value1": post_params,
+                            "value2": None,
+                            "meta": None
+                        }
+                    )
+
+                for i, (file_param_key, file_param_value) in enumerate(http_resource.file_params):
+                    # file_param_value will be something like ['pix.gif', 'GIF89a', 'image/gif']
+                    # just keep the file name
+                    if len(file_param_value) == 3:
+                        meta = file_param_value[2]
+                    else:
+                        meta = None
+
+                    all_param_values.append(
+                        {
+                            "path_id": bigest_id,
+                            "type": "FILE",
+                            "position": i,
+                            "name": file_param_key,
+                            "value1": file_param_value[0],
+                            "value2": file_param_value[1],
+                            "meta": meta
+                        }
+                    )
+
+            if all_path_values:
+                await conn.execute(paths.insert(), all_path_values)
+
+                if all_param_values:
+                    await conn.execute(params.insert(), all_param_values)
+
+    async def add_request(self, http_resource):
+        async with self._engine.begin() as conn:
             if http_resource.path_id:
                 # Request was already saved but not fetched, just update to set HTTP code and headers
-                cursor.execute(
-                    """UPDATE paths SET http_status = ?, headers = ? WHERE path_id = ?""",
-                    (
-                        http_resource.status if isinstance(http_resource.status, int) else None,
-                        None if http_resource.headers is None else json.dumps(dict(http_resource.headers)),
-                        http_resource.path_id
-                    )
+                statement = paths.update().where(
+                    paths.c.path_id == http_resource.path_id
+                ).values(
+                    http_status=http_resource.status if isinstance(http_resource.status, int) else None,
+                    headers=http_resource.headers
                 )
-                continue
+                await conn.execute(statement)
+                return
 
-            # Save the request along with its parameters
-            cursor.execute(
-                """INSERT INTO paths VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
-                (
-                    None,
-                    http_resource.path,
-                    http_resource.method,
-                    http_resource.enctype,
-                    http_resource.link_depth,
-                    http_resource.encoding,
-                    http_resource.status if isinstance(http_resource.status, int) else None,
-                    None if http_resource.headers is None else json.dumps(dict(http_resource.headers)),
-                    http_resource.referer,
-                    0
-                )
+            # as we have a unique request let's do insertion the classic way
+            statement = paths.insert().values(
+                path=http_resource.path,
+                method=http_resource.method,
+                enctype=http_resource.enctype,
+                depth=http_resource.link_depth,
+                encoding=http_resource.encoding,
+                http_status=http_resource.status if isinstance(http_resource.status, int) else None,
+                headers=http_resource.headers,
+                referer=http_resource.referer,
+                evil=False
             )
-            path_id = cursor.lastrowid
 
+            result = await conn.execute(statement)
+
+            path_id = result.inserted_primary_key[0]
+            all_values = []
             for i, (get_param_key, get_param_value) in enumerate(http_resource.get_params):
-                cursor.execute(
-                    """INSERT INTO params VALUES (?, ?, ?, ?, ?, ?, ?)""",
-                    (path_id, "GET", i, get_param_key, get_param_value, None, None)
+                all_values.append(
+                    {
+                        "path_id": path_id,
+                        "type": "GET",
+                        "position": i,
+                        "name": get_param_key,
+                        "value1": get_param_value,
+                        "value2": None,
+                        "meta": None
+                    }
                 )
 
             post_params = http_resource.post_params
             if isinstance(post_params, list):
                 for i, (post_param_key, post_param_value) in enumerate(http_resource.post_params):
-                    cursor.execute(
-                        """INSERT INTO params VALUES (?, ?, ?, ?, ?, ?, ?)""",
-                        (path_id, "POST", i, post_param_key, post_param_value, None, None)
+                    all_values.append(
+                        {
+                            "path_id": path_id,
+                            "type": "POST",
+                            "position": i,
+                            "name": post_param_key,
+                            "value1": post_param_value,
+                            "value2": None,
+                            "meta": None
+                        }
                     )
-            elif post_params:
-                cursor.execute(
-                    """INSERT INTO params VALUES (?, ?, ?, ?, ?, ?, ?)""",
-                    (path_id, "POST", 0, "__RAW__", post_params, None, None)
+            elif len(post_params):
+                all_values.append(
+                    {
+                        "path_id": path_id,
+                        "type": "POST",
+                        "position": 0,
+                        "name": "__RAW__",
+                        "value1": post_params,
+                        "value2": None,
+                        "meta": None
+                    }
                 )
 
             for i, (file_param_key, file_param_value) in enumerate(http_resource.file_params):
@@ -218,65 +372,282 @@ class SqlitePersister:
                     meta = file_param_value[2]
                 else:
                     meta = None
-                cursor.execute(
-                    """INSERT INTO params VALUES (?, ?, ?, ?, ?, ?, ?)""",
-                    (path_id, "FILE", i, file_param_key, file_param_value[0], file_param_value[1], meta)
+
+                all_values.append(
+                    {
+                        "path_id": path_id,
+                        "type": "FILE",
+                        "position": i,
+                        "name": file_param_key,
+                        "value1": file_param_value[0],
+                        "value2": file_param_value[1],
+                        "meta": meta
+                    }
                 )
 
-        self._conn.commit()
-        cursor.close()
+            if all_values:
+                await conn.execute(params.insert(), all_values)
 
-    def add_request(self, link):
-        self._set_paths([link])
-
-    def _get_paths(self, path=None, method=None, crawled: bool = True, attack_module: str = "", evil: bool = False):
-        cursor = self._conn.cursor()
-
-        conditions = ["evil = ?"]
-        args = [int(evil)]
+    async def _get_paths(self, path=None, method=None, crawled: bool = True, module: str = "", evil: bool = False):
+        conditions = [paths.c.evil == evil]
 
         if path and isinstance(path, str):
-            conditions.append("path = ?")
-            args.append(path)
+            conditions.append(paths.c.path == path)
 
         if method in ("GET", "POST"):
-            conditions.append("method = ?")
-            args.append(method)
+            conditions.append(paths.c.method == method)
 
         if crawled:
-            conditions.append("headers IS NOT NULL")
+            conditions.append(paths.c.headers != None)
 
-        conditions = " AND ".join(conditions)
-        conditions = "WHERE " + conditions
+        async with self._engine.begin() as conn:
+            result = await conn.execute(select(paths).where(and_(True, *conditions)).order_by(paths.c.path))
 
-        cursor.execute("SELECT * FROM paths {} ORDER BY path".format(conditions), args)
-
-        for row in cursor.fetchall():
+        for row in result.fetchall():
             path_id = row[0]
 
-            if attack_module:
+            if module:
                 # Exclude requests matching the attack module, we want requests that aren't attacked yet
-                cursor.execute(
-                    "SELECT * FROM attack_log WHERE path_id = ? AND module_name = ? LIMIT 1",
-                    (path_id, attack_module)
-                )
+                statement = select(attack_logs).where(
+                    attack_logs.c.path_id == path_id,
+                    attack_logs.c.module == module
+                ).limit(1)
+                async with self._engine.begin() as conn:
+                    result = await conn.execute(statement)
 
-                if cursor.fetchone():
+                if result.fetchone():
                     continue
 
             get_params = []
             post_params = []
             file_params = []
 
-            for param_row in cursor.execute(
-                    (
-                        "SELECT type, name, value1, value2, meta "
-                        "FROM params "
-                        "WHERE path_id = ? "
-                        "ORDER BY type, param_order"
-                    ),
-                    (path_id, )
-            ):
+            statement = select(
+                params.c.type, params.c.name, params.c.value1, params.c.value2, params.c.meta
+            ).where(params.c.path_id == path_id).order_by(params.c.type, params.c.position)
+
+            async with self._engine.begin() as conn:
+                async_result = await conn.stream(statement)
+
+                async for param_row in async_result:
+                    name = param_row[1]
+                    value1 = param_row[2]
+
+                    if param_row[0] == "GET":
+                        get_params.append([name, value1])
+                    elif param_row[0] == "POST":
+                        if name == "__RAW__" and not post_params:
+                            # First POST parameter is __RAW__, it should mean that we have raw content
+                            post_params = value1
+                        elif isinstance(post_params, list):
+                            post_params.append([name, value1])
+                    elif param_row[0] == "FILE":
+                        if param_row[4]:
+                            file_params.append([name, (value1, param_row[3], param_row[4])])
+                        else:
+                            file_params.append([name, (value1, param_row[3])])
+                    else:
+                        raise ValueError("Unknown param type {}".format(param_row[0]))
+
+                http_res = web.Request(
+                    row[1],
+                    method=row[2],
+                    encoding=row[5],
+                    enctype=row[3],
+                    referer=row[8],
+                    get_params=get_params,
+                    post_params=post_params,
+                    file_params=file_params
+                )
+
+                if row[6]:
+                    http_res.status = row[6]
+
+                if row[7]:
+                    http_res.set_headers(row[7])
+
+                http_res.link_depth = row[4]
+                http_res.path_id = path_id
+
+                yield http_res
+
+    async def get_links(self, path=None, attack_module: str = ""):
+        async for path in self._get_paths(path=path, method="GET", crawled=True, module=attack_module):
+            yield path
+
+    async def get_forms(self, path=None, attack_module: str = ""):
+        async for path in self._get_paths(path=path, method="POST", crawled=True, module=attack_module):
+            yield path
+
+    async def count_paths(self) -> int:
+        statement = select(func.count(paths.c.path_id)).where(~paths.c.evil)
+        async with self._engine.begin() as conn:
+            result = await conn.execute(statement)
+            return result.fetchone()[0]
+
+    async def set_attacked(self, path_ids: Iterable, module_name):
+        if not path_ids:
+            return
+
+        async with self._engine.begin() as conn:
+            all_values = [
+                {"path_id": path_id, "module": module_name} for path_id in path_ids
+            ]
+            await conn.execute(attack_logs.insert(), all_values)
+
+    async def count_attacked(self, module_name) -> int:
+        statement = select(func.count(attack_logs.c.path_id)).where(attack_logs.c.module == module_name)
+        async with self._engine.begin() as conn:
+            result = await conn.execute(statement)
+
+        return result.fetchone()[0]
+
+    async def has_scan_finished(self):
+        # If we have a path without headers set then the scan is not finished
+        statement = select(paths.c.path_id).where(paths.c.headers == None).limit(1)
+        async with self._engine.begin() as conn:
+            result = await conn.execute(statement)
+
+        if result.fetchone():
+            return False
+        return True
+
+    async def has_scan_started(self) -> bool:
+        statement = select(paths.c.path_id).limit(1)
+        async with self._engine.begin() as conn:
+            result = await conn.execute(statement)
+        if result.fetchone():
+            return True
+        return False
+
+    async def have_attacks_started(self) -> bool:
+        statement = select(attack_logs.c.path_id).limit(1)
+        async with self._engine.begin() as conn:
+            result = await conn.execute(statement)
+
+        if result.fetchone():
+            return True
+        return False
+
+    async def add_payload(
+            self, request_id: int, payload_type: str, module: str,
+            category=None, level=0, request=None, parameter="", info=""):
+
+        # Save the request along with its parameters
+        statement = paths.insert().values(
+            path=request.path,
+            method=request.method,
+            enctype=request.enctype,
+            depth=request.link_depth,
+            encoding=request.encoding,
+            http_status=request.status if isinstance(request.status, int) else None,
+            headers=request.headers,
+            referer=request.referer,
+            evil=True
+        )
+        async with self._engine.begin() as conn:
+            result = await conn.execute(statement)
+        # path_id is the ID of the evil path
+        path_id = result.inserted_primary_key[0]
+
+        all_values = []
+        for i, (get_param_key, get_param_value) in enumerate(request.get_params):
+            all_values.append(
+                {
+                    "path_id": path_id,
+                    "type": "GET",
+                    "position": i,
+                    "name": get_param_key,
+                    "value1": get_param_value,
+                    "value2": None,
+                    "meta": None
+                }
+            )
+
+        post_params = request.post_params
+        if isinstance(post_params, list):
+            for i, (post_param_key, post_param_value) in enumerate(request.post_params):
+                all_values.append(
+                    {
+                        "path_id": path_id,
+                        "type": "POST",
+                        "position": i,
+                        "name": post_param_key,
+                        "value1": post_param_value,
+                        "value2": None,
+                        "meta": None
+                    }
+                )
+        elif post_params:
+            all_values.append(
+                {
+                    "path_id": path_id,
+                    "type": "POST",
+                    "position": 0,
+                    "name": "__RAW__",
+                    "value1": post_params,
+                    "value2": None,
+                    "meta": None
+                }
+            )
+
+        for i, (file_param_key, file_param_value) in enumerate(request.file_params):
+            if len(file_param_value) == 3:
+                meta = file_param_value[2]
+            else:
+                meta = None
+
+            all_values.append(
+                {
+                    "path_id": path_id,
+                    "type": "FILE",
+                    "position": i,
+                    "name": file_param_key,
+                    "value1": file_param_value[0],
+                    "value2": file_param_value[1],
+                    "meta": meta
+                }
+            )
+
+        if all_values:
+            async with self._engine.begin() as conn:
+                await conn.execute(params.insert(), all_values)
+
+        # request_id is the ID of the original (legit) request
+        statement = payloads.insert().values(
+            evil_path_id=path_id,
+            original_path_id=request_id,
+            module=module,
+            category=category,
+            level=level,
+            parameter=parameter,
+            info=info,
+            type=payload_type
+        )
+        async with self._engine.begin() as conn:
+            await conn.execute(statement)
+
+    async def get_path_by_id(self, path_id):
+        path_id = int(path_id)
+        async with self._engine.begin() as conn:
+            result = await conn.execute(select(paths).where(paths.c.path_id == path_id).limit(1))
+
+        row = result.fetchone()
+        if not row:
+            return None
+
+        get_params = []
+        post_params = []
+        file_params = []
+
+        statement = select(
+            params.c.type, params.c.name, params.c.value1, params.c.value2, params.c.meta
+        ).where(params.c.path_id == path_id).order_by(params.c.type, params.c.position)
+
+        async with self._engine.begin() as conn:
+            async_result = await conn.stream(statement)
+
+            async for param_row in async_result:
                 name = param_row[1]
                 value1 = param_row[2]
 
@@ -296,7 +667,7 @@ class SqlitePersister:
                 else:
                     raise ValueError("Unknown param type {}".format(param_row[0]))
 
-            http_res = web.Request(
+            request = web.Request(
                 row[1],
                 method=row[2],
                 encoding=row[5],
@@ -308,273 +679,69 @@ class SqlitePersister:
             )
 
             if row[6]:
-                http_res.status = row[6]
+                request.status = row[6]
 
             if row[7]:
-                http_res.set_headers(json.loads(row[7]))
+                request.set_headers(row[7])
 
-            http_res.link_depth = row[4]
-            http_res.path_id = path_id
+            request.link_depth = row[4]
+            request.path_id = path_id
 
-            yield http_res
+            return request
 
-    def get_links(self, path=None, attack_module: str = ""):
-        yield from self._get_paths(path=path, method="GET", crawled=True, attack_module=attack_module)
+    async def get_payloads(self):
+        async with self._engine.begin() as conn:
+            result = await conn.execute(select(payloads))
 
-    def get_forms(self, path=None, attack_module: str = ""):
-        yield from self._get_paths(path=path, method="POST", crawled=True, attack_module=attack_module)
+        for row in result.fetchall():
+            evil_id, original_id, module, category, level, parameter, info, payload_type = row
 
-    def count_paths(self) -> int:
-        cursor = self._conn.cursor()
-        cursor.execute("SELECT COUNT(path_id) from paths WHERE evil = 0")
-        return cursor.fetchone()[0]
-
-    def set_attacked(self, path_id, module_name):
-        cursor = self._conn.cursor()
-        cursor.execute("INSERT INTO attack_log VALUES (?, ?)", (path_id, module_name))
-        self._conn.commit()
-
-    def count_attacked(self, module_name) -> int:
-        cursor = self._conn.cursor()
-        cursor.execute("SELECT COUNT(path_id) from attack_log WHERE module_name = ?", (module_name, ))
-        return cursor.fetchone()[0]
-
-    def has_scan_finished(self):
-        cursor = self._conn.cursor()
-        cursor.execute("SELECT path_id FROM paths WHERE headers IS NULL LIMIT 1")
-        if cursor.fetchone():
-            return False
-        return True
-
-    def has_scan_started(self) -> bool:
-        cursor = self._conn.cursor()
-        cursor.execute("SELECT path_id FROM paths LIMIT 1")
-        if cursor.fetchone():
-            return True
-        return False
-
-    def have_attacks_started(self) -> bool:
-        cursor = self._conn.cursor()
-        cursor.execute("SELECT path_id FROM attack_log LIMIT 1")
-        if cursor.fetchone():
-            return True
-        return False
-
-    def add_payload(self, request_id: int, payload_type: str, module: str,
-    category=None, level=0, request=None, parameter="", info=""):
-        cursor = self._conn.cursor()
-
-        cursor.execute(
-            """INSERT INTO paths VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
-            (
-                None,
-                request.path,
-                request.method,
-                request.enctype,
-                request.link_depth,
-                request.encoding,
-                request.status if isinstance(request.status, int) else None,
-                None if request.headers is None else json.dumps(dict(request.headers)),
-                request.referer,
-                1
-            )
-        )
-
-        # path_id is the ID of the evil path
-        path_id = cursor.lastrowid
-        for i, (get_param_key, get_param_value) in enumerate(request.get_params):
-            cursor.execute(
-                """INSERT INTO params VALUES (?, ?, ?, ?, ?, ?, ?)""",
-                (path_id, "GET", i, get_param_key, get_param_value, None, None)
-            )
-
-        post_params = request.post_params
-        if isinstance(post_params, list):
-            for i, (post_param_key, post_param_value) in enumerate(request.post_params):
-                cursor.execute(
-                    """INSERT INTO params VALUES (?, ?, ?, ?, ?, ?, ?)""",
-                    (path_id, "POST", i, post_param_key, post_param_value, None, None)
-                )
-        elif post_params:
-            cursor.execute(
-                """INSERT INTO params VALUES (?, ?, ?, ?, ?, ?, ?)""",
-                (path_id, "POST", 0, "__RAW__", post_params, None, None)
-            )
-
-        for i, (file_param_key, file_param_value) in enumerate(request.file_params):
-            if len(file_param_value) == 3:
-                meta = file_param_value[2]
-            else:
-                meta = None
-
-            cursor.execute(
-                """INSERT INTO params VALUES (?, ?, ?, ?, ?, ?, ?)""",
-                (path_id, "FILE", i, file_param_key, file_param_value[0], file_param_value[1], meta)
-            )
-
-        # request_id is the ID of the original (legit) request
-        cursor.execute(
-            "INSERT INTO payloads VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
-            (path_id, request_id, category, level, parameter, info, payload_type, module)
-        )
-        self._conn.commit()
-
-    def add_additional(self, module: str, request_id: int = -1,
-    category=None, level=0, request=None, parameter="", info=""):
-        self.add_payload(
-            request_id,
-            "additional",
-            module,
-            category,
-            level,
-            request,
-            parameter,
-            info
-        )
-
-    def add_anomaly(self, module: str, request_id: int = -1,
-    category=None, level=0, request=None, parameter="", info=""):
-        self.add_payload(
-            request_id,
-            "anomaly",
-            module,
-            category,
-            level,
-            request,
-            parameter,
-            info
-        )
-
-    def add_vulnerability(self, module: str, request_id: int = -1,
-    category=None, level=0, request=None, parameter="", info=""):
-        self.add_payload(
-            request_id,
-            "vulnerability",
-            module,
-            category,
-            level,
-            request,
-            parameter,
-            info
-        )
-
-    def get_path_by_id(self, path_id):
-        cursor = self._conn.cursor()
-
-        cursor.execute("SELECT * FROM paths WHERE path_id = ? LIMIT 1", (path_id, ))
-
-        row = cursor.fetchone()
-        if not row:
-            return None
-
-        get_params = []
-        post_params = []
-        file_params = []
-
-        for param_row in cursor.execute(
-                (
-                    "SELECT type, name, value1, value2, meta "
-                    "FROM params "
-                    "WHERE path_id = ? "
-                    "ORDER BY type, param_order"
-                ),
-                (path_id, )
-        ):
-            name = param_row[1]
-            value1 = param_row[2]
-
-            if param_row[0] == "GET":
-                get_params.append([name, value1])
-            elif param_row[0] == "POST":
-                if name == "__RAW__" and not post_params:
-                    # First POST parameter is __RAW__, it should mean that we have raw content
-                    post_params = value1
-                elif isinstance(post_params, list):
-                    post_params.append([name, value1])
-            elif param_row[0] == "FILE":
-                if param_row[4]:
-                    file_params.append([name, (value1, param_row[3], param_row[4])])
-                else:
-                    file_params.append([name, (value1, param_row[3])])
-            else:
-                raise ValueError("Unknown param type {}".format(param_row[0]))
-
-        request = web.Request(
-            row[1],
-            method=row[2],
-            encoding=row[5],
-            enctype=row[3],
-            referer=row[8],
-            get_params=get_params,
-            post_params=post_params,
-            file_params=file_params
-        )
-
-        if row[6]:
-            request.status = row[6]
-
-        if row[7]:
-            request.set_headers(json.loads(row[7]))
-
-        request.link_depth = row[4]
-        request.path_id = path_id
-
-        return request
-
-    def get_payloads(self):
-        cursor = self._conn.cursor()
-        cursor.execute("SELECT * FROM payloads")
-
-        for row in cursor.fetchall():
-            evil_id, original_id, category, level, parameter, info, payload_type, module = row
-
-            evil_request = self.get_path_by_id(evil_id)
-            original_request = self.get_path_by_id(original_id)
+            evil_request = await self.get_path_by_id(evil_id)
+            original_request = await self.get_path_by_id(original_id)
 
             yield Payload(evil_request, original_request, category, level, parameter, info, payload_type, module)
 
-    def flush_session(self):
-        self.flush_attacks()
-        cursor = self._conn.cursor()
-        cursor.execute("DELETE FROM paths")
-        cursor.execute("DELETE FROM params")
-        self._conn.commit()
+    async def flush_session(self):
+        await self.flush_attacks()
+        async with self._engine.begin() as conn:
+            await conn.execute(paths.delete())
+            await conn.execute(params.delete())
 
-    def flush_attacks(self):
-        cursor = self._conn.cursor()
-        cursor.execute("DELETE FROM attack_log")  # which module was launched on which URL
-        cursor.execute("DELETE FROM payloads")  # informations on vulnerabilities and anomalies
-        cursor.execute("DELETE FROM paths WHERE evil = 1")  # Evil requests
-        # Remove params tied to deleted requests
-        cursor.execute("DELETE FROM params WHERE path_id NOT IN (SELECT path_id FROM paths)")
-        self._conn.commit()
+    async def flush_attacks(self):
+        async with self._engine.begin() as conn:
+            await conn.execute(attack_logs.delete())  # which module was launched on which URL
+            await conn.execute(payloads.delete())  # information on vulnerabilities and anomalies
+            await conn.execute(paths.delete().where(paths.c.evil == True))  # Evil requests
+            # Remove params tied to deleted requests
+            await conn.execute(params.delete().where(~params.c.path_id.in_(select(paths.c.path_id))))
 
-    def delete_path_by_id(self, path_id):
-        cursor = self._conn.cursor()
+    async def delete_path_by_id(self, path_id):
         # First remove all references to that path then remove it
-        cursor.execute("DELETE FROM payloads WHERE evil_path = ? OR original_path = ?", (path_id, path_id))
-        cursor.execute("DELETE FROM attack_log WHERE path_id = ?", (path_id, ))
-        cursor.execute("DELETE FROM params WHERE path_id = ?", (path_id, ))
-        cursor.execute("DELETE FROM paths WHERE path_id = ?", (path_id, ))
-        self._conn.commit()
+        async with self._engine.begin() as conn:
+            await conn.execute(
+                payloads.delete().where(or_(payloads.c.evil_path_id == path_id, payloads.c.original_path_id == path_id))
+            )
+            await conn.execute(attack_logs.delete().where(attack_logs.c.path_id == path_id))
+            await conn.execute(params.delete().where(params.c.path_id == path_id))
+            await conn.execute(paths.delete().where(paths.c.path_id == path_id))
 
-    def get_big_requests_ids(self, params_count: int) -> list:
-        cursor = self._conn.cursor()
-        cursor.execute(
-            "SELECT path_id, count(*) as params_count FROM params GROUP BY path_id HAVING params_count > ?",
-            (params_count, )
-        )
+    async def get_big_requests_ids(self, params_count: int) -> list:
+        statement = select(
+            params.c.path_id, func.count(params.c.param_id).label("params_count")
+        ).group_by("path_id").having(literal_column("params_count") > params_count)
 
+        async with self._engine.begin() as conn:
+            result = await conn.execute(statement)
         path_ids = set()
-        for row in cursor.fetchall():
+        for row in result.fetchall():
             path_id, __ = row
             path_ids.add(path_id)
 
         return list(path_ids)
 
-    def remove_big_requests(self, params_count: int) -> int:
-        path_ids = self.get_big_requests_ids(params_count)
+    async def remove_big_requests(self, params_count: int) -> int:
+        path_ids = await self.get_big_requests_ids(params_count)
 
         for path_id in path_ids:
-            self.delete_path_by_id(path_id)
+            await self.delete_path_by_id(path_id)
         return len(path_ids)

--- a/wapitiCore/report/csvreportgenerator.py
+++ b/wapitiCore/report/csvreportgenerator.py
@@ -53,24 +53,33 @@ class CSVReportGenerator(ReportGenerator):
         """
         if request is not None:
             self._vulns.append(
-                [category, level, info, request.method, parameter, request.url,
-                request.encoded_data, request.referer, auth, module]
+                [
+                    category, level, info, request.method, parameter,
+                    request.url, request.encoded_data, request.referer,
+                    auth, module
+                ]
             )
 
     def add_anomaly(self, module: str, category=None, level=0, request=None, parameter="", info="", auth=None):
         """Store the information about an anomaly met during the attack."""
         if request is not None:
             self._anomalies.append(
-                [category, level, info, request.method, parameter, request.url,
-                request.encoded_data, request.referer, auth, module]
+                [
+                    category, level, info, request.method, parameter,
+                    request.url, request.encoded_data, request.referer,
+                    auth, module
+                ]
             )
 
     def add_additional(self, module: str, category=None, level=0, request=None, parameter="", info="", auth=None):
         """Store the information about an additional."""
         if request is not None:
             self._additionals.append(
-                [category, level, info, request.method, parameter, request.url,
-                request.encoded_data, request.referer, auth, module]
+                [
+                    category, level, info, request.method, parameter,
+                    request.url, request.encoded_data, request.referer,
+                    auth, module
+                ]
             )
 
     # We don't want description of each vulnerability for this report format


### PR DESCRIPTION
First:

In order to support other databases than SQLite for the persister we should use SQL Alchemy that offers a great level of abstraction.

SQLAlchemy ORM seems clumsy to use for our situation, especially as we need to create Request objects without necessarily saving them to a database. Also the ORM generates some queries to the database when we do not expect them.

SQLAlchemy Core seems the good solution: we can specify abtract column types and the library will use the good data types for each DBMS.

Second:

SQLAlchemy offers a asyncio interface so we can use the dbms in a non blocking way and prevent blocking the asyncio event loop. There is a bit of magic for sqlite because asyncio is made for network and sqlite is file based but with the aiosqlite engine queries are executed inside threads.

Third:

The FakePersister used in tests in non-pythonic and the code appears at too many places. As I had to rewrote this because of asyncio I prefered to completely remove it in favor of standard Python mocking.
