### PR TITLE
Improved the Log4Shell module to attack Apache Solr

### DIFF
--- a/tests/attack/test_mod_log4shell.py
+++ b/tests/attack/test_mod_log4shell.py
@@ -285,9 +285,9 @@ async def test_attack():
 
         mock_open_headers.assert_called_once()
 
-        # vsphere case (2) + each header batch (10) + url case (1) + druid case (1)
-        assert crawler.async_send.call_count == 14
-        assert mock_verify_dns.call_count == 104
+        # vsphere case (2) + each header batch (10) + url case (1) + druid case (1) + solr case (1)
+        assert crawler.async_send.call_count == 15
+        assert mock_verify_dns.call_count == 105
 
 def test_init():
     persister = AsyncMock()


### PR DESCRIPTION
## Description
Improved the Log4Shell module to attack Apache Solr.
  
A docker has been created to test this feature.  
To run the server: `docker run -p 8080:8080 julientd/apache-solr-log4shell:latest` (it uses the version 8.9)
To run wapiti: `wapiti -u http://localhost:8983/ -m log4shell`

## Related Issue(s)
N/A