### PR TITLE
Add Django’s CSRF HTML form name to the token list

### DIFF
--- a/wapitiCore/attack/mod_csrf.py
+++ b/wapitiCore/attack/mod_csrf.py
@@ -46,7 +46,7 @@ class ModuleCsrf(Attack):
     TOKEN_FORM_STRINGS = [
         "authenticity_token", "_token", "csrf_token", "csrfname", "csrftoken", "anticsrf",
         "__requestverificationtoken", "token", "csrf", "_csrf_token", "xsrf_token",
-        "_csrf", "csrf-token", "xsrf-token", "_wpnonce"
+        "_csrf", "csrf-token", "xsrf-token", "_wpnonce", "csrfmiddlewaretoken"
     ]
 
     TOKEN_HEADER_STRINGS = [


### PR DESCRIPTION
Allow Wapiti to confirm Django has submitted the correct anti-CSRF form POST field.

This setting is not configurable within Django, so there’s no way for a developer to change the field’s name to match one of the tokens in the list.