### PR TITLE
More control over Wapiti generated output with its method

### DIFF
--- a/tests/attack/test_mod_backup.py
+++ b/tests/attack/test_mod_backup.py
@@ -28,7 +28,6 @@ async def test_whole_stuff():
     options = {"timeout": 10, "level": 2}
 
     module = mod_backup(crawler, persister, options, Event())
-    module.verbose = 2
     module.do_get = True
     await module.attack(request)
 

--- a/tests/attack/test_mod_buster.py
+++ b/tests/attack/test_mod_buster.py
@@ -41,7 +41,6 @@ async def test_whole_stuff():
             [("nawak", Flags()), ("admin", Flags()), ("config.inc", Flags()), ("authconfig.php", Flags())]
     ):
         module = mod_buster(crawler, persister, options, Event())
-        module.verbose = 2
         module.do_get = True
         await module.attack(request)
 

--- a/tests/attack/test_mod_crlf.py
+++ b/tests/attack/test_mod_crlf.py
@@ -29,7 +29,6 @@ async def test_whole_stuff():
     options = {"timeout": 10, "level": 2}
 
     module = mod_crlf(crawler, persister, options, Event())
-    module.verbose = 2
     module.do_get = True
     await module.attack(request)
 

--- a/tests/attack/test_mod_csrf.py
+++ b/tests/attack/test_mod_csrf.py
@@ -62,7 +62,6 @@ async def test_csrf_cases():
 
     module = mod_csrf(crawler, persister, options, Event())
     module.do_post = True
-    module.verbose = 2
     for request in all_requests:
         if await module.must_attack(request):
             await module.attack(request)

--- a/tests/attack/test_mod_drupal_enum.py
+++ b/tests/attack/test_mod_drupal_enum.py
@@ -38,7 +38,6 @@ async def test_no_drupal():
     options = {"timeout": 10, "level": 2, "tasks": 20}
 
     module = mod_drupal_enum(crawler, persister, options, Event())
-    module.verbose = 2
 
     await module.attack(request)
 
@@ -75,7 +74,6 @@ async def test_version_detected():
     options = {"timeout": 10, "level": 2, "tasks": 20}
 
     module = mod_drupal_enum(crawler, persister, options, Event())
-    module.verbose = 2
 
     await module.attack(request)
 
@@ -116,7 +114,6 @@ async def test_multi_versions_detected():
     options = {"timeout": 10, "level": 2, "tasks": 20}
 
     module = mod_drupal_enum(crawler, persister, options, Event())
-    module.verbose = 2
 
     await module.attack(request)
 
@@ -156,7 +153,6 @@ async def test_version_not_detected():
     options = {"timeout": 10, "level": 2, "tasks": 20}
 
     module = mod_drupal_enum(crawler, persister, options, Event())
-    module.verbose = 2
 
     await module.attack(request)
 

--- a/tests/attack/test_mod_exec.py
+++ b/tests/attack/test_mod_exec.py
@@ -56,7 +56,6 @@ async def test_whole_stuff():
     options = {"timeout": 10, "level": 2}
 
     module = mod_exec(crawler, persister, options, Event())
-    module.verbose = 2
     module.do_post = True
     for request in all_requests:
         await module.attack(request)
@@ -85,7 +84,6 @@ async def test_detection():
     options = {"timeout": 10, "level": 1}
 
     module = mod_exec(crawler, persister, options, Event())
-    module.verbose = 2
     await module.attack(request)
 
     assert persister.add_payload.call_count == 1
@@ -115,7 +113,6 @@ async def test_blind_detection():
     options = {"timeout": 1, "level": 1}
 
     module = mod_exec(crawler, persister, options, Event())
-    module.verbose = 2
     module.do_post = False
 
     payloads_until_sleep = 0

--- a/tests/attack/test_mod_htaccess.py
+++ b/tests/attack/test_mod_htaccess.py
@@ -42,7 +42,6 @@ async def test_whole_stuff():
     options = {"timeout": 10, "level": 2}
 
     module = mod_htaccess(crawler, persister, options, Event())
-    module.verbose = 2
     module.do_get = True
     for request in all_requests:
         if await module.must_attack(request):

--- a/tests/attack/test_mod_methods.py
+++ b/tests/attack/test_mod_methods.py
@@ -42,7 +42,6 @@ async def test_whole_stuff():
     options = {"timeout": 10, "level": 2}
 
     module = mod_methods(crawler, persister, options, Event())
-    module.verbose = 2
     module.do_get = True
     for request in all_requests:
         await module.attack(request)

--- a/tests/attack/test_mod_nikto.py
+++ b/tests/attack/test_mod_nikto.py
@@ -42,7 +42,6 @@ async def test_whole_stuff():
     options = {"timeout": 10, "level": 2, "tasks": 20}
 
     module = mod_nikto(crawler, persister, options, Event())
-    module.verbose = 2
     module.do_get = True
     await module.attack(request)
 

--- a/tests/attack/test_mod_redirect.py
+++ b/tests/attack/test_mod_redirect.py
@@ -74,7 +74,6 @@ async def test_whole_stuff():
     options = {"timeout": 10, "level": 2}
 
     module = mod_redirect(crawler, persister, options, Event())
-    module.verbose = 2
     module.do_post = True
     for request in all_requests:
         await module.attack(request)

--- a/tests/attack/test_mod_shellshock.py
+++ b/tests/attack/test_mod_shellshock.py
@@ -48,7 +48,6 @@ async def test_whole_stuff():
     options = {"timeout": 10, "level": 2}
 
     module = mod_shellshock(crawler, persister, options, Event())
-    module.verbose = 2
     module.do_get = True
     for request in all_requests:
         await module.attack(request)

--- a/tests/attack/test_mod_sql.py
+++ b/tests/attack/test_mod_sql.py
@@ -44,7 +44,6 @@ async def test_whole_stuff():
     options = {"timeout": 10, "level": 2}
 
     module = mod_sql(crawler, persister, options, Event())
-    module.verbose = 2
     module.do_post = True
     for request in all_requests:
         await module.attack(request)
@@ -67,7 +66,6 @@ async def test_false_positive():
     options = {"timeout": 10, "level": 1}
 
     module = mod_sql(crawler, persister, options, Event())
-    module.verbose = 2
     module.do_post = True
     await module.attack(request)
 
@@ -99,7 +97,6 @@ async def test_true_positive():
     options = {"timeout": 10, "level": 1}
 
     module = mod_sql(crawler, persister, options, Event())
-    module.verbose = 2
     module.do_post = True
     await module.attack(request)
 
@@ -157,7 +154,6 @@ async def test_blind_detection():
         options = {"timeout": 10, "level": 1}
 
         module = mod_sql(crawler, persister, options, Event())
-        module.verbose = 2
         module.do_post = True
         await module.attack(request)
 
@@ -181,7 +177,6 @@ async def test_negative_blind():
     options = {"timeout": 10, "level": 1}
 
     module = mod_sql(crawler, persister, options, Event())
-    module.verbose = 2
     await module.attack(request)
 
     assert not persister.add_payload.call_count
@@ -241,7 +236,6 @@ async def test_blind_detection_parenthesis():
         options = {"timeout": 10, "level": 1}
 
         module = mod_sql(crawler, persister, options, Event())
-        module.verbose = 2
         module.do_post = True
         await module.attack(request)
 

--- a/tests/attack/test_mod_ssrf.py
+++ b/tests/attack/test_mod_ssrf.py
@@ -48,7 +48,6 @@ async def test_whole_stuff():
     options = {"timeout": 10, "level": 2}
 
     module = mod_ssrf(crawler, persister, options, Event())
-    module.verbose = 2
     module.do_post = True
 
     respx.get("https://wapiti3.ovh/get_ssrf.php?session_id=" + module._session_id).mock(

--- a/tests/attack/test_mod_takeover.py
+++ b/tests/attack/test_mod_takeover.py
@@ -61,7 +61,6 @@ async def test_unregistered_cname():
             options = {"timeout": 10, "level": 2}
 
             module = mod_takeover(crawler, persister, options, Event())
-            module.verbose = 2
 
             for request in all_requests:
                 await module.attack(request)

--- a/tests/attack/test_mod_timesql.py
+++ b/tests/attack/test_mod_timesql.py
@@ -80,7 +80,6 @@ async def test_false_positive_request_count():
     options = {"timeout": 1, "level": 1}
 
     module = mod_timesql(crawler, persister, options, Event())
-    module.verbose = 2
     module.do_post = False
     await module.attack(request)
 
@@ -106,7 +105,6 @@ async def test_true_positive_request_count():
     options = {"timeout": 1, "level": 1}
 
     module = mod_timesql(crawler, persister, options, Event())
-    module.verbose = 2
     module.do_post = False
     await module.attack(request)
 

--- a/tests/attack/test_mod_wapp.py
+++ b/tests/attack/test_mod_wapp.py
@@ -39,7 +39,6 @@ async def test_false_positive():
     options = {"timeout": 10, "level": 2}
 
     module = mod_wapp(crawler, persister, options, Event())
-    module.verbose = 2
 
     await module.attack(request)
 
@@ -72,7 +71,6 @@ async def test_url_detection():
     options = {"timeout": 10, "level": 2}
 
     module = mod_wapp(crawler, persister, options, Event())
-    module.verbose = 2
 
     await module.attack(request)
 
@@ -111,7 +109,6 @@ async def test_html_detection():
     options = {"timeout": 10, "level": 2}
 
     module = mod_wapp(crawler, persister, options, Event())
-    module.verbose = 2
 
     await module.attack(request)
 
@@ -149,7 +146,6 @@ async def test_script_detection():
     options = {"timeout": 10, "level": 2}
 
     module = mod_wapp(crawler, persister, options, Event())
-    module.verbose = 2
 
     await module.attack(request)
 
@@ -187,7 +183,6 @@ async def test_cookies_detection():
     options = {"timeout": 10, "level": 2}
 
     module = mod_wapp(crawler, persister, options, Event())
-    module.verbose = 2
 
     await module.attack(request)
 
@@ -225,7 +220,6 @@ async def test_headers_detection():
     options = {"timeout": 10, "level": 2}
 
     module = mod_wapp(crawler, persister, options, Event())
-    module.verbose = 2
 
     await module.attack(request)
 
@@ -264,7 +258,6 @@ async def test_meta_detection():
     options = {"timeout": 10, "level": 2}
 
     module = mod_wapp(crawler, persister, options, Event())
-    module.verbose = 2
 
     await module.attack(request)
 
@@ -305,7 +298,6 @@ async def test_multi_detection():
     options = {"timeout": 10, "level": 2}
 
     module = mod_wapp(crawler, persister, options, Event())
-    module.verbose = 2
 
     await module.attack(request)
 
@@ -343,7 +335,6 @@ async def test_implies_detection():
     options = {"timeout": 10, "level": 2}
 
     module = mod_wapp(crawler, persister, options, Event())
-    module.verbose = 2
 
     await module.attack(request)
 
@@ -384,7 +375,6 @@ async def test_vulnerabilities():
     options = {"timeout": 10, "level": 2}
 
     module = mod_wapp(crawler, persister, options, Event())
-    module.verbose = 2
 
     await module.attack(request)
 

--- a/tests/attack/test_mod_wp_enum.py
+++ b/tests/attack/test_mod_wp_enum.py
@@ -34,7 +34,6 @@ async def test_no_wordpress():
     options = {"timeout": 10, "level": 2}
 
     module = mod_wp_enum(crawler, persister, options, Event())
-    module.verbose = 2
 
     await module.attack(request)
 
@@ -105,7 +104,6 @@ async def test_plugin():
     options = {"timeout": 10, "level": 2}
 
     module = mod_wp_enum(crawler, persister, options, Event())
-    module.verbose = 2
 
     await module.attack(request)
 
@@ -186,7 +184,6 @@ async def test_theme():
     options = {"timeout": 10, "level": 2}
 
     module = mod_wp_enum(crawler, persister, options, Event())
-    module.verbose = 2
 
     await module.attack(request)
 

--- a/tests/attack/test_mod_xss_basics.py
+++ b/tests/attack/test_mod_xss_basics.py
@@ -40,7 +40,6 @@ async def test_whole_stuff():
     options = {"timeout": 10, "level": 2}
 
     module = mod_xss(crawler, persister, options, Event())
-    module.verbose = 2
     module.do_post = True
     for request in all_requests:
         await module.attack(request)

--- a/wapitiCore/attack/attack.py
+++ b/wapitiCore/attack/attack.py
@@ -26,10 +26,9 @@ from math import ceil
 import random
 from types import GeneratorType, FunctionType
 from binascii import hexlify
-from functools import partialmethod, partial
+from functools import partialmethod
 
 from httpx import ReadTimeout, RequestError
-from wapitiCore.main.log import logging
 
 from wapitiCore.language.vulnerability import CRITICAL_LEVEL, HIGH_LEVEL, MEDIUM_LEVEL, LOW_LEVEL, INFO_LEVEL
 from wapitiCore.net.web import Request
@@ -210,19 +209,11 @@ class Attack:
         self.attacked_post = []
         self.network_errors = 0
 
-        self.verbose = 0
-        self.color = 0
         self.finished = False
 
         # List of modules (objects) that must be launched before the current module
         # Must be left empty in the code
         self.deps = []
-
-    def set_verbose(self, verbose):
-        self.verbose = verbose
-
-    def set_color(self):
-        self.color = 1
 
     async def add_payload(self, payload_type: str, category: str, request_id: int = -1,
                           level=0, request=None, parameter="", info=""):
@@ -236,11 +227,6 @@ class Attack:
             parameter=parameter,
             info=info
         )
-
-    log_blue = partial(logging.log, "BLUE")
-    log_green = partial(logging.log, "GREEN")
-    log_red = partial(logging.log, "RED")
-    log_orange = partial(logging.log, "ORANGE")
 
     add_vuln_critical = partialmethod(add_payload, payload_type=VULN, level=CRITICAL_LEVEL)
     add_vuln_high = partialmethod(add_payload, payload_type=VULN, level=HIGH_LEVEL)

--- a/wapitiCore/attack/mod_backup.py
+++ b/wapitiCore/attack/mod_backup.py
@@ -25,8 +25,8 @@ from os.path import splitext
 from urllib.parse import urljoin
 
 from httpx import RequestError
-from wapitiCore.main.log import logging
 
+from wapitiCore.main.log import log_verbose, log_red
 from wapitiCore.attack.attack import Attack
 from wapitiCore.language.vulnerability import _
 from wapitiCore.definitions.backup import NAME
@@ -82,8 +82,7 @@ class mod_backup(Attack):
 
                 url = urljoin(request.path, payload)
 
-            if self.verbose == 2:
-                logging.info("[¨] {0}".format(url))
+            log_verbose("[¨] {0}".format(url))
 
             self.attacked_get.append(page)
             evil_req = Request(url)
@@ -95,7 +94,7 @@ class mod_backup(Attack):
                 continue
 
             if response and response.status == 200:
-                self.log_red(_("Found backup file {}".format(evil_req.url)))
+                log_red(_("Found backup file {}".format(evil_req.url)))
 
                 await self.add_vuln_low(
                     request_id=request.path_id,

--- a/wapitiCore/attack/mod_brute_login_form.py
+++ b/wapitiCore/attack/mod_brute_login_form.py
@@ -28,6 +28,7 @@ from wapitiCore.attack.attack import Attack
 from wapitiCore.language.vulnerability import Messages, _
 from wapitiCore.definitions.credentials import NAME
 from wapitiCore.net.web import Request
+from wapitiCore.main.log import log_red
 
 
 class mod_brute_login_form(Attack):
@@ -201,11 +202,11 @@ class mod_brute_login_form(Attack):
                             info=vuln_message
                         )
 
-                        self.log_red("---")
-                        self.log_red(vuln_message)
-                        self.log_red(Messages.MSG_EVIL_REQUEST)
-                        self.log_red(evil_request.http_repr())
-                        self.log_red("---")
+                        log_red("---")
+                        log_red(vuln_message)
+                        log_red(Messages.MSG_EVIL_REQUEST)
+                        log_red(evil_request.http_repr())
+                        log_red("---")
 
                 tasks.remove(task)
 

--- a/wapitiCore/attack/mod_buster.py
+++ b/wapitiCore/attack/mod_buster.py
@@ -20,8 +20,8 @@
 import asyncio
 
 from httpx import RequestError
-from wapitiCore.main.log import logging
 
+from wapitiCore.main.log import log_red, log_verbose
 from wapitiCore.attack.attack import Attack
 from wapitiCore.net.web import Request
 
@@ -56,22 +56,21 @@ class mod_buster(Attack):
         if response.redirection_url:
             loc = response.redirection_url
             if response.is_directory_redirection:
-                self.log_red("Found webpage {0}", loc)
+                log_red("Found webpage {0}", loc)
                 self.new_resources.append(loc)
             else:
-                self.log_red("Found webpage {0}", page.path)
+                log_red("Found webpage {0}", page.path)
                 self.new_resources.append(page.path)
             return True
         if response.status not in [403, 404]:
-            self.log_red("Found webpage {0}", page.path)
+            log_red("Found webpage {0}", page.path)
             self.new_resources.append(page.path)
             return True
 
         return False
 
     async def test_directory(self, path: str):
-        if self.verbose == 2:
-            logging.info("[¨] Testing directory {0}".format(path))
+        log_verbose("[¨] Testing directory {0}".format(path))
 
         test_page = Request(path + "does_n0t_exist.htm")
         try:

--- a/wapitiCore/attack/mod_cookieflags.py
+++ b/wapitiCore/attack/mod_cookieflags.py
@@ -19,6 +19,7 @@ from wapitiCore.net.web import Request
 from wapitiCore.language.vulnerability import _
 from wapitiCore.definitions.secure_cookie import NAME as COOKIE_SECURE_DISABLED
 from wapitiCore.definitions.http_only import NAME as COOKIE_HTTPONLY_DISABLED
+from wapitiCore.main.log import log_red, log_blue
 
 INFO_COOKIE_HTTPONLY = _("HttpOnly flag is not set in the cookie : {0}")
 INFO_COOKIE_SECURE = _("Secure flag is not set in the cookie : {0}")
@@ -51,9 +52,9 @@ class mod_cookieflags(Attack):
         cookies = self.crawler.session_cookies
 
         for cookie in cookies.jar:
-            self.log_blue(_("Checking cookie : {}").format(cookie.name))
+            log_blue(_("Checking cookie : {}").format(cookie.name))
             if not self.check_httponly_flag(cookie):
-                self.log_red(INFO_COOKIE_HTTPONLY.format(cookie.name))
+                log_red(INFO_COOKIE_HTTPONLY.format(cookie.name))
                 await self.add_vuln_low(
                     category=COOKIE_HTTPONLY_DISABLED,
                     request=request,
@@ -61,7 +62,7 @@ class mod_cookieflags(Attack):
                 )
 
             if not self.check_secure_flag(cookie):
-                self.log_red(INFO_COOKIE_SECURE.format(cookie.name))
+                log_red(INFO_COOKIE_SECURE.format(cookie.name))
                 await self.add_vuln_low(
                     category=COOKIE_SECURE_DISABLED,
                     request=request,

--- a/wapitiCore/attack/mod_crlf.py
+++ b/wapitiCore/attack/mod_crlf.py
@@ -24,7 +24,7 @@ from wapitiCore.attack.attack import Attack, Flags
 from wapitiCore.language.vulnerability import Messages, _
 from wapitiCore.definitions.crlf import NAME
 from wapitiCore.net.web import Request
-from wapitiCore.main.log import logging
+from wapitiCore.main.log import logging, log_verbose, log_orange, log_red
 
 
 class mod_crlf(Attack):
@@ -45,8 +45,7 @@ class mod_crlf(Attack):
         page = request.path
 
         for mutated_request, parameter, _payload, _flags in self.mutator.mutate(request):
-            if self.verbose == 2:
-                logging.info("[¨] {0}".format(mutated_request.url))
+            log_verbose("[¨] {0}".format(mutated_request.url))
 
             try:
                 response = await self.crawler.async_send(mutated_request)
@@ -60,11 +59,11 @@ class mod_crlf(Attack):
                     info="Timeout (" + parameter + ")"
                 )
 
-                self.log_orange("---")
-                self.log_orange(Messages.MSG_TIMEOUT, page)
-                self.log_orange(Messages.MSG_EVIL_REQUEST)
-                self.log_orange(mutated_request.http_repr())
-                self.log_orange("---")
+                log_orange("---")
+                log_orange(Messages.MSG_TIMEOUT, page)
+                log_orange(Messages.MSG_EVIL_REQUEST)
+                log_orange(mutated_request.http_repr())
+                log_orange("---")
             except HTTPStatusError:
                 self.network_errors += 1
                 logging.error(_("Error: The server did not understand this request"))
@@ -85,13 +84,13 @@ class mod_crlf(Attack):
                     else:
                         injection_msg = Messages.MSG_PARAM_INJECT
 
-                    self.log_red("---")
-                    self.log_red(
+                    log_red("---")
+                    log_red(
                         injection_msg,
                         self.MSG_VULN,
                         page,
                         parameter
                     )
-                    self.log_red(Messages.MSG_EVIL_REQUEST)
-                    self.log_red(mutated_request.http_repr())
-                    self.log_red("---")
+                    log_red(Messages.MSG_EVIL_REQUEST)
+                    log_red(mutated_request.http_repr())
+                    log_red("---")

--- a/wapitiCore/attack/mod_csp.py
+++ b/wapitiCore/attack/mod_csp.py
@@ -21,10 +21,12 @@ from wapitiCore.net.web import Request
 from wapitiCore.language.vulnerability import _
 from wapitiCore.net.csp_utils import csp_header_to_dict, CSP_CHECK_LISTS, check_policy_values
 from wapitiCore.definitions.csp import NAME
+from wapitiCore.main.log import log_red
 
 MSG_NO_CSP = _("CSP is not set")
 MSG_CSP_MISSING = _("CSP attribute \"{0}\" is missing")
 MSG_CSP_UNSAFE = _("CSP \"{0}\" value is not safe")
+
 
 # This module check the basics recommendations of CSP
 class mod_csp(Attack):
@@ -51,7 +53,7 @@ class mod_csp(Attack):
             return
 
         if "Content-Security-Policy" not in response.headers:
-            self.log_red(MSG_NO_CSP)
+            log_red(MSG_NO_CSP)
             await self.add_vuln_low(
                 category=NAME,
                 request=request_to_root,
@@ -69,7 +71,7 @@ class mod_csp(Attack):
                     else:  # result == 0
                         info = MSG_CSP_UNSAFE.format(policy_name)
 
-                    self.log_red(info)
+                    log_red(info)
                     await self.add_vuln_low(
                         category=NAME,
                         request=request_to_root,

--- a/wapitiCore/attack/mod_csrf.py
+++ b/wapitiCore/attack/mod_csrf.py
@@ -25,6 +25,7 @@ from wapitiCore.language.vulnerability import _
 from wapitiCore.definitions.csrf import NAME
 from wapitiCore.net.web import Request
 from wapitiCore.net.crawler import Page
+from wapitiCore.main.log import log_red
 
 
 class mod_csrf(Attack):
@@ -177,10 +178,10 @@ class mod_csrf(Attack):
 
         self.already_vulnerable.append((request.url, request.post_keys))
 
-        self.log_red("---")
-        self.log_red(vuln_message)
-        self.log_red(request.http_repr())
-        self.log_red("---")
+        log_red("---")
+        log_red(vuln_message)
+        log_red(request.http_repr())
+        log_red("---")
 
         await self.add_vuln_medium(
             request_id=request.path_id,

--- a/wapitiCore/attack/mod_drupal_enum.py
+++ b/wapitiCore/attack/mod_drupal_enum.py
@@ -11,6 +11,7 @@ from wapitiCore.net.web import Request
 from wapitiCore.attack.attack import Attack
 from wapitiCore.language.vulnerability import _
 from wapitiCore.definitions.fingerprint import NAME as TECHNO_DETECTED
+from wapitiCore.main.log import log_blue
 
 MSG_TECHNO_VERSIONED = _("{0} {1} detected")
 MSG_NO_DRUPAL = _("No Drupal Detected")
@@ -142,7 +143,7 @@ class mod_drupal_enum(Attack):
                 "versions": self.versions,
                 "categories": ["CMS Drupal"]
             }
-            self.log_blue(
+            log_blue(
                 MSG_TECHNO_VERSIONED,
                 "Drupal",
                 self.versions
@@ -153,4 +154,4 @@ class mod_drupal_enum(Attack):
                 info=json.dumps(drupal_detected),
             )
         else:
-            self.log_blue(MSG_NO_DRUPAL)
+            log_blue(MSG_NO_DRUPAL)

--- a/wapitiCore/attack/mod_exec.py
+++ b/wapitiCore/attack/mod_exec.py
@@ -17,8 +17,8 @@
 # along with this program; if not, write to the Free Software
 # Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 from httpx import ReadTimeout, RequestError
-from wapitiCore.main.log import logging
 
+from wapitiCore.main.log import log_red, log_verbose, log_orange
 from wapitiCore.attack.attack import Attack, PayloadType
 from wapitiCore.language.vulnerability import Messages, _
 from wapitiCore.definitions.exec import NAME
@@ -100,8 +100,7 @@ class mod_exec(Attack):
                 # and move to next payload
                 continue
 
-            if self.verbose == 2:
-                logging.info("[¨] {0}".format(mutated_request))
+            log_verbose("[¨] {0}".format(mutated_request))
 
             try:
                 response = await self.crawler.async_send(mutated_request)
@@ -126,17 +125,17 @@ class mod_exec(Attack):
                         parameter=parameter
                     )
 
-                    self.log_red("---")
-                    self.log_red(
+                    log_red("---")
+                    log_red(
                         Messages.MSG_QS_INJECT if parameter == "QUERY_STRING"
                         else Messages.MSG_PARAM_INJECT,
                         vuln_info,
                         page,
                         parameter
                     )
-                    self.log_red(Messages.MSG_EVIL_REQUEST)
-                    self.log_red(mutated_request.http_repr())
-                    self.log_red("---")
+                    log_red(Messages.MSG_EVIL_REQUEST)
+                    log_red(mutated_request.http_repr())
+                    log_red("---")
                     vulnerable_parameter = True
                     continue
 
@@ -144,11 +143,11 @@ class mod_exec(Attack):
                 if timeouted:
                     continue
 
-                self.log_orange("---")
-                self.log_orange(Messages.MSG_TIMEOUT, page)
-                self.log_orange(Messages.MSG_EVIL_REQUEST)
-                self.log_orange(mutated_request.http_repr())
-                self.log_orange("---")
+                log_orange("---")
+                log_orange(Messages.MSG_TIMEOUT, page)
+                log_orange(Messages.MSG_EVIL_REQUEST)
+                log_orange(mutated_request.http_repr())
+                log_orange("---")
 
                 if parameter == "QUERY_STRING":
                     anom_msg = Messages.MSG_QS_TIMEOUT
@@ -186,16 +185,16 @@ class mod_exec(Attack):
                         parameter=parameter
                     )
 
-                    self.log_red("---")
-                    self.log_red(
+                    log_red("---")
+                    log_red(
                         log_message,
                         vuln_info,
                         page,
                         parameter
                     )
-                    self.log_red(Messages.MSG_EVIL_REQUEST)
-                    self.log_red(mutated_request.http_repr())
-                    self.log_red("---")
+                    log_red(Messages.MSG_EVIL_REQUEST)
+                    log_red(mutated_request.http_repr())
+                    log_red("---")
 
                     if executed:
                         # We reached maximum exploitation for this parameter, don't send more payloads
@@ -217,8 +216,8 @@ class mod_exec(Attack):
                         parameter=parameter
                     )
 
-                    self.log_orange("---")
-                    self.log_orange(Messages.MSG_500, page)
-                    self.log_orange(Messages.MSG_EVIL_REQUEST)
-                    self.log_orange(mutated_request.http_repr())
-                    self.log_orange("---")
+                    log_orange("---")
+                    log_orange(Messages.MSG_500, page)
+                    log_orange(Messages.MSG_EVIL_REQUEST)
+                    log_orange(mutated_request.http_repr())
+                    log_orange("---")

--- a/wapitiCore/attack/mod_file.py
+++ b/wapitiCore/attack/mod_file.py
@@ -22,8 +22,8 @@ from collections import defaultdict, namedtuple
 import re
 
 from httpx import ReadTimeout, RequestError
-from wapitiCore.main.log import logging
 
+from wapitiCore.main.log import log_red, log_orange, log_verbose
 from wapitiCore.attack.attack import Attack, PayloadReader
 from wapitiCore.language.vulnerability import Messages, _
 from wapitiCore.definitions.file import NAME
@@ -179,8 +179,7 @@ class mod_file(Attack):
                 # If parameter is vulnerable, just skip till next parameter
                 continue
 
-            if self.verbose == 2:
-                logging.info("[¨] {0}".format(mutated_request))
+            log_verbose("[¨] {0}".format(mutated_request))
 
             try:
                 response = await self.crawler.async_send(mutated_request)
@@ -189,11 +188,11 @@ class mod_file(Attack):
                 if timeouted:
                     continue
 
-                self.log_orange("---")
-                self.log_orange(Messages.MSG_TIMEOUT, page)
-                self.log_orange(Messages.MSG_EVIL_REQUEST)
-                self.log_orange(mutated_request.http_repr())
-                self.log_orange("---")
+                log_orange("---")
+                log_orange(Messages.MSG_TIMEOUT, page)
+                log_orange(Messages.MSG_EVIL_REQUEST)
+                log_orange(mutated_request.http_repr())
+                log_orange("---")
 
                 if parameter == "QUERY_STRING":
                     anom_msg = Messages.MSG_QS_TIMEOUT
@@ -267,8 +266,8 @@ class mod_file(Attack):
                         parameter=parameter
                     )
 
-                    self.log_red("---")
-                    self.log_red(
+                    log_red("---")
+                    log_red(
                         Messages.MSG_QS_INJECT if parameter == "QUERY_STRING" else Messages.MSG_PARAM_INJECT,
                         vulnerable_method,
                         page,
@@ -276,11 +275,11 @@ class mod_file(Attack):
                     )
 
                     if constraint_message:
-                        self.log_red(constraint_message)
+                        log_red(constraint_message)
 
-                    self.log_red(Messages.MSG_EVIL_REQUEST)
-                    self.log_red(mutated_request.http_repr())
-                    self.log_red("---")
+                    log_red(Messages.MSG_EVIL_REQUEST)
+                    log_red(mutated_request.http_repr())
+                    log_red("---")
 
                     if inclusion_succeed:
                         # We reached maximum exploitation for this parameter, don't send more payloads
@@ -302,8 +301,8 @@ class mod_file(Attack):
                         parameter=parameter
                     )
 
-                    self.log_orange("---")
-                    self.log_orange(Messages.MSG_500, page)
-                    self.log_orange(Messages.MSG_EVIL_REQUEST)
-                    self.log_orange(mutated_request.http_repr())
-                    self.log_orange("---")
+                    log_orange("---")
+                    log_orange(Messages.MSG_500, page)
+                    log_orange(Messages.MSG_EVIL_REQUEST)
+                    log_orange(mutated_request.http_repr())
+                    log_orange("---")

--- a/wapitiCore/attack/mod_htaccess.py
+++ b/wapitiCore/attack/mod_htaccess.py
@@ -27,6 +27,7 @@ from wapitiCore.attack.attack import Attack
 from wapitiCore.language.vulnerability import _
 from wapitiCore.definitions.htaccess import NAME
 from wapitiCore.net.web import Request
+from wapitiCore.main.log import log_red, log_verbose
 
 
 class mod_htaccess(Attack):
@@ -64,22 +65,21 @@ class mod_htaccess(Attack):
 
             unblocked_content = response.content
 
-            self.log_red("---")
+            log_red("---")
             await self.add_vuln_medium(
                 request_id=request.path_id,
                 category=NAME,
                 request=evil_req,
                 info=_("{0} bypassable weak restriction").format(evil_req.url)
             )
-            self.log_red(_("Weak restriction bypass vulnerability: {0}"), evil_req.url)
-            self.log_red(_("HTTP status code changed from {0} to {1}").format(
+            log_red(_("Weak restriction bypass vulnerability: {0}"), evil_req.url)
+            log_red(_("HTTP status code changed from {0} to {1}").format(
                 request.status,
                 response.status
             ))
 
-            if self.verbose == 2:
-                self.log_red(_("Source code:"))
-                self.log_red(unblocked_content)
-            self.log_red("---")
+            log_verbose(_("Source code:"))
+            log_verbose(unblocked_content)
+            log_red("---")
 
         self.attacked_get.append(url)

--- a/wapitiCore/attack/mod_http_headers.py
+++ b/wapitiCore/attack/mod_http_headers.py
@@ -21,6 +21,7 @@ from wapitiCore.net.web import Request
 from wapitiCore.language.vulnerability import _
 from wapitiCore.definitions.http_headers import NAME
 from wapitiCore.net.page import Page
+from wapitiCore.main.log import log_red, log_blue, log_green
 
 INFO_HSTS = _("Strict-Transport-Security is not set")
 INFO_XCONTENT_TYPE = _("X-Content-Type-Options is not set")
@@ -59,16 +60,16 @@ class mod_http_headers(Attack):
         return any(element in response.headers[header_name].lower() for element in check_list)
 
     async def check_header(self, response, request, header, check_list, info, log):
-        self.log_blue(log)
+        log_blue(log)
         if not self.is_set(response, header, check_list):
-            self.log_red(info)
+            log_red(info)
             await self.add_vuln_low(
                 category=NAME,
                 request=request,
                 info=info
             )
         else:
-            self.log_green("OK")
+            log_green("OK")
 
     async def must_attack(self, request: Request):
         if self.finished:

--- a/wapitiCore/attack/mod_methods.py
+++ b/wapitiCore/attack/mod_methods.py
@@ -17,7 +17,8 @@
 # along with this program; if not, write to the Free Software
 # Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 from httpx import RequestError
-from wapitiCore.main.log import logging
+
+from wapitiCore.main.log import log_verbose, log_orange
 
 from wapitiCore.attack.attack import Attack
 from wapitiCore.definitions.methods import NAME
@@ -51,8 +52,7 @@ class mod_methods(Attack):
             link_depth=request.link_depth
         )
 
-        if self.verbose == 2:
-            logging.info("[+] {}".format(option_request))
+        log_verbose("[+] {}".format(option_request))
 
         try:
             response = await self.crawler.async_send(option_request)
@@ -66,8 +66,8 @@ class mod_methods(Attack):
             interesting_methods = sorted(methods - self.KNOWN_METHODS)
 
             if interesting_methods:
-                self.log_orange("---")
-                self.log_orange(
+                log_orange("---")
+                log_orange(
                     _("Interesting methods allowed on {}: {}").format(
                         page,
                         ", ".join(interesting_methods)
@@ -81,4 +81,4 @@ class mod_methods(Attack):
                         ", ".join(interesting_methods)
                     )
                 )
-                self.log_orange("---")
+                log_orange("---")

--- a/wapitiCore/attack/mod_nikto.py
+++ b/wapitiCore/attack/mod_nikto.py
@@ -24,8 +24,8 @@ import random
 from urllib.parse import urlparse
 
 from httpx import RequestError
-from wapitiCore.main.log import logging
 
+from wapitiCore.main.log import logging, log_verbose, log_red
 from wapitiCore.attack.attack import Attack
 from wapitiCore.language.vulnerability import _
 from wapitiCore.definitions.dangerous_resource import NAME
@@ -192,11 +192,10 @@ class mod_nikto(Attack):
         else:
             evil_request = Request(url, post_params=post_data, method=method)
 
-        if self.verbose == 2:
-            if method == "GET":
-                logging.info("[¨] {0}".format(evil_request.url))
-            else:
-                logging.info("[¨] {0}".format(evil_request.http_repr()))
+        if method == "GET":
+            log_verbose("[¨] {0}".format(evil_request.url))
+        else:
+            log_verbose("[¨] {0}".format(evil_request.http_repr()))
 
         try:
             response = await self.crawler.async_send(evil_request)
@@ -259,9 +258,9 @@ class mod_nikto(Attack):
                     fail_or = True
 
         if ((match or match_or) and match_and) and not (fail or fail_or):
-            self.log_red("---")
-            self.log_red(vuln_desc)
-            self.log_red(url)
+            log_red("---")
+            log_red(vuln_desc)
+            log_red(url)
 
             refs = []
             if osv_id != "0":
@@ -294,13 +293,13 @@ class mod_nikto(Attack):
 
             info = vuln_desc
             if refs:
-                self.log_red(_("References:"))
-                self.log_red("  {0}".format("\n  ".join(refs)))
+                log_red(_("References:"))
+                log_red("  {0}".format("\n  ".join(refs)))
 
                 info += "\n" + _("References:") + "\n"
                 info += "\n".join(refs)
 
-            self.log_red("---")
+            log_red("---")
 
             await self.add_vuln_high(
                 category=NAME,

--- a/wapitiCore/attack/mod_permanentxss.py
+++ b/wapitiCore/attack/mod_permanentxss.py
@@ -21,8 +21,8 @@ from configparser import ConfigParser
 from os.path import join as path_join
 
 from httpx import ReadTimeout, RequestError
-from wapitiCore.main.log import logging
 
+from wapitiCore.main.log import log_red, log_orange, log_verbose
 from wapitiCore.attack.attack import Attack, PayloadType, Mutator, random_string
 from wapitiCore.language.vulnerability import Messages, _
 from wapitiCore.definitions.xss import NAME
@@ -165,8 +165,8 @@ class mod_permanentxss(Attack):
                                 else:
                                     injection_msg = Messages.MSG_PARAM_INJECT
 
-                                self.log_red("---")
-                                self.log_red(
+                                log_red("---")
+                                log_red(
                                     injection_msg,
                                     self.MSG_VULN,
                                     request.path,
@@ -174,11 +174,11 @@ class mod_permanentxss(Attack):
                                 )
 
                                 if has_strong_csp(response):
-                                    self.log_red(_("Warning: Content-Security-Policy is present!"))
+                                    log_red(_("Warning: Content-Security-Policy is present!"))
 
-                                self.log_red(Messages.MSG_EVIL_REQUEST)
-                                self.log_red(evil_request.http_repr())
-                                self.log_red("---")
+                                log_red(Messages.MSG_EVIL_REQUEST)
+                                log_red(evil_request.http_repr())
+                                log_red("---")
                                 # FIX: search for the next code in the webpage
 
                 # Ok the content is stored, but will we be able to inject javascript?
@@ -219,8 +219,7 @@ class mod_permanentxss(Attack):
         )
 
         for evil_request, xss_param, _xss_payload, xss_flags in attack_mutator.mutate(injection_request):
-            if self.verbose == 2:
-                logging.info("[¨] {0}".format(evil_request))
+            log_verbose("[¨] {0}".format(evil_request))
 
             try:
                 await self.crawler.async_send(evil_request)
@@ -229,11 +228,11 @@ class mod_permanentxss(Attack):
                 if timeouted:
                     continue
 
-                self.log_orange("---")
-                self.log_orange(Messages.MSG_TIMEOUT, page)
-                self.log_orange(Messages.MSG_EVIL_REQUEST)
-                self.log_orange(evil_request.http_repr())
-                self.log_orange("---")
+                log_orange("---")
+                log_orange(Messages.MSG_TIMEOUT, page)
+                log_orange(Messages.MSG_EVIL_REQUEST)
+                log_orange(evil_request.http_repr())
+                log_orange("---")
 
                 if xss_param == "QUERY_STRING":
                     anom_msg = Messages.MSG_QS_TIMEOUT
@@ -294,9 +293,9 @@ class mod_permanentxss(Attack):
                     else:
                         injection_msg = Messages.MSG_PARAM_INJECT
 
-                    self.log_red("---")
+                    log_red("---")
                     # TODO: a last parameter should give URL used to pass the vulnerable parameter
-                    self.log_red(
+                    log_red(
                         injection_msg,
                         self.MSG_VULN,
                         output_url,
@@ -304,11 +303,11 @@ class mod_permanentxss(Attack):
                     )
 
                     if has_strong_csp(response):
-                        self.log_red(_("Warning: Content-Security-Policy is present!"))
+                        log_red(_("Warning: Content-Security-Policy is present!"))
 
-                    self.log_red(Messages.MSG_EVIL_REQUEST)
-                    self.log_red(evil_request.http_repr())
-                    self.log_red("---")
+                    log_red(Messages.MSG_EVIL_REQUEST)
+                    log_red(evil_request.http_repr())
+                    log_red("---")
 
                     # stop trying payloads and jump to the next parameter
                     break
@@ -326,11 +325,11 @@ class mod_permanentxss(Attack):
                         parameter=xss_param
                     )
 
-                    self.log_orange("---")
-                    self.log_orange(Messages.MSG_500, page)
-                    self.log_orange(Messages.MSG_EVIL_REQUEST)
-                    self.log_orange(evil_request.http_repr())
-                    self.log_orange("---")
+                    log_orange("---")
+                    log_orange(Messages.MSG_500, page)
+                    log_orange(Messages.MSG_EVIL_REQUEST)
+                    log_orange(evil_request.http_repr())
+                    log_orange("---")
                     saw_internal_error = True
 
     def check_payload(self, response, flags, taint):

--- a/wapitiCore/attack/mod_redirect.py
+++ b/wapitiCore/attack/mod_redirect.py
@@ -17,8 +17,8 @@
 # along with this program; if not, write to the Free Software
 # Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 from httpx import RequestError
-from wapitiCore.main.log import logging
 
+from wapitiCore.main.log import log_red, log_verbose
 from wapitiCore.attack.attack import Attack, Flags
 from wapitiCore.language.vulnerability import Messages, _
 from wapitiCore.definitions.redirect import NAME
@@ -43,8 +43,7 @@ class mod_redirect(Attack):
         page = request.path
 
         for mutated_request, parameter, __, __ in self.mutator.mutate(request):
-            if self.verbose == 2:
-                logging.info("[¨] {0}".format(mutated_request.url))
+            log_verbose("[¨] {0}".format(mutated_request.url))
 
             try:
                 response = await self.crawler.async_send(mutated_request)
@@ -66,13 +65,13 @@ class mod_redirect(Attack):
                 else:
                     injection_msg = Messages.MSG_PARAM_INJECT
 
-                self.log_red("---")
-                self.log_red(
+                log_red("---")
+                log_red(
                     injection_msg,
                     self.MSG_VULN,
                     page,
                     parameter
                 )
-                self.log_red(Messages.MSG_EVIL_REQUEST)
-                self.log_red(mutated_request.http_repr())
-                self.log_red("---")
+                log_red(Messages.MSG_EVIL_REQUEST)
+                log_red(mutated_request.http_repr())
+                log_red("---")

--- a/wapitiCore/attack/mod_shellshock.py
+++ b/wapitiCore/attack/mod_shellshock.py
@@ -26,6 +26,7 @@ from wapitiCore.attack.attack import Attack
 from wapitiCore.language.vulnerability import _
 from wapitiCore.net.web import Request
 from wapitiCore.definitions.exec import NAME
+from wapitiCore.main.log import log_red
 
 
 class mod_shellshock(Attack):
@@ -76,7 +77,7 @@ class mod_shellshock(Attack):
         if resp:
             data = resp.content
             if self.rand_string in data:
-                self.log_red(_("URL {0} seems vulnerable to Shellshock attack!").format(url))
+                log_red(_("URL {0} seems vulnerable to Shellshock attack!").format(url))
 
                 await self.add_vuln_high(
                     request_id=request.path_id,

--- a/wapitiCore/attack/mod_sql.py
+++ b/wapitiCore/attack/mod_sql.py
@@ -20,8 +20,8 @@ import re
 from random import randint
 
 from httpx import ReadTimeout, RequestError
-from wapitiCore.main.log import logging
 
+from wapitiCore.main.log import log_red, log_orange, log_verbose
 from wapitiCore.attack.attack import Attack, Flags, Mutator
 from wapitiCore.language.vulnerability import Messages, _
 from wapitiCore.definitions.sql import NAME
@@ -336,8 +336,7 @@ class mod_sql(Attack):
                 # If parameter is vulnerable, just skip till next parameter
                 continue
 
-            if self.verbose == 2:
-                logging.info("[¨] {0}".format(mutated_request))
+            log_verbose("[¨] {0}".format(mutated_request))
 
             try:
                 response = await self.crawler.async_send(mutated_request)
@@ -361,16 +360,16 @@ class mod_sql(Attack):
                         parameter=parameter
                     )
 
-                    self.log_red("---")
-                    self.log_red(
+                    log_red("---")
+                    log_red(
                         Messages.MSG_QS_INJECT if parameter == "QUERY_STRING" else Messages.MSG_PARAM_INJECT,
                         vuln_info,
                         page,
                         parameter
                     )
-                    self.log_red(Messages.MSG_EVIL_REQUEST)
-                    self.log_red(mutated_request.http_repr())
-                    self.log_red("---")
+                    log_red(Messages.MSG_EVIL_REQUEST)
+                    log_red(mutated_request.http_repr())
+                    log_red("---")
 
                     # We reached maximum exploitation for this parameter, don't send more payloads
                     vulnerable_parameter = True
@@ -391,11 +390,11 @@ class mod_sql(Attack):
                         parameter=parameter
                     )
 
-                    self.log_orange("---")
-                    self.log_orange(Messages.MSG_500, page)
-                    self.log_orange(Messages.MSG_EVIL_REQUEST)
-                    self.log_orange(mutated_request.http_repr())
-                    self.log_orange("---")
+                    log_orange("---")
+                    log_orange(Messages.MSG_500, page)
+                    log_orange(Messages.MSG_EVIL_REQUEST)
+                    log_orange(mutated_request.http_repr())
+                    log_orange("---")
 
         return vulnerable_parameters
 
@@ -453,16 +452,16 @@ class mod_sql(Attack):
                         parameter=current_parameter
                     )
 
-                    self.log_red("---")
-                    self.log_red(
+                    log_red("---")
+                    log_red(
                         Messages.MSG_QS_INJECT if current_parameter == "QUERY_STRING" else Messages.MSG_PARAM_INJECT,
                         vuln_info,
                         page,
                         current_parameter
                     )
-                    self.log_red(Messages.MSG_EVIL_REQUEST)
-                    self.log_red(last_mutated_request.http_repr())
-                    self.log_red("---")
+                    log_red(Messages.MSG_EVIL_REQUEST)
+                    log_red(last_mutated_request.http_repr())
+                    log_red("---")
 
                 # Don't forget to reset session and results
                 current_session = flags.platform
@@ -480,8 +479,7 @@ class mod_sql(Attack):
                 # No need to go further: one of the tests was wrong
                 continue
 
-            if self.verbose == 2:
-                logging.info("[¨] {0}".format(mutated_request))
+            log_verbose("[¨] {0}".format(mutated_request))
 
             try:
                 response = await self.crawler.async_send(mutated_request)

--- a/wapitiCore/attack/mod_ssrf.py
+++ b/wapitiCore/attack/mod_ssrf.py
@@ -21,8 +21,8 @@ from urllib.parse import quote
 from binascii import hexlify, unhexlify
 
 from httpx import RequestError
-from wapitiCore.main.log import logging
 
+from wapitiCore.main.log import logging, log_red, log_verbose
 from wapitiCore.attack.attack import Attack, Mutator, PayloadType, Flags
 from wapitiCore.language.vulnerability import Messages, _
 from wapitiCore.definitions.ssrf import NAME
@@ -176,8 +176,7 @@ class mod_ssrf(Attack):
         # Let's just send payloads, we don't care of the response as what we want to know is if the target
         # contacted the endpoint.
         for mutated_request, _parameter, _payload, _flags in self.mutator.mutate(request):
-            if self.verbose == 2:
-                logging.info("[¨] {0}".format(mutated_request))
+            log_verbose("[¨] {0}".format(mutated_request))
 
             try:
                 await self.crawler.async_send(mutated_request)
@@ -250,14 +249,14 @@ class mod_ssrf(Attack):
                                 parameter=parameter
                             )
 
-                            self.log_red("---")
-                            self.log_red(
+                            log_red("---")
+                            log_red(
                                 Messages.MSG_QS_INJECT if parameter == "QUERY_STRING"
                                 else Messages.MSG_PARAM_INJECT,
                                 self.MSG_VULN,
                                 page,
                                 parameter
                             )
-                            self.log_red(Messages.MSG_EVIL_REQUEST)
-                            self.log_red(mutated_request.http_repr())
-                            self.log_red("---")
+                            log_red(Messages.MSG_EVIL_REQUEST)
+                            log_red(mutated_request.http_repr())
+                            log_red("---")

--- a/wapitiCore/attack/mod_takeover.py
+++ b/wapitiCore/attack/mod_takeover.py
@@ -35,8 +35,8 @@ import dns.asyncresolver
 import dns.exception
 import dns.name
 import dns.resolver
-from loguru import logger as logging
 
+from wapitiCore.main.log import log_red, logging, log_verbose
 from wapitiCore.net.web import Request
 from wapitiCore.attack.attack import Attack
 from wapitiCore.language.vulnerability import _
@@ -272,8 +272,7 @@ class mod_takeover(Attack):
                     if cname in bad_responses:
                         continue
 
-                    if self.verbose:
-                        logging.info(_(f"Record {domain} points to {cname}"))
+                    log_verbose(_(f"Record {domain} points to {cname}"))
 
                     try:
                         if get_root_domain(cname) == root_domain:
@@ -284,9 +283,9 @@ class mod_takeover(Attack):
                         continue
 
                     if await self.takeover.check(domain, cname):
-                        self.log_red("---")
-                        self.log_red(_(f"CNAME {domain} to {cname} seems vulnerable to takeover"))
-                        self.log_red("---")
+                        log_red("---")
+                        log_red(_(f"CNAME {domain} to {cname} seems vulnerable to takeover"))
+                        log_red("---")
 
                         await self.add_vuln_high(
                             category=NAME,

--- a/wapitiCore/attack/mod_timesql.py
+++ b/wapitiCore/attack/mod_timesql.py
@@ -17,8 +17,8 @@
 # along with this program; if not, write to the Free Software
 # Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 from httpx import ReadTimeout, RequestError
-from wapitiCore.main.log import logging
 
+from wapitiCore.main.log import log_verbose, log_red, log_orange, logging
 from wapitiCore.attack.attack import Attack
 from wapitiCore.language.vulnerability import Messages, _
 from wapitiCore.definitions.timesql import NAME
@@ -59,8 +59,7 @@ class mod_timesql(Attack):
                 # If parameter is vulnerable, just skip till next parameter
                 continue
 
-            if self.verbose == 2:
-                logging.error("[¨] {0}".format(mutated_request))
+            log_verbose("[¨] {0}".format(mutated_request))
 
             try:
                 response = await self.crawler.async_send(mutated_request)
@@ -86,16 +85,16 @@ class mod_timesql(Attack):
                     parameter=parameter
                 )
 
-                self.log_red("---")
-                self.log_red(
+                log_red("---")
+                log_red(
                     log_message,
                     self.MSG_VULN,
                     page,
                     parameter
                 )
-                self.log_red(Messages.MSG_EVIL_REQUEST)
-                self.log_red(mutated_request.http_repr())
-                self.log_red("---")
+                log_red(Messages.MSG_EVIL_REQUEST)
+                log_red(mutated_request.http_repr())
+                log_red("---")
 
                 # We reached maximum exploitation for this parameter, don't send more payloads
                 vulnerable_parameter = True
@@ -119,8 +118,8 @@ class mod_timesql(Attack):
                         parameter=parameter
                     )
 
-                    self.log_orange("---")
-                    self.log_orange(Messages.MSG_500, page)
-                    self.log_orange(Messages.MSG_EVIL_REQUEST)
-                    self.log_orange(mutated_request.http_repr())
-                    self.log_orange("---")
+                    log_orange("---")
+                    log_orange(Messages.MSG_500, page)
+                    log_orange(Messages.MSG_EVIL_REQUEST)
+                    log_orange(mutated_request.http_repr())
+                    log_orange("---")

--- a/wapitiCore/attack/mod_wapp.py
+++ b/wapitiCore/attack/mod_wapp.py
@@ -19,8 +19,8 @@ import json
 import os
 
 from httpx import RequestError
-from wapitiCore.main.log import logging
 
+from wapitiCore.main.log import logging, log_blue
 from wapitiCore.attack.attack import Attack
 from wapitiCore.wappalyzer.wappalyzer import Wappalyzer, ApplicationData, ApplicationDataException
 from wapitiCore.language.vulnerability import _
@@ -106,14 +106,14 @@ class mod_wapp(Attack):
         detected_applications = wappalyzer.detect_with_versions_and_categories()
 
         if len(detected_applications) > 0:
-            self.log_blue("---")
+            log_blue("---")
 
         for application_name in sorted(detected_applications, key=lambda x: x.lower()):
 
             versions = detected_applications[application_name]["versions"]
             categories = detected_applications[application_name]["categories"]
 
-            self.log_blue(
+            log_blue(
                 MSG_TECHNO_VERSIONED,
                 application_name,
                 versions

--- a/wapitiCore/attack/mod_wp_enum.py
+++ b/wapitiCore/attack/mod_wp_enum.py
@@ -2,8 +2,7 @@ import re
 import json
 from os.path import join as path_join
 
-from wapitiCore.main.log import logging
-
+from wapitiCore.main.log import logging, log_blue
 from wapitiCore.net.web import Request
 from wapitiCore.attack.attack import Attack
 from wapitiCore.language.vulnerability import _
@@ -57,7 +56,7 @@ class mod_wp_enum(Attack):
                     "categories": ["WordPress plugins"]
                 }
 
-                self.log_blue(
+                log_blue(
                     MSG_TECHNO_VERSIONED,
                     plugin,
                     version
@@ -74,7 +73,7 @@ class mod_wp_enum(Attack):
                     "versions": [""],
                     "categories": ["WordPress plugins"]
                 }
-                self.log_blue(
+                log_blue(
                     MSG_TECHNO_VERSIONED,
                     plugin,
                     [""]
@@ -104,7 +103,7 @@ class mod_wp_enum(Attack):
                     "versions": [version],
                     "categories": ["WordPress themes"]
                 }
-                self.log_blue(
+                log_blue(
                     MSG_TECHNO_VERSIONED,
                     theme,
                     version
@@ -120,7 +119,7 @@ class mod_wp_enum(Attack):
                     "versions": [""],
                     "categories": ["WordPress themes"]
                 }
-                self.log_blue(
+                log_blue(
                     MSG_TECHNO_VERSIONED,
                     theme,
                     [""]
@@ -152,10 +151,10 @@ class mod_wp_enum(Attack):
 
         response = await self.crawler.async_send(request_to_root, follow_redirects=True)
         if self.check_wordpress(response):
-            self.log_blue(_("Enumeration of WordPress Plugins :"))
+            log_blue(_("Enumeration of WordPress Plugins :"))
             await self.detect_plugin(request_to_root.url)
-            self.log_blue("----")
-            self.log_blue(_("Enumeration of WordPress Themes :"))
+            log_blue("----")
+            log_blue(_("Enumeration of WordPress Themes :"))
             await self.detect_theme(request_to_root.url)
         else:
-            self.log_blue(MSG_NO_WP)
+            log_blue(MSG_NO_WP)

--- a/wapitiCore/attack/mod_xss.py
+++ b/wapitiCore/attack/mod_xss.py
@@ -20,8 +20,8 @@ from os.path import join as path_join
 from configparser import ConfigParser
 
 from httpx import ReadTimeout, RequestError
-from wapitiCore.main.log import logging
 
+from wapitiCore.main.log import log_orange, log_red, log_verbose
 from wapitiCore.attack.attack import Attack, Mutator, PayloadType, random_string_with_flags, random_string
 from wapitiCore.language.vulnerability import Messages, _
 from wapitiCore.definitions.xss import NAME
@@ -118,8 +118,7 @@ class mod_xss(Attack):
         )
 
         for evil_request, xss_param, xss_payload, xss_flags in attack_mutator.mutate(original_request):
-            if self.verbose == 2:
-                logging.info("[¨] {0}".format(evil_request))
+            log_verbose("[¨] {0}".format(evil_request))
 
             try:
                 response = await self.crawler.async_send(evil_request)
@@ -128,11 +127,11 @@ class mod_xss(Attack):
                 if timeouted:
                     continue
 
-                self.log_orange("---")
-                self.log_orange(Messages.MSG_TIMEOUT, page)
-                self.log_orange(Messages.MSG_EVIL_REQUEST)
-                self.log_orange(evil_request.http_repr())
-                self.log_orange("---")
+                log_orange("---")
+                log_orange(Messages.MSG_TIMEOUT, page)
+                log_orange(Messages.MSG_EVIL_REQUEST)
+                log_orange(evil_request.http_repr())
+                log_orange("---")
 
                 if xss_param == "QUERY_STRING":
                     anom_msg = Messages.MSG_QS_TIMEOUT
@@ -173,8 +172,8 @@ class mod_xss(Attack):
                     else:
                         injection_msg = Messages.MSG_PARAM_INJECT
 
-                    self.log_red("---")
-                    self.log_red(
+                    log_red("---")
+                    log_red(
                         injection_msg,
                         self.MSG_VULN,
                         page,
@@ -182,11 +181,11 @@ class mod_xss(Attack):
                     )
 
                     if has_strong_csp(response):
-                        self.log_red(_("Warning: Content-Security-Policy is present!"))
+                        log_red(_("Warning: Content-Security-Policy is present!"))
 
-                    self.log_red(Messages.MSG_EVIL_REQUEST)
-                    self.log_red(evil_request.http_repr())
-                    self.log_red("---")
+                    log_red(Messages.MSG_EVIL_REQUEST)
+                    log_red(evil_request.http_repr())
+                    log_red("---")
 
                     # stop trying payloads and jump to the next parameter
                     break
@@ -205,11 +204,11 @@ class mod_xss(Attack):
                         parameter=xss_param
                     )
 
-                    self.log_orange("---")
-                    self.log_orange(Messages.MSG_500, page)
-                    self.log_orange(Messages.MSG_EVIL_REQUEST)
-                    self.log_orange(evil_request.http_repr())
-                    self.log_orange("---")
+                    log_orange("---")
+                    log_orange(Messages.MSG_500, page)
+                    log_orange(Messages.MSG_EVIL_REQUEST)
+                    log_orange(evil_request.http_repr())
+                    log_orange("---")
                     saw_internal_error = True
 
     def check_payload(self, response, flags, taint):

--- a/wapitiCore/attack/mod_xxe.py
+++ b/wapitiCore/attack/mod_xxe.py
@@ -23,8 +23,8 @@ from configparser import ConfigParser
 from os.path import join as path_join
 
 from httpx import ReadTimeout, RequestError
-from wapitiCore.main.log import logging
 
+from wapitiCore.main.log import logging, log_red, log_orange, log_verbose
 from wapitiCore.attack.attack import Attack, FileMutator, Mutator, PayloadReader, Flags
 from wapitiCore.language.vulnerability import Messages, _
 from wapitiCore.definitions.xxe import NAME
@@ -139,8 +139,7 @@ class mod_xxe(Attack):
                 # If parameter is vulnerable, just skip till next parameter
                 continue
 
-            if self.verbose == 2:
-                logging.info("[¨] {0}".format(mutated_request))
+            log_verbose("[¨] {0}".format(mutated_request))
 
             try:
                 response = await self.crawler.async_send(mutated_request)
@@ -149,11 +148,11 @@ class mod_xxe(Attack):
                 if timeouted:
                     continue
 
-                self.log_orange("---")
-                self.log_orange(Messages.MSG_TIMEOUT, page)
-                self.log_orange(Messages.MSG_EVIL_REQUEST)
-                self.log_orange(mutated_request.http_repr())
-                self.log_orange("---")
+                log_orange("---")
+                log_orange(Messages.MSG_TIMEOUT, page)
+                log_orange(Messages.MSG_EVIL_REQUEST)
+                log_orange(mutated_request.http_repr())
+                log_orange("---")
 
                 if parameter == "QUERY_STRING":
                     anom_msg = Messages.MSG_QS_TIMEOUT
@@ -189,16 +188,16 @@ class mod_xxe(Attack):
                         parameter=parameter
                     )
 
-                    self.log_red("---")
-                    self.log_red(
+                    log_red("---")
+                    log_red(
                         Messages.MSG_QS_INJECT if parameter == "QUERY_STRING" else Messages.MSG_PARAM_INJECT,
                         self.MSG_VULN,
                         page,
                         parameter
                     )
-                    self.log_red(Messages.MSG_EVIL_REQUEST)
-                    self.log_red(mutated_request.http_repr())
-                    self.log_red("---")
+                    log_red(Messages.MSG_EVIL_REQUEST)
+                    log_red(mutated_request.http_repr())
+                    log_red("---")
 
                     # We reached maximum exploitation for this parameter, don't send more payloads
                     vulnerable_parameter = True
@@ -219,11 +218,11 @@ class mod_xxe(Attack):
                         parameter=parameter
                     )
 
-                    self.log_orange("---")
-                    self.log_orange(Messages.MSG_500, page)
-                    self.log_orange(Messages.MSG_EVIL_REQUEST)
-                    self.log_orange(mutated_request.http_repr())
-                    self.log_orange("---")
+                    log_orange("---")
+                    log_orange(Messages.MSG_500, page)
+                    log_orange(Messages.MSG_EVIL_REQUEST)
+                    log_orange(mutated_request.http_repr())
+                    log_orange("---")
 
     async def attack_body(self, original_request):
         for payload, tags in self.payloads:
@@ -231,8 +230,7 @@ class mod_xxe(Attack):
             payload = payload.replace("[PARAM_AS_HEX]", "72617720626f6479")  # raw body
             mutated_request = Request(original_request.url, method="POST", enctype="text/xml", post_params=payload)
 
-            if self.verbose == 2:
-                logging.info("[¨] {0}".format(mutated_request))
+            log_verbose("[¨] {0}".format(mutated_request))
 
             try:
                 response = await self.crawler.async_send(mutated_request)
@@ -250,15 +248,15 @@ class mod_xxe(Attack):
                         parameter="raw body"
                     )
 
-                    self.log_red("---")
-                    self.log_red(
+                    log_red("---")
+                    log_red(
                         "{0} in {1} leading to file disclosure",
                         self.MSG_VULN,
                         original_request.url
                     )
-                    self.log_red(Messages.MSG_EVIL_REQUEST)
-                    self.log_red(mutated_request.http_repr())
-                    self.log_red("---")
+                    log_red(Messages.MSG_EVIL_REQUEST)
+                    log_red(mutated_request.http_repr())
+                    log_red("---")
                     self.vulnerables.add(original_request.path_id)
                     break
 
@@ -276,8 +274,7 @@ class mod_xxe(Attack):
                 # If parameter is vulnerable, just skip till next parameter
                 continue
 
-            if self.verbose == 2:
-                logging.info("[¨] {0}".format(mutated_request))
+            log_verbose("[¨] {0}".format(mutated_request))
 
             try:
                 response = await self.crawler.async_send(mutated_request)
@@ -294,16 +291,16 @@ class mod_xxe(Attack):
                         parameter=parameter
                     )
 
-                    self.log_red("---")
-                    self.log_red(
+                    log_red("---")
+                    log_red(
                         Messages.MSG_PARAM_INJECT,
                         self.MSG_VULN,
                         original_request.url,
                         parameter
                     )
-                    self.log_red(Messages.MSG_EVIL_REQUEST)
-                    self.log_red(mutated_request.http_repr())
-                    self.log_red("---")
+                    log_red(Messages.MSG_EVIL_REQUEST)
+                    log_red(mutated_request.http_repr())
+                    log_red("---")
                     vulnerable_parameter = True
                     self.vulnerables.add(original_request.path_id)
 
@@ -421,8 +418,8 @@ class mod_xxe(Attack):
                         parameter=parameter
                     )
 
-                    self.log_red("---")
-                    self.log_red(vuln_message)
-                    self.log_red(Messages.MSG_EVIL_REQUEST)
-                    self.log_red(mutated_request.http_repr())
-                    self.log_red("---")
+                    log_red("---")
+                    log_red(vuln_message)
+                    log_red(Messages.MSG_EVIL_REQUEST)
+                    log_red(mutated_request.http_repr())
+                    log_red("---")

--- a/wapitiCore/main/log.py
+++ b/wapitiCore/main/log.py
@@ -22,7 +22,13 @@ from functools import partial
 from loguru import logger as logging
 
 logging.remove()
-# logging.debug is 10
+
+# Setup additional logging levels, from the less important to the more critical
+# Each attempted mutated request will be logged as VERBOSE as it generates a lot of output
+# Each attacked original request will be logged as INFO
+# Others info like currently used attack module must be logged even in quiet mode so BLUE level must be used as least
+
+# logging.debug is level 10, this is the value defined in Python's logging module and is reused by loguru
 logging.level("VERBOSE", no=15)
 # logging.info is 20
 logging.level("BLUE", no=21, color="<blue>")

--- a/wapitiCore/main/log.py
+++ b/wapitiCore/main/log.py
@@ -16,11 +16,29 @@
 # You should have received a copy of the GNU General Public License
 # along with this program; if not, write to the Free Software
 # Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+import sys
+from functools import partial
 
 from loguru import logger as logging
 
 logging.remove()
-logging.level("RED", no=45, color="<red>")
-logging.level("ORANGE", no=35, color="<yellow>")
-logging.level("GREEN", no=22, color="<green>")
+# logging.debug is 10
+logging.level("VERBOSE", no=15)
+# logging.info is 20
 logging.level("BLUE", no=21, color="<blue>")
+logging.level("GREEN", no=22, color="<green>")
+# logging.success is 25
+# logging.warning is 30
+logging.level("ORANGE", no=35, color="<yellow>")
+# logging.error is 40
+logging.level("RED", no=45, color="<red>")
+# logging.critical is 50
+
+log_blue = partial(logging.log, "BLUE")
+log_green = partial(logging.log, "GREEN")
+log_red = partial(logging.log, "RED")
+log_orange = partial(logging.log, "ORANGE")
+log_verbose = partial(logging.log, "VERBOSE")
+
+# Set default logging
+logging.add(sys.stdout, colorize=False, format="{message}", level="INFO")

--- a/wapitiCore/main/wapiti.py
+++ b/wapitiCore/main/wapiti.py
@@ -123,7 +123,7 @@ class Wapiti:
         self.forms = []
         self.attacks = []
 
-        self.color = False
+        self.color_enabled = False
         self.verbose = 0
         self.module_options = None
         self.attack_options = {}
@@ -161,7 +161,7 @@ class Wapiti:
 
     def refresh_logging(self):
         format = "{message}"
-        if self.color:
+        if self.color_enabled:
             format = "<lvl>" + format + "</lvl>"
 
         verbosity_levels = {
@@ -171,7 +171,12 @@ class Wapiti:
         }
 
         handlers = [
-            {"sink": sys.stdout, "colorize": self.color, "format": format, "level": verbosity_levels[self.verbose]}
+            {
+                "sink": sys.stdout,
+                "colorize": self.color_enabled,
+                "format": format,
+                "level": verbosity_levels[self.verbose]
+            }
         ]
         if self._logfile:
             handlers.append({"sink": self._logfile, "level": "DEBUG"})
@@ -672,7 +677,7 @@ class Wapiti:
         """Put colors in the console output (terminal must support colors)"""
         # logging.remove()
         # logging.add(sys.stdout, format="<lvl>{message}</lvl>", level="INFO")
-        self.color = True
+        self.color_enabled = True
         self.refresh_logging()
 
     def verbosity(self, verbose: int):

--- a/wapitiCore/net/crawler.py
+++ b/wapitiCore/net/crawler.py
@@ -42,7 +42,7 @@ from wapitiCore.net import swf
 from wapitiCore.net import lamejs
 from wapitiCore.net import jsparser_angular
 from wapitiCore.net.page import Page
-from wapitiCore.main.log import logging
+from wapitiCore.main.log import logging, log_verbose
 
 warnings.filterwarnings(action='ignore', category=UserWarning, module='bs4')
 
@@ -567,7 +567,6 @@ class Explorer:
         self._crawler = crawler_instance
         self._max_depth = 20
         self._max_page_size = MAX_PAGE_SIZE
-        self._log = True
         self._bad_params = set()
         self._max_per_depth = 0
         self._max_files_per_dir = 0
@@ -605,14 +604,6 @@ class Explorer:
     @max_page_size.setter
     def max_page_size(self, value: int):
         self._max_page_size = value
-
-    @property
-    def verbose(self) -> bool:
-        return self._log
-
-    @verbose.setter
-    def verbose(self, value: bool):
-        self._log = value
 
     @property
     def forbidden_parameters(self) -> set:
@@ -765,8 +756,7 @@ class Explorer:
         async with self._sem:
             self._processed_requests.append(request)  # thread safe
 
-            if self._log:
-                logging.info("[+] {0}".format(request))
+            log_verbose("[+] {0}".format(request))
 
             dir_name = request.dir_name
             # Currently not exploited. Would be interesting though but then it should be implemented separately


### PR DESCRIPTION
Fix #156 

I moved log_red and co from attack.py to log.py directly.

I added a refresh_logging method that reconfigure logging and is called when verbosity / coloring / log file is changed.

I removed the need to pass verbosity and color to attack modules as they are now handled directly by logging level.