### PR TITLE
Fix drupal detection when return code is not 200

### DIFF
--- a/tests/attack/test_mod_drupal_enum.py
+++ b/tests/attack/test_mod_drupal_enum.py
@@ -57,7 +57,7 @@ async def test_version_detected():
         data = changelog.read()
 
     # Response to tell that Drupal is used
-    respx.get("http://perdu.com/sites/").mock(return_value=httpx.Response(403))
+    respx.get("http://perdu.com/sites/").mock(return_value=httpx.Response(200))
 
     # Response for changelog.txt
     respx.get("http://perdu.com/CHANGELOG.txt").mock(return_value=httpx.Response(200, text=data))
@@ -97,7 +97,7 @@ async def test_multi_versions_detected():
         data = maintainers.read()
 
     # Response to tell that Drupal is used
-    respx.get("http://perdu.com/sites/").mock(return_value=httpx.Response(403))
+    respx.get("http://perdu.com/sites/").mock(return_value=httpx.Response(200))
 
     # Response for  maintainers.txt
     respx.get("http://perdu.com/core/MAINTAINERS.txt").mock(return_value=httpx.Response(200, text=data))
@@ -136,7 +136,7 @@ async def test_version_not_detected():
         data = changelog.read()
 
     # Response to tell that Drupal is used
-    respx.get("http://perdu.com/sites/").mock(return_value=httpx.Response(403))
+    respx.get("http://perdu.com/sites/").mock(return_value=httpx.Response(200))
 
     # Response for edited changelog.txt
     respx.get("http://perdu.com/CHANGELOG.txt").mock(return_value=httpx.Response(200, text=data))

--- a/wapitiCore/attack/mod_drupal_enum.py
+++ b/wapitiCore/attack/mod_drupal_enum.py
@@ -118,7 +118,7 @@ class ModuleDrupalEnum(Attack):
             except Exception as exception:
                 logging.exception(exception)
             else:
-                if response.status != 404:
+                if response.status == 200:
                     return True
         return False
 


### PR DESCRIPTION
When the page tested returns anything but 200, the result should be ignored