### PR TITLE
Changed the pylint module to an anterior version due to a ModuleNotFoundError problem inside of it

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -18,8 +18,8 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install -e .
-          pip install pylint
-          pip install pylint-ignore
+          pip install "pylint==2.11.1"
+          pip install "pylint-ignore==2021.1020"
       - name: Pylint
         run: |
           pylint-ignore --rcfile=.pylintrc *.py wapitiCore


### PR DESCRIPTION
## Description

The CI has currently a problem due to the module `pylint` which has a ModuleNotFoundError inside of it. (https://github.com/wapiti-scanner/wapiti/runs/4351531830?check_suite_focus=true)
```txt
Traceback (most recent call last):
  File "/opt/hostedtoolcache/Python/3.9.9/x64/lib/python3.9/site-packages/pylint_ignore/__main__.py", line 44, in <module>
    from pylint.message.message_handler_mix_in import MessagesHandlerMixIn
ModuleNotFoundError: No module named 'pylint.message.message_handler_mix_in'
```
https://github.com/PyCQA/pylint/issues/5390  

To fix it, I have changed the `pylint` version to an anterior one.
