### PR TITLE
Fixed the html_redirections function to adapt to every type of http-equiv meta tag and retrieve URLs

### DIFF
--- a/wapitiCore/net/page.py
+++ b/wapitiCore/net/page.py
@@ -700,10 +700,16 @@ class Page:
         urls = set()
         for meta_tag in self.soup.find_all("meta", attrs={"content": True, "http-equiv": True}):
             if meta_tag and meta_tag["http-equiv"].lower() == "refresh":
-                content_str = meta_tag["content"].lower()
-                url_eq_idx = content_str.find("url=")
+                content_str = meta_tag["content"]
+                content_str_length = len(meta_tag["content"])
+                url_eq_idx = content_str.lower().find("url=")
+
                 if url_eq_idx >= 0:
-                    url = meta_tag["content"][url_eq_idx + 4:]
+                    if content_str[url_eq_idx + 4] in ("\"", "'"):
+                        url_eq_idx += 1
+                        if content_str.endswith(("\"", "'")):
+                            content_str_length -= 1
+                    url = content_str[url_eq_idx + 4:content_str_length]
                     if url:
                         urls.add(self.make_absolute(url))
         return [url for url in urls if url]


### PR DESCRIPTION
## Description
Sometimes Wapiti crawls URLs in the meta tag, but the tag can be written in three different formats.  
Currently, we can only detect URLs with one specific formatting, and in this PR, I have added the two other types.  
  
The three types:  
The URL is written without any quotes. (already supported)
```html
    <!DOCTYPE html>
    <html>
        <head>
            <meta http-equiv="refresh" content="0;url=http://test.com/" />
            <title>Foobar</title>
        </head>
        <body>
            <h1>hello world</h1>
        </body>
    </html>
```
  
The URL is written with simple quotes. (added support in this pr)
```html
    <!DOCTYPE html>
    <html>
        <head>
            <meta http-equiv="refresh" content="0;url='http://test.com/'" />
            <title>Foobar</title>
        </head>
        <body>
            <h1>hello world</h1>
        </body>
    </html>
```
  
The URL is written with double quotes. (added support in this pr)
```html
    <!DOCTYPE html>
    <html>
        <head>
            <meta http-equiv="refresh" content='0;url="http://test.com/"' />
            <title>Foobar</title>
        </head>
        <body>
            <h1>hello world</h1>
        </body>
    </html>
```

## Related Issue(s)
N/A