### PR TITLE
Update dockerfile to use bullseye

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:buster-slim as build
+FROM debian:bullseye-slim as build
 
 ENV DEBIAN_FRONTEND=noninteractive \
   LANG=en_US.UTF-8
@@ -6,7 +6,7 @@ ENV DEBIAN_FRONTEND=noninteractive \
 WORKDIR /usr/src/app
 
 RUN apt update \
-  && apt install python3 python3-setuptools ca-certificates -y \
+  && apt install python3 python3-pip python3-setuptools ca-certificates -y \
   && apt clean -yq \
   && apt autoremove -yq \
   && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* \
@@ -16,7 +16,7 @@ COPY . .
 
 RUN python3 setup.py install
 
-FROM debian:buster-slim
+FROM debian:bullseye-slim
 
 ENV DEBIAN_FRONTEND=noninteractive \
   LANG=en_US.UTF-8 \
@@ -29,7 +29,7 @@ RUN apt update \
   && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* \
   && truncate -s 0 /var/log/*log
 
-COPY --from=build /usr/local/lib/python3.7/dist-packages/ /usr/local/lib/python3.7/dist-packages/
+COPY --from=build /usr/local/lib/python3.9/dist-packages/ /usr/local/lib/python3.9/dist-packages/
 COPY --from=build /usr/local/bin/wapiti /usr/local/bin/wapiti-getcookie /usr/local/bin/
 
 CMD ["wapiti"]


### PR DESCRIPTION
@devl00p now we use python 3.9 in production, you can drop the 3.7/3.8 support if you need.