### PR TITLE
[INSTALL.md] fix activation command for bash/sh

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -36,7 +36,7 @@ python -m venv wapiti3
 Now let's activate it (make it our current working environment) :
  
 ```sh
-./wapiti3/bin/activate
+. wapiti3/bin/activate
 ```
 
 Or alternatively on Windows :


### PR DESCRIPTION
I noticed a little inaccuracy in the instructions about using a virtual Python environment, in the section about activating the venv.

Please see the commit message.

_Thank you for maintaining and sharing the fabulous Wapiti by the way !_