### PR TITLE
Remove references to "wapiti3.ovh" from XSS payloads by overwriting…

### DIFF
--- a/tests/data/xss/no_http_no_parenthesis.php
+++ b/tests/data/xss/no_http_no_parenthesis.php
@@ -1,0 +1,12 @@
+<html>
+<body>
+Hello <?php
+$name = isset($_GET["name"]) ? $_GET["name"] : "anonymous coward";
+if (stristr($name, "http") || stristr($name, "(")) {
+    // Look mah, uber-31337 xss filtering
+    $name = "anonymous hacker";
+}
+echo $name;
+?>
+</body>
+</html>

--- a/wapitiCore/attack/attack.py
+++ b/wapitiCore/attack/attack.py
@@ -19,7 +19,7 @@
 import os
 import sys
 from os.path import splitext, join as path_join
-from urllib.parse import quote
+from urllib.parse import quote, urlparse
 from collections import defaultdict
 from enum import Enum
 from math import ceil
@@ -274,6 +274,11 @@ class Attack:
     @property
     def external_endpoint(self):
         return self.options.get("external_endpoint", "http://wapiti3.ovh")
+
+    @property
+    def proto_endpoint(self):
+        parts = urlparse(self.external_endpoint)
+        return parts.netloc + parts.path
 
     async def must_attack(self, request: Request):  # pylint: disable=unused-argument
         return not self.finished

--- a/wapitiCore/data/attacks/xssPayloads.ini
+++ b/wapitiCore/data/attacks/xssPayloads.ini
@@ -48,11 +48,9 @@ case_sensitive = yes
 
 ; I saw webpages cuttings words on uppercase letters so let's keep only the S uppercase
 [script_absolute_src]
-; payload = <Script src=https://wapiti3.ovh/__XSS__z.js></Script>
 payload = <Script src=[EXTERNAL_ENDPOINT]__XSS__z.js></Script>
 tag = script
 attribute = src
-; value = https://wapiti3.ovh/__XSS__z.js
 value = [EXTERNAL_ENDPOINT]__XSS__z.js
 case_sensitive = no
 


### PR DESCRIPTION
Remove references to "wapiti3.ovh" from XSS payloads by overwriting `external_endpoint` in both XSS modules and using a random website name instead.

Also I saw that the replacement of `[PROTO_ENDPOINT]` wasn't there so I fixed it and added a test.

Fix #151 