### PR TITLE
Wapiti: clear stop_event at start of browse and attack methods

### DIFF
--- a/tests/web/test_crawl.py
+++ b/tests/web/test_crawl.py
@@ -58,7 +58,6 @@ async def test_resume_crawling():
     wapiti = Wapiti("http://perdu.com/", session_dir=temp_obj.name)
     await wapiti.init_persister()
     await wapiti.load_scan_state()
-    stop_event.clear()
     await wapiti.browse(stop_event)
     await wapiti.save_scan_state()
     remaining_requests = set([request async for request in wapiti.persister.get_to_browse()])

--- a/wapitiCore/main/wapiti.py
+++ b/wapitiCore/main/wapiti.py
@@ -229,6 +229,7 @@ class Wapiti:
 
     def _init_attacks(self, stop_event: asyncio.Event):
         self._init_report()
+        stop_event.clear()
 
         logging.info(_("[*] Loading modules:"))
         modules_list = sorted(module_name[4:] for module_name in attack.modules)
@@ -361,6 +362,7 @@ class Wapiti:
 
     async def browse(self, stop_event: asyncio.Event, parallelism: int = 8):
         """Extract hyperlinks and forms from the webpages found on the website"""
+        stop_event.clear()
         explorer = crawler.Explorer(self.crawler, stop_event, parallelism=parallelism)
         explorer.max_depth = self._max_depth
         explorer.max_files_per_dir = self._max_files_per_dir
@@ -1350,7 +1352,6 @@ async def wapiti_main():
             )))
 
         logging.info(_("[*] Wapiti found {0} URLs and forms during the scan").format(await wap.count_resources()))
-        global_stop_event.clear()
         loop.add_signal_handler(signal.SIGINT, stop_attack_process)
         await wap.attack(global_stop_event)
         loop.remove_signal_handler(signal.SIGINT)


### PR DESCRIPTION
Fix #164 