### PR TITLE
Fix consider-using-with linting errors

### DIFF
--- a/tests/cookies/test_json_cookie.py
+++ b/tests/cookies/test_json_cookie.py
@@ -15,7 +15,7 @@ from wapitiCore.net.web import Request
 async def test_cookie_dump():
     with NamedTemporaryFile() as json_fd:
         json_cookie = JsonCookie()
-        json_cookie.open(json_fd.name)
+        json_cookie.load(json_fd.name)
         json_cookie.delete("httpbin.org")
 
         url = "http://httpbin.org/welcome/"
@@ -36,7 +36,6 @@ async def test_cookie_dump():
 
         await crawler.close()
         json_cookie.dump()
-        json_cookie.close()
 
         data = json.load(open(json_fd.name))
         assert data == {
@@ -90,13 +89,12 @@ async def test_cookie_load():
         }
         json.dump(data, json_fd)
         json_cookie = JsonCookie()
-        json_cookie.open(json_fd.name)
+        json_cookie.load(json_fd.name)
         jar = json_cookie.cookiejar("httpbin.org")
         for cookie in jar:
             assert (cookie.name == "foo" and cookie.value == "bar" and cookie.path == "/") or\
                    (cookie.name == "dead" and cookie.value == "beef" and cookie.path == "/welcome/")
         json_cookie.dump()
-        json_cookie.close()
 
 
 @pytest.mark.asyncio
@@ -126,9 +124,8 @@ async def test_cookie_delete():
         }
         json.dump(data, json_fd)
         json_cookie = JsonCookie()
-        json_cookie.open(json_fd.name)
+        json_cookie.load(json_fd.name)
         json_cookie.delete("httpbin.org")
         json_cookie.dump()
-        json_cookie.close()
 
         assert open(json_fd.name).read() == '{}'

--- a/wapitiCore/main/getcookie.py
+++ b/wapitiCore/main/getcookie.py
@@ -141,7 +141,7 @@ async def getcookie_main(arguments):
 
     # Open or create the cookie file and delete previous cookies from this server
     json_cookie = jsoncookie.JsonCookie()
-    json_cookie.open(args.cookie)
+    json_cookie.load(args.cookie)
     json_cookie.delete(server)
 
     page = await crawler.async_get(Request(args.url), follow_redirects=True)
@@ -201,7 +201,6 @@ async def getcookie_main(arguments):
 
     await crawler.close()
     json_cookie.dump()
-    json_cookie.close()
 
 
 def getcookie_asyncio_wrapper():

--- a/wapitiCore/net/jsoncookie.py
+++ b/wapitiCore/net/jsoncookie.py
@@ -32,18 +32,19 @@ class JsonCookie:
 
     def __init__(self):
         self.cookiedict = None
-        self.file_data = None
+        self.filename = None
 
     # return a dictionary on success, None on failure
-    def open(self, filename):
+    def load(self, filename):
         if not filename:
             return None
+        self.filename = filename
         try:
-            self.file_data = open(filename, "r+", encoding='utf-8')
-            self.cookiedict = json.load(self.file_data)
+            with open(filename, "r+", encoding='utf-8') as file_data:
+                self.cookiedict = json.load(file_data)
         except (IOError, ValueError):
-            self.file_data = open(filename, "w+", encoding='utf-8')
-            self.cookiedict = {}
+            with open(filename, "w+", encoding='utf-8') as file_data:
+                self.cookiedict = {}
         return self.cookiedict
 
     def addcookies(self, cookies):
@@ -177,12 +178,10 @@ class JsonCookie:
         return False
 
     def dump(self):
-        if not self.file_data:
+        if not self.filename:
             return False
-        self.file_data.seek(0)
-        self.file_data.truncate()
-        json.dump(self.cookiedict, self.file_data, indent=2)
+        with open(self.filename, "r+", encoding='utf-8') as file_data:
+            file_data.seek(0)
+            file_data.truncate()
+            json.dump(self.cookiedict, file_data, indent=2)
         return True
-
-    def close(self):
-        self.file_data.close()

--- a/wapitiCore/net/xss_utils.py
+++ b/wapitiCore/net/xss_utils.py
@@ -224,8 +224,10 @@ def get_context_list(html_code, original_keyword):
 
 def load_payloads_from_ini(filename, external_endpoint):
     config_reader = ConfigParser(interpolation=None)
-    config_reader.read_file(open(filename, encoding='utf-8'))
     payloads = []
+
+    with open(filename, 'r', encoding='utf-8') as file_data:
+        config_reader.read_file(file_data)
     external_endpoint = external_endpoint if external_endpoint.endswith('/') else external_endpoint + "/"
     parts = urlparse(external_endpoint)
     proto_endpoint = parts.netloc + parts.path


### PR DESCRIPTION
Hello, in this pull request I have fixed all `consider-using-with` linting errors.  
In the `JsonCookie` class, I have renamed the `open` function to `load` because in my opinion, `open` means that we need to close it after, but I have changed this behavior to open the file then close it after automatically.