### PR TITLE
Add test for net/page

### DIFF
--- a/tests/net/test_page.py
+++ b/tests/net/test_page.py
@@ -1,0 +1,33 @@
+#!/usr/bin/env python3
+
+from httpx import Response, Request
+from wapitiCore.net.page import Page
+
+def test_make_absolute():
+
+    TEST_CASES = [
+        ("http://base.url", "relative", "http://base.url/relative"),
+        ("http://base.url", ".", "http://base.url/"),
+        ("http://base.url/with_folder", ".", "http://base.url/"),
+        ("http://base.url/with_folder", "./with_dot", "http://base.url/with_dot"),
+        ("http://base.url/with_folder", "..", "http://base.url/"),
+        ("http://base.url/with_folder", "../folder", "http://base.url/folder"),
+        ("http://base.url", "http://whole.url", "http://whole.url/"),
+        ("http://base.url", "https://whole.url", "https://whole.url/"),
+        ("http://base.url", "http://whole.url:987", "http://whole.url:987/"),
+        ("http://base.url", "https://whole.url:987", "https://whole.url:987/"),
+        ("http://base.url", "/", "http://base.url/"),
+        ("http://base.url", "//", ""),
+        ("http://base.url", "//only_this", "http://only_this/"),
+        ("http://base.url", "./..//", "http://base.url/"),
+        ("http://base.url", "./wrong_folder/../good_folder/", "http://base.url/good_folder/"),
+    ]
+
+    request = Request("GET", "http://base.url")
+    response = Response(status_code=200, request=request)
+    page = Page(response)
+
+    for base_url, relative_url, expected in TEST_CASES:
+        page._base = base_url
+        assert page.make_absolute(relative_url) == expected, \
+            f"Absolute url from base_url='{base_url}' and relative_url='{relative_url}' is not '{expected}'"


### PR DESCRIPTION
This adds a test for the make_absolute function of file page.py before a possible refactor:

```
$ pylint wapitiCore/net/page.py
************* Module wapitiCore.net.page
wapitiCore/net/page.py:355:4: R0911: Too many return statements (9/6) (too-many-return-statements)
wapitiCore/net/page.py:721:4: R0912: Too many branches (41/40) (too-many-branches)
```

I noticed that some results are strange to me:

Shouldn't:
 - `'http://base.url/with_folder' + '.'` be `'http://base.url/with_folder'` instead of `http://base.url/` ?
 - `'http://base.url' + '/..//'` be `''` instead of `'http://base.url/'` ?
 - `'http://base.url' + './wrong_folder/../good_folder/'` be `'http://base.url/'` instead of `'http://base.url/good_folder/'` ?

Maybe the function [urllib.parse.urljoin](https://docs.python.org/3/library/urllib.parse.html#urllib.parse.urljoin) can be used instead ?
