### PR TITLE
Changed the payload type for the technology detection to addition instead of vulnerability

### DIFF
--- a/tests/attack/test_mod_drupal_enum.py
+++ b/tests/attack/test_mod_drupal_enum.py
@@ -10,6 +10,7 @@ import pytest
 from wapitiCore.net.web import Request
 from wapitiCore.net.crawler import AsyncCrawler
 from wapitiCore.attack.mod_drupal_enum import ModuleDrupalEnum
+from wapitiCore.language.vulnerability import _
 from tests import AsyncMock
 
 
@@ -77,10 +78,16 @@ async def test_version_detected():
 
     await module.attack(request)
 
-    assert persister.add_payload.call_count == 1
+    assert persister.add_payload.call_count == 2
     assert persister.add_payload.call_args_list[0][1]["module"] == "drupal_enum"
+    assert persister.add_payload.call_args_list[0][1]["category"] == _("Fingerprint web application framework")
     assert persister.add_payload.call_args_list[0][1]["info"] == (
-        '{"name": "Drupal", "versions": ["7.67"], "categories": ["CMS Drupal"]}'
+        '{"name": "Drupal", "versions": ["7.67"], "categories": ["CMS Drupal"], "groups": ["Content"]}'
+    )
+    assert persister.add_payload.call_args_list[1][1]["module"] == "drupal_enum"
+    assert persister.add_payload.call_args_list[1][1]["category"] == _("Fingerprint web technology")
+    assert persister.add_payload.call_args_list[1][1]["info"] == (
+        '{"name": "Drupal", "versions": ["7.67"], "categories": ["CMS Drupal"], "groups": ["Content"]}'
     )
     await crawler.close()
 
@@ -117,9 +124,12 @@ async def test_multi_versions_detected():
 
     await module.attack(request)
 
-    assert persister.add_payload.call_count == 1
+    assert persister.add_payload.call_count == 2
     assert persister.add_payload.call_args_list[0][1]["info"] == (
-        '{"name": "Drupal", "versions": ["8.0.0-beta4", "8.0.0-beta5", "8.0.0-beta6"], "categories": ["CMS Drupal"]}'
+        '{"name": "Drupal", "versions": ["8.0.0-beta4", "8.0.0-beta5", "8.0.0-beta6"], "categories": ["CMS Drupal"], "groups": ["Content"]}'
+    )
+    assert persister.add_payload.call_args_list[1][1]["info"] == (
+        '{"name": "Drupal", "versions": ["8.0.0-beta4", "8.0.0-beta5", "8.0.0-beta6"], "categories": ["CMS Drupal"], "groups": ["Content"]}'
     )
     await crawler.close()
 
@@ -158,6 +168,6 @@ async def test_version_not_detected():
 
     assert persister.add_payload.call_count == 1
     assert persister.add_payload.call_args_list[0][1]["info"] == (
-        '{"name": "Drupal", "versions": [""], "categories": ["CMS Drupal"]}'
+        '{"name": "Drupal", "versions": [], "categories": ["CMS Drupal"], "groups": ["Content"]}'
     )
     await crawler.close()

--- a/tests/attack/test_mod_wp_enum.py
+++ b/tests/attack/test_mod_wp_enum.py
@@ -109,16 +109,23 @@ async def test_plugin():
     await module.attack(request)
 
     assert persister.add_payload.call_count
+
     assert persister.add_payload.call_args_list[0][1]["module"] == "wp_enum"
     assert persister.add_payload.call_args_list[0][1]["category"] == _("Fingerprint web technology")
     assert persister.add_payload.call_args_list[0][1]["info"] == (
-        '{"name": "bbpress", "versions": ["2.6.6"], "categories": ["WordPress plugins"]}'
+        '{"name": "WordPress", "versions": [], "categories": ["CMS", "Blogs"], "groups": ["Content"]}'
     )
+
+    assert persister.add_payload.call_args_list[1][1]["module"] == "wp_enum"
+    assert persister.add_payload.call_args_list[1][1]["category"] == _("Fingerprint web technology")
     assert persister.add_payload.call_args_list[1][1]["info"] == (
-        '{"name": "wp-reset", "versions": [""], "categories": ["WordPress plugins"]}'
+        '{"name": "bbpress", "versions": ["2.6.6"], "categories": ["WordPress plugins"], "groups": ["Add-ons"]}'
     )
     assert persister.add_payload.call_args_list[2][1]["info"] == (
-        '{"name": "unyson", "versions": [""], "categories": ["WordPress plugins"]}'
+        '{"name": "wp-reset", "versions": [""], "categories": ["WordPress plugins"], "groups": ["Add-ons"]}'
+    )
+    assert persister.add_payload.call_args_list[3][1]["info"] == (
+        '{"name": "unyson", "versions": [""], "categories": ["WordPress plugins"], "groups": ["Add-ons"]}'
     )
     await crawler.close()
 
@@ -190,14 +197,14 @@ async def test_theme():
     await module.attack(request)
 
     assert persister.add_payload.call_count
-    assert persister.add_payload.call_args_list[0][1]["info"] == (
-        '{"name": "twentynineteen", "versions": ["1.9"], "categories": ["WordPress themes"]}'
-    )
     assert persister.add_payload.call_args_list[1][1]["info"] == (
-        '{"name": "seedlet", "versions": [""], "categories": ["WordPress themes"]}'
+        '{"name": "twentynineteen", "versions": ["1.9"], "categories": ["WordPress themes"], "groups": ["Add-ons"]}'
     )
     assert persister.add_payload.call_args_list[2][1]["info"] == (
-        '{"name": "customify", "versions": [""], "categories": ["WordPress themes"]}'
+        '{"name": "seedlet", "versions": [""], "categories": ["WordPress themes"], "groups": ["Add-ons"]}'
+    )
+    assert persister.add_payload.call_args_list[3][1]["info"] == (
+        '{"name": "customify", "versions": [""], "categories": ["WordPress themes"], "groups": ["Add-ons"]}'
     )
 
     await crawler.close()
@@ -244,9 +251,12 @@ async def test_wp_version():
 
         mock_detect_plugin.assert_called_once()
         mock_detect_theme.assert_called_once()
-        assert persister.add_payload.call_count == 1
+        assert persister.add_payload.call_count == 2
         assert persister.add_payload.call_args_list[0][1]["info"] == (
-            '{"name": "WordPress", "versions": ["5.8.2"], "categories": ["CMS", "Blogs"]}'
+            '{"name": "WordPress", "versions": ["5.8.2"], "categories": ["CMS", "Blogs"], "groups": ["Content"]}'
+        )
+        assert persister.add_payload.call_args_list[1][1]["info"] == (
+            '{"name": "WordPress", "versions": ["5.8.2"], "categories": ["CMS", "Blogs"], "groups": ["Content"]}'
         )
 
 @pytest.mark.asyncio
@@ -281,4 +291,4 @@ async def test_wp_version_no_file():
 
         mock_detect_plugin.assert_called_once()
         mock_detect_theme.assert_called_once()
-        assert persister.add_payload.call_count == 0
+        assert persister.add_payload.call_count == 1

--- a/wapitiCore/attack/mod_drupal_enum.py
+++ b/wapitiCore/attack/mod_drupal_enum.py
@@ -10,6 +10,7 @@ from httpx import RequestError
 from wapitiCore.net.web import Request
 from wapitiCore.attack.attack import Attack
 from wapitiCore.language.vulnerability import _
+from wapitiCore.definitions.fingerprint_webapp import NAME as WEB_APP_VERSIONED
 from wapitiCore.definitions.fingerprint import NAME as TECHNO_DETECTED, WSTG_CODE
 from wapitiCore.main.log import log_blue
 
@@ -137,17 +138,25 @@ class ModuleDrupalEnum(Attack):
 
         if await self.check_drupal(request_to_root.url):
             await self.detect_version(request_to_root.url)
-            self.versions = sorted(self.versions, key=lambda x: x.split('.')) if self.versions else [""]
+            self.versions = sorted(self.versions, key=lambda x: x.split('.')) if self.versions else []
             drupal_detected = {
                 "name": "Drupal",
                 "versions": self.versions,
-                "categories": ["CMS Drupal"]
+                "categories": ["CMS Drupal"],
+                "groups": ["Content"]
             }
             log_blue(
                 MSG_TECHNO_VERSIONED,
                 "Drupal",
                 self.versions
             )
+            if self.versions:
+                await self.add_vuln_info(
+                    category=WEB_APP_VERSIONED,
+                    request=request_to_root,
+                    info=json.dumps(drupal_detected),
+                    wstg=WSTG_CODE
+                )
             await self.add_addition(
                 category=TECHNO_DETECTED,
                 request=request_to_root,

--- a/wapitiCore/attack/mod_wp_enum.py
+++ b/wapitiCore/attack/mod_wp_enum.py
@@ -70,21 +70,26 @@ class ModuleWpEnum(Attack):
                 continue
             detected_version = version.group(1)
             break
-        if detected_version is None:
-            log_blue(
-                MSG_WP_VERSION,
-                "N/A"
-            )
-        else:
-            log_blue(
-                MSG_WP_VERSION,
-                detected_version
-            )
+
+        log_blue(
+            MSG_WP_VERSION,
+            detected_version or "N/A"
+        )
+        info_content = {"name": "WordPress", "versions": [], "categories": ["CMS", "Blogs"], "groups": ["Content"]}
+
+        if detected_version:
+            info_content["versions"].append(detected_version)
             await self.add_vuln_info(
                 category=WEB_APP_VERSIONED,
                 request=req,
-                info=json.dumps({"name": "WordPress", "versions": [detected_version], "categories": ["CMS", "Blogs"]})
+                info=json.dumps(info_content)
             )
+
+        await self.add_addition(
+            category=TECHNO_DETECTED,
+            request=req,
+            info=json.dumps(info_content)
+        )
 
     async def detect_plugin(self, url):
         for plugin in self.get_plugin():
@@ -107,7 +112,8 @@ class ModuleWpEnum(Attack):
                 plugin_detected = {
                     "name": plugin,
                     "versions": [version],
-                    "categories": ["WordPress plugins"]
+                    "categories": ["WordPress plugins"],
+                    "groups": ['Add-ons']
                 }
 
                 log_blue(
@@ -126,7 +132,8 @@ class ModuleWpEnum(Attack):
                 plugin_detected = {
                     "name": plugin,
                     "versions": [""],
-                    "categories": ["WordPress plugins"]
+                    "categories": ["WordPress plugins"],
+                    "groups": ['Add-ons']
                 }
                 log_blue(
                     MSG_TECHNO_VERSIONED,
@@ -157,7 +164,8 @@ class ModuleWpEnum(Attack):
                 theme_detected = {
                     "name": theme,
                     "versions": [version],
-                    "categories": ["WordPress themes"]
+                    "categories": ["WordPress themes"],
+                    "groups": ['Add-ons']
                 }
                 log_blue(
                     MSG_TECHNO_VERSIONED,
@@ -174,7 +182,8 @@ class ModuleWpEnum(Attack):
                 theme_detected = {
                     "name": theme,
                     "versions": [""],
-                    "categories": ["WordPress themes"]
+                    "categories": ["WordPress themes"],
+                    "groups": ['Add-ons']
                 }
                 log_blue(
                     MSG_TECHNO_VERSIONED,


### PR DESCRIPTION
## Description
Currently, when technology is found a vulnerability payload will be saved, but the problem is that some modules will save a payload as an addition, so for the same content, it will be split into two different categories.  
In this pull request, I have changed the type of payload for all the technology detection to an addition.
Also, when a version is found it is registered as a vulnerability, and when a technology is found it is registered as an addition.

## Related Issue(s)
N/A