### PR TITLE
Changed urls to the forked wapiti-scanner repository

### DIFF
--- a/wapitiCore/attack/mod_wapp.py
+++ b/wapitiCore/attack/mod_wapp.py
@@ -42,13 +42,13 @@ class mod_wapp(Attack):
 
     name = "wapp"
 
-    WAPP_CATEGORIES_URL = "https://raw.githubusercontent.com/AliasIO/wappalyzer/master/src/categories.json"
+    WAPP_CATEGORIES_URL = "https://raw.githubusercontent.com/wapiti-scanner/wappalyzer/main/src/categories.json"
     WAPP_CATEGORIES = "categories.json"
 
-    WAPP_GROUPS_URL = "https://raw.githubusercontent.com/AliasIO/wappalyzer/master/src/groups.json"
+    WAPP_GROUPS_URL = "https://raw.githubusercontent.com/wapiti-scanner/wappalyzer/main/src/groups.json"
     WAPP_GROUPS = "groups.json"
 
-    WAPP_TECHNOLOGIES_BASE_URL = "https://raw.githubusercontent.com/AliasIO/wappalyzer/master/src/technologies/"
+    WAPP_TECHNOLOGIES_BASE_URL = "https://raw.githubusercontent.com/wapiti-scanner/wappalyzer/main/src/technologies/"
     WAPP_TECHNOLOGIES = "technologies.json"
 
     do_get = False

--- a/wapitiCore/wappalyzer/wappalyzer.py
+++ b/wapitiCore/wappalyzer/wappalyzer.py
@@ -62,7 +62,7 @@ class ApplicationData:
         """
         for application_name in self.applications:
 
-            for list_field in ["cats", "html", "implies", "scripts"]:
+            for list_field in ["cats", "html", "implies", "scriptSrc"]:
                 if list_field not in self.applications[application_name]:
                     # Complete with empty elements if not already present
                     self.applications[application_name][list_field] = []
@@ -117,7 +117,7 @@ class ApplicationData:
         """
         for application_name in self.applications:
 
-            for list_field in ["html", "implies", "scripts"]:
+            for list_field in ["html", "implies", "scriptSrc"]:
                 self.applications[application_name][list_field] = [
                     self.normalize_regex(pattern) for pattern in self.applications[application_name][list_field]
                 ]
@@ -206,7 +206,7 @@ class Wappalyzer:
         """
         url_detected = self.is_application_detected_normalize_string(application, 'url', self._url)
         html_detected = self.is_application_detected_normalize_list(application, 'html', self._html)
-        scripts_detected = self.is_application_detected_normalize_list(application, 'scripts', self._scripts)
+        scripts_detected = self.is_application_detected_normalize_list(application, 'scriptSrc', self._scripts)
         cookies_detected = self.is_application_detected_normalize_dict(application, 'cookies', self._cookies)
         headers_detected = self.is_application_detected_normalize_dict(application, 'headers', self._headers)
         meta_detected = self.is_application_detected_normalize_dict(application, 'meta', self._metas)


### PR DESCRIPTION
## Description

This pull request is linked to #169 because it changes URLs to do requests to the forked wapiti-scanner repository.  
I have also updated the field's name `scripts` to `scriptSrc` due to this commit: https://github.com/AliasIO/wappalyzer/commit/fe4092b74bdc1a4fab6d45ce79f16e49c6bde70d#diff-736cc89ac6e7444f5fae5be47729a37a0c705564328fc9a7ad965335e525a2f1
## Related Issue(s)
 
N/A