### PR TITLE
Rename attack modules classes to CamelCase format

### DIFF
--- a/tests/attack/test_mod_backup.py
+++ b/tests/attack/test_mod_backup.py
@@ -6,7 +6,7 @@ import pytest
 
 from wapitiCore.net.web import Request
 from wapitiCore.net.crawler import AsyncCrawler
-from wapitiCore.attack.mod_backup import Backup
+from wapitiCore.attack.mod_backup import ModuleBackup
 from tests import AsyncMock
 
 
@@ -27,7 +27,7 @@ async def test_whole_stuff():
     crawler = AsyncCrawler("http://perdu.com/", timeout=1)
     options = {"timeout": 10, "level": 2}
 
-    module = Backup(crawler, persister, options, Event())
+    module = ModuleBackup(crawler, persister, options, Event())
     module.do_get = True
     await module.attack(request)
 
@@ -52,7 +52,7 @@ async def test_false_positive():
     crawler = AsyncCrawler("http://perdu.com/", timeout=1)
     options = {"timeout": 10, "level": 2}
 
-    module = Backup(crawler, persister, options, Event())
+    module = ModuleBackup(crawler, persister, options, Event())
     module.do_get = True
     assert not await module.must_attack(request)
 

--- a/tests/attack/test_mod_buster.py
+++ b/tests/attack/test_mod_buster.py
@@ -7,7 +7,7 @@ import pytest
 
 from wapitiCore.net.web import Request
 from wapitiCore.net.crawler import AsyncCrawler
-from wapitiCore.attack.mod_buster import Buster
+from wapitiCore.attack.mod_buster import ModuleBuster
 from wapitiCore.attack.attack import Flags
 from tests import AsyncIterator
 
@@ -37,10 +37,10 @@ async def test_whole_stuff():
     options = {"timeout": 10, "level": 2, "tasks": 20}
 
     with patch(
-            "wapitiCore.attack.mod_buster.Buster.payloads",
+            "wapitiCore.attack.mod_buster.ModuleBuster.payloads",
             [("nawak", Flags()), ("admin", Flags()), ("config.inc", Flags()), ("authconfig.php", Flags())]
     ):
-        module = Buster(crawler, persister, options, Event())
+        module = ModuleBuster(crawler, persister, options, Event())
         module.do_get = True
         await module.attack(request)
 

--- a/tests/attack/test_mod_cookieflags.py
+++ b/tests/attack/test_mod_cookieflags.py
@@ -7,7 +7,7 @@ import pytest
 
 from wapitiCore.net.web import Request
 from wapitiCore.net.crawler import AsyncCrawler
-from wapitiCore.attack.mod_cookieflags import Cookieflags
+from wapitiCore.attack.mod_cookieflags import ModuleCookieflags
 from tests import AsyncMock
 
 
@@ -33,7 +33,7 @@ async def test_cookieflags():
     await crawler.async_send(request)  # Put cookies in our crawler object
     options = {"timeout": 10, "level": 2}
 
-    module = Cookieflags(crawler, persister, options, asyncio.Event())
+    module = ModuleCookieflags(crawler, persister, options, asyncio.Event())
     await module.attack(request)
 
     cookie_flags = []

--- a/tests/attack/test_mod_crlf.py
+++ b/tests/attack/test_mod_crlf.py
@@ -7,7 +7,7 @@ import httpx
 from wapitiCore.net.web import Request
 from wapitiCore.net.crawler import AsyncCrawler
 from wapitiCore.language.vulnerability import _
-from wapitiCore.attack.mod_crlf import Crlf
+from wapitiCore.attack.mod_crlf import ModuleCrlf
 from tests import AsyncMock
 
 
@@ -28,7 +28,7 @@ async def test_whole_stuff():
     crawler = AsyncCrawler("http://perdu.com/", timeout=1)
     options = {"timeout": 10, "level": 2}
 
-    module = Crlf(crawler, persister, options, Event())
+    module = ModuleCrlf(crawler, persister, options, Event())
     module.do_get = True
     await module.attack(request)
 

--- a/tests/attack/test_mod_csrf.py
+++ b/tests/attack/test_mod_csrf.py
@@ -8,7 +8,7 @@ import pytest
 
 from wapitiCore.net.web import Request
 from wapitiCore.net.crawler import AsyncCrawler
-from wapitiCore.attack.mod_csrf import Csrf
+from wapitiCore.attack.mod_csrf import ModuleCsrf
 from wapitiCore.language.vulnerability import _
 from tests import AsyncMock
 
@@ -60,7 +60,7 @@ async def test_csrf_cases():
     crawler = AsyncCrawler("http://127.0.0.1:65086/", timeout=1)
     options = {"timeout": 10, "level": 1}
 
-    module = Csrf(crawler, persister, options, Event())
+    module = ModuleCsrf(crawler, persister, options, Event())
     module.do_post = True
     for request in all_requests:
         if await module.must_attack(request):

--- a/tests/attack/test_mod_drupal_enum.py
+++ b/tests/attack/test_mod_drupal_enum.py
@@ -9,7 +9,7 @@ import pytest
 
 from wapitiCore.net.web import Request
 from wapitiCore.net.crawler import AsyncCrawler
-from wapitiCore.attack.mod_drupal_enum import DrupalEnum
+from wapitiCore.attack.mod_drupal_enum import ModuleDrupalEnum
 from tests import AsyncMock
 
 
@@ -37,7 +37,7 @@ async def test_no_drupal():
 
     options = {"timeout": 10, "level": 2, "tasks": 20}
 
-    module = DrupalEnum(crawler, persister, options, Event())
+    module = ModuleDrupalEnum(crawler, persister, options, Event())
 
     await module.attack(request)
 
@@ -73,7 +73,7 @@ async def test_version_detected():
 
     options = {"timeout": 10, "level": 2, "tasks": 20}
 
-    module = DrupalEnum(crawler, persister, options, Event())
+    module = ModuleDrupalEnum(crawler, persister, options, Event())
 
     await module.attack(request)
 
@@ -113,7 +113,7 @@ async def test_multi_versions_detected():
 
     options = {"timeout": 10, "level": 2, "tasks": 20}
 
-    module = DrupalEnum(crawler, persister, options, Event())
+    module = ModuleDrupalEnum(crawler, persister, options, Event())
 
     await module.attack(request)
 
@@ -152,7 +152,7 @@ async def test_version_not_detected():
 
     options = {"timeout": 10, "level": 2, "tasks": 20}
 
-    module = DrupalEnum(crawler, persister, options, Event())
+    module = ModuleDrupalEnum(crawler, persister, options, Event())
 
     await module.attack(request)
 

--- a/tests/attack/test_mod_exec.py
+++ b/tests/attack/test_mod_exec.py
@@ -11,7 +11,7 @@ import httpx
 from wapitiCore.net.web import Request
 from wapitiCore.language.vulnerability import _
 from wapitiCore.net.crawler import AsyncCrawler
-from wapitiCore.attack.mod_exec import Exec
+from wapitiCore.attack.mod_exec import ModuleExec
 from tests import AsyncMock
 
 
@@ -55,7 +55,7 @@ async def test_whole_stuff():
     crawler = AsyncCrawler("http://perdu.com/", timeout=1)
     options = {"timeout": 10, "level": 2}
 
-    module = Exec(crawler, persister, options, Event())
+    module = ModuleExec(crawler, persister, options, Event())
     module.do_post = True
     for request in all_requests:
         await module.attack(request)
@@ -83,7 +83,7 @@ async def test_detection():
     crawler = AsyncCrawler("http://perdu.com/", timeout=1)
     options = {"timeout": 10, "level": 1}
 
-    module = Exec(crawler, persister, options, Event())
+    module = ModuleExec(crawler, persister, options, Event())
     await module.attack(request)
 
     assert persister.add_payload.call_count == 1
@@ -112,7 +112,7 @@ async def test_blind_detection():
     crawler = AsyncCrawler("http://perdu.com/", timeout=1)
     options = {"timeout": 1, "level": 1}
 
-    module = Exec(crawler, persister, options, Event())
+    module = ModuleExec(crawler, persister, options, Event())
     module.do_post = False
 
     payloads_until_sleep = 0

--- a/tests/attack/test_mod_file.py
+++ b/tests/attack/test_mod_file.py
@@ -9,7 +9,7 @@ import pytest
 from wapitiCore.net.web import Request
 from wapitiCore.language.vulnerability import _
 from wapitiCore.net.crawler import AsyncCrawler
-from wapitiCore.attack.mod_file import File, has_prefix_or_suffix, find_warning_message, FileWarning
+from wapitiCore.attack.mod_file import ModuleFile, has_prefix_or_suffix, find_warning_message, FileWarning
 from tests import AsyncMock
 
 
@@ -33,7 +33,7 @@ async def test_inclusion_detection():
     crawler = AsyncCrawler("http://127.0.0.1:65085/")
     options = {"timeout": 10, "level": 2}
 
-    module = File(crawler, persister, options, Event())
+    module = ModuleFile(crawler, persister, options, Event())
     module.do_post = False
     await module.attack(request)
 
@@ -52,7 +52,7 @@ async def test_warning_false_positive():
     crawler = AsyncCrawler("http://127.0.0.1:65085/")
     options = {"timeout": 10, "level": 2}
 
-    module = File(crawler, persister, options, Event())
+    module = ModuleFile(crawler, persister, options, Event())
     module.do_post = False
     await module.attack(request)
 
@@ -81,7 +81,7 @@ async def test_no_crash():
     crawler = AsyncCrawler("http://127.0.0.1:65085/")
     options = {"timeout": 10, "level": 2}
 
-    module = File(crawler, persister, options, Event())
+    module = ModuleFile(crawler, persister, options, Event())
     module.do_post = False
     for request in all_requests:
         await module.attack(request)

--- a/tests/attack/test_mod_htaccess.py
+++ b/tests/attack/test_mod_htaccess.py
@@ -7,7 +7,7 @@ import pytest
 from wapitiCore.net.web import Request
 from wapitiCore.net.crawler import AsyncCrawler
 from wapitiCore.language.vulnerability import _
-from wapitiCore.attack.mod_htaccess import Htaccess
+from wapitiCore.attack.mod_htaccess import ModuleHtaccess
 from tests import AsyncMock
 
 
@@ -41,7 +41,7 @@ async def test_whole_stuff():
     crawler = AsyncCrawler("http://perdu.com/", timeout=1)
     options = {"timeout": 10, "level": 2}
 
-    module = Htaccess(crawler, persister, options, Event())
+    module = ModuleHtaccess(crawler, persister, options, Event())
     module.do_get = True
     for request in all_requests:
         if await module.must_attack(request):

--- a/tests/attack/test_mod_methods.py
+++ b/tests/attack/test_mod_methods.py
@@ -7,7 +7,7 @@ import pytest
 
 from wapitiCore.net.web import Request
 from wapitiCore.net.crawler import AsyncCrawler
-from wapitiCore.attack.mod_methods import Methods
+from wapitiCore.attack.mod_methods import ModuleMethods
 from tests import AsyncMock
 
 
@@ -41,7 +41,7 @@ async def test_whole_stuff():
     crawler = AsyncCrawler("http://perdu.com/", timeout=1)
     options = {"timeout": 10, "level": 2}
 
-    module = Methods(crawler, persister, options, Event())
+    module = ModuleMethods(crawler, persister, options, Event())
     module.do_get = True
     for request in all_requests:
         await module.attack(request)

--- a/tests/attack/test_mod_nikto.py
+++ b/tests/attack/test_mod_nikto.py
@@ -9,7 +9,7 @@ import pytest
 from wapitiCore.net.web import Request
 from wapitiCore.net.crawler import AsyncCrawler
 from wapitiCore.language.vulnerability import _
-from wapitiCore.attack.mod_nikto import Nikto
+from wapitiCore.attack.mod_nikto import ModuleNikto
 from tests import AsyncMock
 
 
@@ -41,7 +41,7 @@ async def test_whole_stuff():
     crawler = AsyncCrawler("http://perdu.com/", timeout=1)
     options = {"timeout": 10, "level": 2, "tasks": 20}
 
-    module = Nikto(crawler, persister, options, Event())
+    module = ModuleNikto(crawler, persister, options, Event())
     module.do_get = True
     await module.attack(request)
 
@@ -95,7 +95,7 @@ async def test_false_positives():
     crawler = AsyncCrawler("http://perdu.com/", timeout=1)
     options = {"timeout": 10, "level": 2, "tasks": 20}
 
-    module = Nikto(crawler, persister, options, Event())
+    module = ModuleNikto(crawler, persister, options, Event())
     module.do_get = True
     module.NIKTO_DB = "temp_nikto_db"
     await module.attack(request)

--- a/tests/attack/test_mod_redirect.py
+++ b/tests/attack/test_mod_redirect.py
@@ -11,7 +11,7 @@ import respx
 from wapitiCore.net.web import Request
 from wapitiCore.net.crawler import AsyncCrawler
 from wapitiCore.language.vulnerability import _
-from wapitiCore.attack.mod_redirect import Redirect
+from wapitiCore.attack.mod_redirect import ModuleRedirect
 from tests import AsyncMock
 
 
@@ -33,7 +33,7 @@ async def test_redirect_detection():
     crawler = AsyncCrawler("http://127.0.0.1:65080/")
     options = {"timeout": 10, "level": 2}
 
-    module = Redirect(crawler, persister, options, Event())
+    module = ModuleRedirect(crawler, persister, options, Event())
     await module.attack(request)
 
     assert persister.add_payload.call_args_list[0][1]["module"] == "redirect"
@@ -73,7 +73,7 @@ async def test_whole_stuff():
     crawler = AsyncCrawler("http://perdu.com/", timeout=1)
     options = {"timeout": 10, "level": 2}
 
-    module = Redirect(crawler, persister, options, Event())
+    module = ModuleRedirect(crawler, persister, options, Event())
     module.do_post = True
     for request in all_requests:
         await module.attack(request)

--- a/tests/attack/test_mod_shellshock.py
+++ b/tests/attack/test_mod_shellshock.py
@@ -9,7 +9,7 @@ import pytest
 from wapitiCore.net.web import Request
 from wapitiCore.net.crawler import AsyncCrawler
 from wapitiCore.language.vulnerability import _
-from wapitiCore.attack.mod_shellshock import Shellshock
+from wapitiCore.attack.mod_shellshock import ModuleShellshock
 from tests import AsyncMock
 
 
@@ -47,7 +47,7 @@ async def test_whole_stuff():
     crawler = AsyncCrawler("http://perdu.com/", timeout=1)
     options = {"timeout": 10, "level": 2}
 
-    module = Shellshock(crawler, persister, options, Event())
+    module = ModuleShellshock(crawler, persister, options, Event())
     module.do_get = True
     for request in all_requests:
         await module.attack(request)

--- a/tests/attack/test_mod_sql.py
+++ b/tests/attack/test_mod_sql.py
@@ -10,7 +10,7 @@ import pytest
 from wapitiCore.net.web import Request
 from wapitiCore.net.crawler import AsyncCrawler
 from wapitiCore.language.vulnerability import _
-from wapitiCore.attack.mod_sql import Sql
+from wapitiCore.attack.mod_sql import ModuleSql
 from tests import AsyncMock
 
 
@@ -43,7 +43,7 @@ async def test_whole_stuff():
     crawler = AsyncCrawler("http://perdu.com/", timeout=1)
     options = {"timeout": 10, "level": 2}
 
-    module = Sql(crawler, persister, options, Event())
+    module = ModuleSql(crawler, persister, options, Event())
     module.do_post = True
     for request in all_requests:
         await module.attack(request)
@@ -65,7 +65,7 @@ async def test_false_positive():
     crawler = AsyncCrawler("http://perdu.com/", timeout=1)
     options = {"timeout": 10, "level": 1}
 
-    module = Sql(crawler, persister, options, Event())
+    module = ModuleSql(crawler, persister, options, Event())
     module.do_post = True
     await module.attack(request)
 
@@ -96,7 +96,7 @@ async def test_true_positive():
     crawler = AsyncCrawler("http://perdu.com/", timeout=1)
     options = {"timeout": 10, "level": 1}
 
-    module = Sql(crawler, persister, options, Event())
+    module = ModuleSql(crawler, persister, options, Event())
     module.do_post = True
     await module.attack(request)
 
@@ -153,7 +153,7 @@ async def test_blind_detection():
         crawler = AsyncCrawler("http://perdu.com/", timeout=1)
         options = {"timeout": 10, "level": 1}
 
-        module = Sql(crawler, persister, options, Event())
+        module = ModuleSql(crawler, persister, options, Event())
         module.do_post = True
         await module.attack(request)
 
@@ -176,7 +176,7 @@ async def test_negative_blind():
     crawler = AsyncCrawler("http://perdu.com/", timeout=1)
     options = {"timeout": 10, "level": 1}
 
-    module = Sql(crawler, persister, options, Event())
+    module = ModuleSql(crawler, persister, options, Event())
     await module.attack(request)
 
     assert not persister.add_payload.call_count
@@ -235,7 +235,7 @@ async def test_blind_detection_parenthesis():
         crawler = AsyncCrawler("http://perdu.com/", timeout=1)
         options = {"timeout": 10, "level": 1}
 
-        module = Sql(crawler, persister, options, Event())
+        module = ModuleSql(crawler, persister, options, Event())
         module.do_post = True
         await module.attack(request)
 

--- a/tests/attack/test_mod_ssrf.py
+++ b/tests/attack/test_mod_ssrf.py
@@ -7,7 +7,7 @@ import pytest
 from wapitiCore.net.web import Request
 from wapitiCore.net.crawler import AsyncCrawler
 from wapitiCore.language.vulnerability import _
-from wapitiCore.attack.mod_ssrf import Ssrf
+from wapitiCore.attack.mod_ssrf import ModuleSsrf
 from tests import AsyncMock
 
 
@@ -47,7 +47,7 @@ async def test_whole_stuff():
     crawler = AsyncCrawler("http://perdu.com/", timeout=1)
     options = {"timeout": 10, "level": 2}
 
-    module = Ssrf(crawler, persister, options, Event())
+    module = ModuleSsrf(crawler, persister, options, Event())
     module.do_post = True
 
     respx.get("https://wapiti3.ovh/get_ssrf.php?session_id=" + module._session_id).mock(

--- a/tests/attack/test_mod_takeover.py
+++ b/tests/attack/test_mod_takeover.py
@@ -10,7 +10,7 @@ import dns.resolver
 
 from wapitiCore.net.web import Request
 from wapitiCore.net.crawler import AsyncCrawler
-from wapitiCore.attack.mod_takeover import Takeover, TakeoverChecker
+from wapitiCore.attack.mod_takeover import ModuleTakeover, TakeoverChecker
 from tests import AsyncMock
 
 CNAME_TEMPLATE = """id 5395
@@ -60,7 +60,7 @@ async def test_unregistered_cname():
             crawler = AsyncCrawler("http://perdu.com/", timeout=1)
             options = {"timeout": 10, "level": 2}
 
-            module = Takeover(crawler, persister, options, Event())
+            module = ModuleTakeover(crawler, persister, options, Event())
 
             for request in all_requests:
                 await module.attack(request)

--- a/tests/attack/test_mod_timesql.py
+++ b/tests/attack/test_mod_timesql.py
@@ -12,7 +12,7 @@ import httpx
 from wapitiCore.net.web import Request
 from wapitiCore.net.crawler import AsyncCrawler
 from wapitiCore.language.vulnerability import _
-from wapitiCore.attack.mod_timesql import Timesql
+from wapitiCore.attack.mod_timesql import ModuleTimesql
 from tests import AsyncMock
 
 
@@ -37,7 +37,7 @@ async def test_timesql_detection():
     crawler = AsyncCrawler("http://127.0.0.1:65082/", timeout=1)
     options = {"timeout": 1, "level": 1}
 
-    module = Timesql(crawler, persister, options, Event())
+    module = ModuleTimesql(crawler, persister, options, Event())
     module.do_post = False
     await module.attack(request)
 
@@ -59,7 +59,7 @@ async def test_timesql_false_positive():
     crawler = AsyncCrawler("http://127.0.0.1:65082/", timeout=1)
     options = {"timeout": 1, "level": 1}
 
-    module = Timesql(crawler, persister, options, Event())
+    module = ModuleTimesql(crawler, persister, options, Event())
     module.do_post = False
     await module.attack(request)
 
@@ -79,7 +79,7 @@ async def test_false_positive_request_count():
     crawler = AsyncCrawler("http://perdu.com/", timeout=1)
     options = {"timeout": 1, "level": 1}
 
-    module = Timesql(crawler, persister, options, Event())
+    module = ModuleTimesql(crawler, persister, options, Event())
     module.do_post = False
     await module.attack(request)
 
@@ -104,7 +104,7 @@ async def test_true_positive_request_count():
     crawler = AsyncCrawler("http://perdu.com/", timeout=1)
     options = {"timeout": 1, "level": 1}
 
-    module = Timesql(crawler, persister, options, Event())
+    module = ModuleTimesql(crawler, persister, options, Event())
     module.do_post = False
     await module.attack(request)
 

--- a/tests/attack/test_mod_wapp.py
+++ b/tests/attack/test_mod_wapp.py
@@ -7,7 +7,7 @@ import pytest
 
 from wapitiCore.net.web import Request
 from wapitiCore.net.crawler import AsyncCrawler
-from wapitiCore.attack.mod_wapp import Wapp
+from wapitiCore.attack.mod_wapp import ModuleWapp
 from wapitiCore.language.language import _
 from tests import AsyncMock
 
@@ -38,7 +38,7 @@ async def test_false_positive():
     crawler = AsyncCrawler("http://perdu.com/")
     options = {"timeout": 10, "level": 2}
 
-    module = Wapp(crawler, persister, options, Event())
+    module = ModuleWapp(crawler, persister, options, Event())
 
     await module.attack(request)
 
@@ -70,7 +70,7 @@ async def test_url_detection():
     crawler = AsyncCrawler("http://perdu.com/")
     options = {"timeout": 10, "level": 2}
 
-    module = Wapp(crawler, persister, options, Event())
+    module = ModuleWapp(crawler, persister, options, Event())
 
     await module.attack(request)
 
@@ -108,7 +108,7 @@ async def test_html_detection():
     crawler = AsyncCrawler("http://perdu.com/")
     options = {"timeout": 10, "level": 2}
 
-    module = Wapp(crawler, persister, options, Event())
+    module = ModuleWapp(crawler, persister, options, Event())
 
     await module.attack(request)
 
@@ -145,7 +145,7 @@ async def test_script_detection():
     crawler = AsyncCrawler("http://perdu.com/")
     options = {"timeout": 10, "level": 2}
 
-    module = Wapp(crawler, persister, options, Event())
+    module = ModuleWapp(crawler, persister, options, Event())
 
     await module.attack(request)
 
@@ -182,7 +182,7 @@ async def test_cookies_detection():
     crawler = AsyncCrawler("http://perdu.com/")
     options = {"timeout": 10, "level": 2}
 
-    module = Wapp(crawler, persister, options, Event())
+    module = ModuleWapp(crawler, persister, options, Event())
 
     await module.attack(request)
 
@@ -219,7 +219,7 @@ async def test_headers_detection():
     crawler = AsyncCrawler("http://perdu.com/")
     options = {"timeout": 10, "level": 2}
 
-    module = Wapp(crawler, persister, options, Event())
+    module = ModuleWapp(crawler, persister, options, Event())
 
     await module.attack(request)
 
@@ -257,7 +257,7 @@ async def test_meta_detection():
     crawler = AsyncCrawler("http://perdu.com/")
     options = {"timeout": 10, "level": 2}
 
-    module = Wapp(crawler, persister, options, Event())
+    module = ModuleWapp(crawler, persister, options, Event())
 
     await module.attack(request)
 
@@ -297,7 +297,7 @@ async def test_multi_detection():
     crawler = AsyncCrawler("http://perdu.com/")
     options = {"timeout": 10, "level": 2}
 
-    module = Wapp(crawler, persister, options, Event())
+    module = ModuleWapp(crawler, persister, options, Event())
 
     await module.attack(request)
 
@@ -334,7 +334,7 @@ async def test_implies_detection():
     crawler = AsyncCrawler("http://perdu.com")
     options = {"timeout": 10, "level": 2}
 
-    module = Wapp(crawler, persister, options, Event())
+    module = ModuleWapp(crawler, persister, options, Event())
 
     await module.attack(request)
 
@@ -374,7 +374,7 @@ async def test_vulnerabilities():
     crawler = AsyncCrawler("http://perdu.com")
     options = {"timeout": 10, "level": 2}
 
-    module = Wapp(crawler, persister, options, Event())
+    module = ModuleWapp(crawler, persister, options, Event())
 
     await module.attack(request)
 

--- a/tests/attack/test_mod_wp_enum.py
+++ b/tests/attack/test_mod_wp_enum.py
@@ -6,7 +6,7 @@ import pytest
 
 from wapitiCore.net.web import Request
 from wapitiCore.net.crawler import AsyncCrawler
-from wapitiCore.attack.mod_wp_enum import WpEnum
+from wapitiCore.attack.mod_wp_enum import ModuleWpEnum
 from wapitiCore.language.vulnerability import _
 from tests import AsyncMock
 
@@ -33,7 +33,7 @@ async def test_no_wordpress():
 
     options = {"timeout": 10, "level": 2}
 
-    module = WpEnum(crawler, persister, options, Event())
+    module = ModuleWpEnum(crawler, persister, options, Event())
 
     await module.attack(request)
 
@@ -103,7 +103,7 @@ async def test_plugin():
 
     options = {"timeout": 10, "level": 2}
 
-    module = WpEnum(crawler, persister, options, Event())
+    module = ModuleWpEnum(crawler, persister, options, Event())
 
     await module.attack(request)
 
@@ -183,7 +183,7 @@ async def test_theme():
 
     options = {"timeout": 10, "level": 2}
 
-    module = WpEnum(crawler, persister, options, Event())
+    module = ModuleWpEnum(crawler, persister, options, Event())
 
     await module.attack(request)
 

--- a/tests/attack/test_mod_xss_advanced.py
+++ b/tests/attack/test_mod_xss_advanced.py
@@ -8,7 +8,7 @@ import pytest
 
 from wapitiCore.net.web import Request
 from wapitiCore.net.crawler import AsyncCrawler
-from wapitiCore.attack.mod_xss import Xss
+from wapitiCore.attack.mod_xss import ModuleXss
 from wapitiCore.language.vulnerability import _
 from tests import AsyncMock
 
@@ -33,7 +33,7 @@ async def test_title_false_positive():
     crawler = AsyncCrawler("http://127.0.0.1:65081/")
     options = {"timeout": 10, "level": 2}
 
-    module = Xss(crawler, persister, options, Event())
+    module = ModuleXss(crawler, persister, options, Event())
     module.do_post = False
     await module.attack(request)
 
@@ -50,7 +50,7 @@ async def test_title_positive():
     crawler = AsyncCrawler("http://127.0.0.1:65081/")
     options = {"timeout": 10, "level": 2}
 
-    module = Xss(crawler, persister, options, Event())
+    module = ModuleXss(crawler, persister, options, Event())
     module.do_post = False
     await module.attack(request)
 
@@ -74,7 +74,7 @@ async def test_script_filter_bypass():
     crawler = AsyncCrawler("http://127.0.0.1:65081/")
     options = {"timeout": 10, "level": 2}
 
-    module = Xss(crawler, persister, options, Event())
+    module = ModuleXss(crawler, persister, options, Event())
     module.do_post = False
     await module.attack(request)
 
@@ -93,7 +93,7 @@ async def test_script_src_protocol_relative():
     crawler = AsyncCrawler("http://127.0.0.1:65081/")
     options = {"timeout": 10, "level": 2}
 
-    module = Xss(crawler, persister, options, Event())
+    module = ModuleXss(crawler, persister, options, Event())
     module.do_post = False
     await module.attack(request)
 
@@ -114,7 +114,7 @@ async def test_attr_quote_escape():
     crawler = AsyncCrawler("http://127.0.0.1:65081/")
     options = {"timeout": 10, "level": 2}
 
-    module = Xss(crawler, persister, options, Event())
+    module = ModuleXss(crawler, persister, options, Event())
     module.do_post = False
     await module.attack(request)
 
@@ -133,7 +133,7 @@ async def test_attr_double_quote_escape():
     crawler = AsyncCrawler("http://127.0.0.1:65081/")
     options = {"timeout": 10, "level": 2}
 
-    module = Xss(crawler, persister, options, Event())
+    module = ModuleXss(crawler, persister, options, Event())
     module.do_post = False
     await module.attack(request)
 
@@ -152,7 +152,7 @@ async def test_attr_escape():
     crawler = AsyncCrawler("http://127.0.0.1:65081/")
     options = {"timeout": 10, "level": 2}
 
-    module = Xss(crawler, persister, options, Event())
+    module = ModuleXss(crawler, persister, options, Event())
     module.do_post = False
     await module.attack(request)
 
@@ -171,7 +171,7 @@ async def test_tag_name_escape():
     crawler = AsyncCrawler("http://127.0.0.1:65081/")
     options = {"timeout": 10, "level": 2}
 
-    module = Xss(crawler, persister, options, Event())
+    module = ModuleXss(crawler, persister, options, Event())
     module.do_post = False
     await module.attack(request)
 
@@ -190,7 +190,7 @@ async def test_partial_tag_name_escape():
     crawler = AsyncCrawler("http://127.0.0.1:65081/")
     options = {"timeout": 10, "level": 2}
 
-    module = Xss(crawler, persister, options, Event())
+    module = ModuleXss(crawler, persister, options, Event())
     module.do_post = False
     await module.attack(request)
 
@@ -208,7 +208,7 @@ async def test_xss_inside_tag_input():
     crawler = AsyncCrawler("http://127.0.0.1:65081/")
     options = {"timeout": 10, "level": 2}
 
-    module = Xss(crawler, persister, options, Event())
+    module = ModuleXss(crawler, persister, options, Event())
     module.do_post = False
     await module.attack(request)
 
@@ -227,7 +227,7 @@ async def test_xss_inside_tag_link():
     crawler = AsyncCrawler("http://127.0.0.1:65081/")
     options = {"timeout": 10, "level": 2}
 
-    module = Xss(crawler, persister, options, Event())
+    module = ModuleXss(crawler, persister, options, Event())
     module.do_post = False
     await module.attack(request)
 
@@ -246,7 +246,7 @@ async def test_xss_uppercase_no_script():
     crawler = AsyncCrawler("http://127.0.0.1:65081/")
     options = {"timeout": 10, "level": 2}
 
-    module = Xss(crawler, persister, options, Event())
+    module = ModuleXss(crawler, persister, options, Event())
     module.do_post = False
     await module.attack(request)
 
@@ -265,7 +265,7 @@ async def test_frame_src_escape():
     crawler = AsyncCrawler("http://127.0.0.1:65081/")
     options = {"timeout": 10, "level": 2}
 
-    module = Xss(crawler, persister, options, Event())
+    module = ModuleXss(crawler, persister, options, Event())
     module.do_post = False
     await module.attack(request)
 
@@ -284,7 +284,7 @@ async def test_frame_src_no_escape():
     crawler = AsyncCrawler("http://127.0.0.1:65081/")
     options = {"timeout": 10, "level": 2}
 
-    module = Xss(crawler, persister, options, Event())
+    module = ModuleXss(crawler, persister, options, Event())
     module.do_post = False
     await module.attack(request)
 
@@ -303,7 +303,7 @@ async def test_bad_separator_used():
     crawler = AsyncCrawler("http://127.0.0.1:65081/")
     options = {"timeout": 10, "level": 2}
 
-    module = Xss(crawler, persister, options, Event())
+    module = ModuleXss(crawler, persister, options, Event())
     module.do_post = False
     await module.attack(request)
 
@@ -321,7 +321,7 @@ async def test_escape_with_style():
     crawler = AsyncCrawler("http://127.0.0.1:65081/")
     options = {"timeout": 10, "level": 2}
 
-    module = Xss(crawler, persister, options, Event())
+    module = ModuleXss(crawler, persister, options, Event())
     module.do_post = False
     await module.attack(request)
 
@@ -339,7 +339,7 @@ async def test_rare_tag_and_event():
     crawler = AsyncCrawler("http://127.0.0.1:65081/")
     options = {"timeout": 10, "level": 2}
 
-    module = Xss(crawler, persister, options, Event())
+    module = ModuleXss(crawler, persister, options, Event())
     module.do_post = False
     await module.attack(request)
 
@@ -357,7 +357,7 @@ async def test_xss_with_strong_csp():
     crawler = AsyncCrawler("http://127.0.0.1:65081/")
     options = {"timeout": 10, "level": 2}
 
-    module = Xss(crawler, persister, options, Event())
+    module = ModuleXss(crawler, persister, options, Event())
     module.do_post = False
     await module.attack(request)
 
@@ -374,7 +374,7 @@ async def test_xss_with_weak_csp():
     crawler = AsyncCrawler("http://127.0.0.1:65081/")
     options = {"timeout": 10, "level": 2}
 
-    module = Xss(crawler, persister, options, Event())
+    module = ModuleXss(crawler, persister, options, Event())
     module.do_post = False
     await module.attack(request)
 

--- a/tests/attack/test_mod_xss_basics.py
+++ b/tests/attack/test_mod_xss_basics.py
@@ -6,7 +6,7 @@ import pytest
 
 from wapitiCore.net.web import Request
 from wapitiCore.net.crawler import AsyncCrawler
-from wapitiCore.attack.mod_xss import Xss
+from wapitiCore.attack.mod_xss import ModuleXss
 from tests import AsyncMock
 
 
@@ -39,7 +39,7 @@ async def test_whole_stuff():
     crawler = AsyncCrawler("http://perdu.com/", timeout=1)
     options = {"timeout": 10, "level": 2}
 
-    module = Xss(crawler, persister, options, Event())
+    module = ModuleXss(crawler, persister, options, Event())
     module.do_post = True
     for request in all_requests:
         await module.attack(request)

--- a/tests/attack/test_mod_xxe.py
+++ b/tests/attack/test_mod_xxe.py
@@ -11,7 +11,7 @@ import httpx
 
 from wapitiCore.net.web import Request
 from wapitiCore.net.crawler import AsyncCrawler
-from wapitiCore.attack.mod_xxe import Xxe
+from wapitiCore.attack.mod_xxe import ModuleXxe
 from wapitiCore.language.vulnerability import _
 from tests import AsyncMock
 
@@ -42,7 +42,7 @@ async def test_direct_body():
     crawler = AsyncCrawler("http://127.0.0.1:65084/")
     options = {"timeout": 10, "level": 1}
 
-    module = Xxe(crawler, persister, options, Event())
+    module = ModuleXxe(crawler, persister, options, Event())
 
     await module.attack(request)
 
@@ -63,7 +63,7 @@ async def test_direct_param():
     crawler = AsyncCrawler("http://127.0.0.1:65084/")
     options = {"timeout": 10, "level": 1}
 
-    module = Xxe(crawler, persister, options, Event())
+    module = ModuleXxe(crawler, persister, options, Event())
     module.do_post = False
     await module.attack(request)
 
@@ -80,7 +80,7 @@ async def test_direct_query_string():
     crawler = AsyncCrawler("http://127.0.0.1:65084/")
     options = {"timeout": 10, "level": 2}
 
-    module = Xxe(crawler, persister, options, Event())
+    module = ModuleXxe(crawler, persister, options, Event())
     module.do_post = False
     await module.attack(request)
 
@@ -112,7 +112,7 @@ async def test_out_of_band_body():
         "internal_endpoint": "http://wapiti3.ovh/"
     }
 
-    module = Xxe(crawler, persister, options, Event())
+    module = ModuleXxe(crawler, persister, options, Event())
 
     respx.get("http://wapiti3.ovh/get_xxe.php?session_id=" + module._session_id).mock(
         return_value=httpx.Response(
@@ -161,7 +161,7 @@ async def test_out_of_band_param():
         "internal_endpoint": "http://wapiti3.ovh/"
     }
 
-    module = Xxe(crawler, persister, options, Event())
+    module = ModuleXxe(crawler, persister, options, Event())
 
     respx.get("http://wapiti3.ovh/get_xxe.php?session_id=" + module._session_id).mock(
         return_value=httpx.Response(
@@ -210,7 +210,7 @@ async def test_out_of_band_query_string():
         "internal_endpoint": "http://wapiti3.ovh/"
     }
 
-    module = Xxe(crawler, persister, options, Event())
+    module = ModuleXxe(crawler, persister, options, Event())
     module.do_post = False
     await module.attack(request)
 
@@ -263,7 +263,7 @@ async def test_direct_upload():
         "internal_endpoint": "http://wapiti3.ovh/"
     }
 
-    module = Xxe(crawler, persister, options, Event())
+    module = ModuleXxe(crawler, persister, options, Event())
 
     await module.attack(request)
 

--- a/wapitiCore/attack/mod_backup.py
+++ b/wapitiCore/attack/mod_backup.py
@@ -33,7 +33,7 @@ from wapitiCore.definitions.backup import NAME
 from wapitiCore.net.web import Request
 
 
-class Backup(Attack):
+class ModuleBackup(Attack):
     """
     Uncover backup files on the web server.
     """

--- a/wapitiCore/attack/mod_brute_login_form.py
+++ b/wapitiCore/attack/mod_brute_login_form.py
@@ -31,7 +31,7 @@ from wapitiCore.net.web import Request
 from wapitiCore.main.log import log_red
 
 
-class BruteLoginForm(Attack):
+class ModuleBruteLoginForm(Attack):
     """Attempt to login on authentication forms using known weak credentials (like admin/admin)."""
     name = "brute_login_form"
     PAYLOADS_FILE = "passwords.txt"

--- a/wapitiCore/attack/mod_buster.py
+++ b/wapitiCore/attack/mod_buster.py
@@ -26,7 +26,7 @@ from wapitiCore.attack.attack import Attack
 from wapitiCore.net.web import Request
 
 
-class Buster(Attack):
+class ModuleBuster(Attack):
     """
     Brute force paths on the web-server to discover hidden files and directories.
     """

--- a/wapitiCore/attack/mod_cookieflags.py
+++ b/wapitiCore/attack/mod_cookieflags.py
@@ -26,7 +26,7 @@ INFO_COOKIE_HTTPONLY = _("HttpOnly flag is not set in the cookie : {0}")
 INFO_COOKIE_SECURE = _("Secure flag is not set in the cookie : {0}")
 
 
-class Cookieflags(Attack):
+class ModuleCookieflags(Attack):
     """Evaluate the security of cookies on the website."""
     name = "cookieflags"
     finished = False

--- a/wapitiCore/attack/mod_crlf.py
+++ b/wapitiCore/attack/mod_crlf.py
@@ -27,7 +27,7 @@ from wapitiCore.net.web import Request
 from wapitiCore.main.log import logging, log_verbose, log_orange, log_red
 
 
-class Crlf(Attack):
+class ModuleCrlf(Attack):
     """Detect Carriage Return Line Feed (CRLF) injection vulnerabilities."""
     # Won't work with PHP >= 4.4.2
 

--- a/wapitiCore/attack/mod_csp.py
+++ b/wapitiCore/attack/mod_csp.py
@@ -29,7 +29,7 @@ MSG_CSP_UNSAFE = _("CSP \"{0}\" value is not safe")
 
 
 # This module check the basics recommendations of CSP
-class Csp(Attack):
+class ModuleCsp(Attack):
     """Evaluate the security level of Content Security Policies of the web server."""
     name = "csp"
 

--- a/wapitiCore/attack/mod_csrf.py
+++ b/wapitiCore/attack/mod_csrf.py
@@ -28,7 +28,7 @@ from wapitiCore.net.crawler import Page
 from wapitiCore.main.log import log_red
 
 
-class Csrf(Attack):
+class ModuleCsrf(Attack):
     """
     Detect forms missing Cross-Site Request Forgery protections (CSRF tokens).
     """

--- a/wapitiCore/attack/mod_drupal_enum.py
+++ b/wapitiCore/attack/mod_drupal_enum.py
@@ -17,7 +17,7 @@ MSG_TECHNO_VERSIONED = _("{0} {1} detected")
 MSG_NO_DRUPAL = _("No Drupal Detected")
 
 
-class DrupalEnum(Attack):
+class ModuleDrupalEnum(Attack):
     """Detect Drupal version."""
     name = "drupal_enum"
     PAYLOADS_HASH = "drupal_hash_files.json"

--- a/wapitiCore/attack/mod_exec.py
+++ b/wapitiCore/attack/mod_exec.py
@@ -25,7 +25,7 @@ from wapitiCore.definitions.exec import NAME
 from wapitiCore.net.web import Request
 
 
-class Exec(Attack):
+class ModuleExec(Attack):
     """
     Detect scripts vulnerable to command and/or code execution.
     """

--- a/wapitiCore/attack/mod_file.py
+++ b/wapitiCore/attack/mod_file.py
@@ -97,7 +97,7 @@ def find_warning_message(data, payload):
     return None
 
 
-class File(Attack):
+class ModuleFile(Attack):
     """Detect file-related vulnerabilities such as directory traversal and include() vulnerabilities."""
 
     PAYLOADS_FILE = "fileHandlingPayloads.ini"

--- a/wapitiCore/attack/mod_htaccess.py
+++ b/wapitiCore/attack/mod_htaccess.py
@@ -30,7 +30,7 @@ from wapitiCore.net.web import Request
 from wapitiCore.main.log import log_red, log_verbose
 
 
-class Htaccess(Attack):
+class ModuleHtaccess(Attack):
     """
     Attempt to bypass access controls to a resource by using a custom HTTP method.
     """

--- a/wapitiCore/attack/mod_http_headers.py
+++ b/wapitiCore/attack/mod_http_headers.py
@@ -29,7 +29,7 @@ INFO_XSS_PROTECTION = _("X-XSS-Protection is not set")
 INFO_XFRAME_OPTIONS = _("X-Frame-Options is not set")
 
 
-class HttpHeaders(Attack):
+class ModuleHttpHeaders(Attack):
     """Evaluate the security of HTTP headers."""
     name = "http_headers"
     check_list_xframe = ['deny', 'sameorigin', 'allow-from']

--- a/wapitiCore/attack/mod_methods.py
+++ b/wapitiCore/attack/mod_methods.py
@@ -26,7 +26,7 @@ from wapitiCore.net.web import Request
 from wapitiCore.language.vulnerability import _
 
 
-class Methods(Attack):
+class ModuleMethods(Attack):
     """
     Detect uncommon HTTP methods (like PUT) that may be allowed by a script.
     """

--- a/wapitiCore/attack/mod_nikto.py
+++ b/wapitiCore/attack/mod_nikto.py
@@ -53,7 +53,7 @@ from wapitiCore.net.web import Request
 # ((6 or 7) and 8) and not (9 or 10)
 
 
-class Nikto(Attack):
+class ModuleNikto(Attack):
     """
     Perform a brute-force attack to uncover known and potentially dangerous scripts on the web server.
     """

--- a/wapitiCore/attack/mod_permanentxss.py
+++ b/wapitiCore/attack/mod_permanentxss.py
@@ -30,7 +30,7 @@ from wapitiCore.net.xss_utils import generate_payloads, valid_xss_content_type, 
 from wapitiCore.net.csp_utils import has_strong_csp
 
 
-class Permanentxss(Attack):
+class ModulePermanentxss(Attack):
     """
     Detect stored (aka permanent) Cross-Site Scripting vulnerabilities on the web server.
     """

--- a/wapitiCore/attack/mod_redirect.py
+++ b/wapitiCore/attack/mod_redirect.py
@@ -25,7 +25,7 @@ from wapitiCore.definitions.redirect import NAME
 from wapitiCore.net.web import Request
 
 
-class Redirect(Attack):
+class ModuleRedirect(Attack):
     """Detect Open Redirect vulnerabilities."""
     # Won't work with PHP >= 4.4.2
 

--- a/wapitiCore/attack/mod_shellshock.py
+++ b/wapitiCore/attack/mod_shellshock.py
@@ -29,7 +29,7 @@ from wapitiCore.definitions.exec import NAME
 from wapitiCore.main.log import log_red
 
 
-class Shellshock(Attack):
+class ModuleShellshock(Attack):
     """
     Detects scripts vulnerable to the infamous ShellShock vulnerability.
     """

--- a/wapitiCore/attack/mod_sql.py
+++ b/wapitiCore/attack/mod_sql.py
@@ -270,7 +270,7 @@ def generate_boolean_test_values(separator: str, parenthesis: bool):
         )
 
 
-class Sql(Attack):
+class ModuleSql(Attack):
     """
     Detect SQL (also LDAP and XPath) injection vulnerabilities using error-based or boolean-based (blind) techniques.
     """

--- a/wapitiCore/attack/mod_ssrf.py
+++ b/wapitiCore/attack/mod_ssrf.py
@@ -146,7 +146,7 @@ class SsrfMutator(Mutator):
                 yield evil_req, "QUERY_STRING", payload, Flags(method=PayloadType.get)
 
 
-class Ssrf(Attack):
+class ModuleSsrf(Attack):
     """
     Detect Server-Side Request Forgery vulnerabilities.
     """

--- a/wapitiCore/attack/mod_takeover.py
+++ b/wapitiCore/attack/mod_takeover.py
@@ -197,7 +197,7 @@ async def get_wildcard_responses(domain: str, resolvers: Iterator[str]) -> List[
     return [record.to_text().strip(".") for record in results]
 
 
-class Takeover(Attack):
+class ModuleTakeover(Attack):
     """Detect subdomains vulnerable to takeover (CNAME records pointing to non-existent and/or available domains)"""
     name = "takeover"
 

--- a/wapitiCore/attack/mod_timesql.py
+++ b/wapitiCore/attack/mod_timesql.py
@@ -25,7 +25,7 @@ from wapitiCore.definitions.timesql import NAME
 from wapitiCore.net.web import Request
 
 
-class Timesql(Attack):
+class ModuleTimesql(Attack):
     """
     Detect SQL injection vulnerabilities using blind time-based technique.
     """

--- a/wapitiCore/attack/mod_wapp.py
+++ b/wapitiCore/attack/mod_wapp.py
@@ -36,7 +36,7 @@ MSG_CATEGORIES = _("  -> Categorie(s): {0}")
 MSG_GROUPS = _("  -> Group(s): {0}")
 
 
-class Wapp(Attack):
+class ModuleWapp(Attack):
     """
     Identify web technologies used by the web server using Wappalyzer database.
     """

--- a/wapitiCore/attack/mod_wp_enum.py
+++ b/wapitiCore/attack/mod_wp_enum.py
@@ -12,7 +12,7 @@ MSG_TECHNO_VERSIONED = _("{0} {1} detected")
 MSG_NO_WP = _("No WordPress Detected")
 
 
-class WpEnum(Attack):
+class ModuleWpEnum(Attack):
     """Detect WordPress Plugins with version."""
     name = "wp_enum"
     PAYLOADS_FILE_PLUGINS = "wordpress_plugins.txt"

--- a/wapitiCore/attack/mod_xss.py
+++ b/wapitiCore/attack/mod_xss.py
@@ -29,7 +29,7 @@ from wapitiCore.net.csp_utils import has_strong_csp
 from wapitiCore.net.web import Request
 
 
-class Xss(Attack):
+class ModuleXss(Attack):
     """Detects stored (aka permanent) Cross-Site Scripting vulnerabilities on the web server."""
 
     name = "xss"

--- a/wapitiCore/attack/mod_xxe.py
+++ b/wapitiCore/attack/mod_xxe.py
@@ -38,7 +38,7 @@ def search_pattern(content: str, patterns: list) -> str:
     return ""
 
 
-class Xxe(Attack):
+class ModuleXxe(Attack):
     """Detect scripts vulnerable to XML external entity injection (also known as XXE)."""
 
     name = "xxe"

--- a/wapitiCore/main/wapiti.py
+++ b/wapitiCore/main/wapiti.py
@@ -93,7 +93,7 @@ def module_to_class_name(module_name: str) -> str:
     # We should use str.removeprefix when 3.7/3.8 support is removed
     if module_name.startswith("mod_"):
         module_name = module_name[4:]
-    return module_name.title().replace("_", "")
+    return "Module" + module_name.title().replace("_", "")
 
 
 class Wapiti:


### PR DESCRIPTION
Names of classes in attack modules are now CamelCase.

They are still named after the filename (see the new `module_to_class_name` function which converts from the module name to the matching class name)