### PR TITLE
Replaced hard-coded status code to a wrapper function

### DIFF
--- a/wapitiCore/attack/mod_backup.py
+++ b/wapitiCore/attack/mod_backup.py
@@ -61,7 +61,7 @@ class ModuleBackup(Attack):
                 # Do not put anything in false_positive_directories, another luck for next time
                 return False
 
-            self.false_positive_directories[request.dir_name] = (response and response.status == 200)
+            self.false_positive_directories[request.dir_name] = (response and response.is_success)
 
         return self.false_positive_directories[request.dir_name]
 
@@ -113,7 +113,7 @@ class ModuleBackup(Attack):
                 self.network_errors += 1
                 continue
 
-            if response and response.status == 200:
+            if response and response.is_success:
                 # FIXME: Right now we cannot remove the pylint: disable line because the current I18N system
                 # uses the string as a token so we cannot use f string
                 # pylint: disable=consider-using-f-string

--- a/wapitiCore/attack/mod_drupal_enum.py
+++ b/wapitiCore/attack/mod_drupal_enum.py
@@ -33,7 +33,7 @@ class ModuleDrupalEnum(Attack):
     async def get_url_hash(self, root_url: str, path: str) -> Tuple[str, str]:
         request = Request(f"{root_url}{path}")
         response = await self.crawler.async_get(request, follow_redirects=True)
-        if response.status != 200:
+        if response.is_error:
             return "", ""
 
         return hashlib.sha256(response.content.encode()).hexdigest(), path
@@ -118,7 +118,7 @@ class ModuleDrupalEnum(Attack):
             except Exception as exception:
                 logging.exception(exception)
             else:
-                if response.status == 200:
+                if response.is_success:
                     return True
         return False
 

--- a/wapitiCore/attack/mod_exec.py
+++ b/wapitiCore/attack/mod_exec.py
@@ -206,7 +206,7 @@ class ModuleExec(Attack):
                         vulnerable_parameter = True
                         continue
 
-                elif response.status == 500 and not saw_internal_error:
+                elif response.is_server_error and not saw_internal_error:
                     saw_internal_error = True
                     if parameter == "QUERY_STRING":
                         anom_msg = Messages.MSG_QS_500

--- a/wapitiCore/attack/mod_file.py
+++ b/wapitiCore/attack/mod_file.py
@@ -290,7 +290,7 @@ class ModuleFile(Attack):
                         vulnerable_parameter = True
                         continue
 
-                elif response.status == 500 and not saw_internal_error:
+                elif response.is_server_error and not saw_internal_error:
                     saw_internal_error = True
                     if parameter == "QUERY_STRING":
                         anom_msg = Messages.MSG_QS_500

--- a/wapitiCore/attack/mod_methods.py
+++ b/wapitiCore/attack/mod_methods.py
@@ -60,7 +60,7 @@ class ModuleMethods(Attack):
             self.network_errors += 1
             return
 
-        if 200 <= response.status < 400:
+        if response.is_success or response.is_redirect:
             methods = response.headers.get("allow", '').upper().split(',')
             methods = {method.strip() for method in methods if method.strip()}
             interesting_methods = sorted(methods - self.KNOWN_METHODS)

--- a/wapitiCore/attack/mod_permanentxss.py
+++ b/wapitiCore/attack/mod_permanentxss.py
@@ -269,7 +269,7 @@ class ModulePermanentxss(Attack):
                     continue
 
                 if (
-                        response.status not in (301, 302, 303) and
+                        not response.is_redirect and
                         valid_xss_content_type(evil_request) and
                         check_payload(
                             self.DATA_DIR,
@@ -331,7 +331,7 @@ class ModulePermanentxss(Attack):
 
                     # stop trying payloads and jump to the next parameter
                     break
-                if response.status == 500 and not saw_internal_error:
+                if response.is_server_error and not saw_internal_error:
                     if xss_param == "QUERY_STRING":
                         anom_msg = Messages.MSG_QS_500
                     else:

--- a/wapitiCore/attack/mod_sql.py
+++ b/wapitiCore/attack/mod_sql.py
@@ -380,7 +380,7 @@ class ModuleSql(Attack):
                     vulnerable_parameter = True
                     vulnerable_parameters.add(parameter)
 
-                elif response.status == 500 and not saw_internal_error:
+                elif response.is_server_error and not saw_internal_error:
                     saw_internal_error = True
                     if parameter == "QUERY_STRING":
                         anom_msg = Messages.MSG_QS_500

--- a/wapitiCore/attack/mod_takeover.py
+++ b/wapitiCore/attack/mod_takeover.py
@@ -114,7 +114,7 @@ class TakeoverChecker:
                             try:
                                 async with httpx.AsyncClient() as client:
                                     response = await client.head(f"https://github.com/{username}", timeout=10.)
-                                    if response.status_code == 404:
+                                    if response.is_client_error:
                                         return True
                             except httpx.RequestError:
                                 logging.warning(f"HTTP request to https://github.com/{username} failed")

--- a/wapitiCore/attack/mod_timesql.py
+++ b/wapitiCore/attack/mod_timesql.py
@@ -105,7 +105,7 @@ class ModuleTimesql(Attack):
                 self.network_errors += 1
                 continue
             else:
-                if response.status == 500 and not saw_internal_error:
+                if response.is_server_error and not saw_internal_error:
                     saw_internal_error = True
                     if parameter == "QUERY_STRING":
                         anom_msg = Messages.MSG_QS_500

--- a/wapitiCore/attack/mod_wp_enum.py
+++ b/wapitiCore/attack/mod_wp_enum.py
@@ -55,7 +55,7 @@ class ModuleWpEnum(Attack):
             req = Request(f"{url}{'' if url.endswith('/') else '/'}{rss_url}")
             rep: Page = await self.crawler.async_get(req, follow_redirects=True)
 
-            if not rep.content or rep.status != 200:
+            if not rep.content or rep.is_error:
                 continue
             root = ET.fromstring(rep.content)
 
@@ -94,7 +94,7 @@ class ModuleWpEnum(Attack):
             req = Request(f'{url}/wp-content/plugins/{plugin}/readme.txt')
             rep = await self.crawler.async_get(req)
 
-            if rep.status == 200:
+            if rep.is_success:
                 version = re.search(r'tag:\s*([\d.]+)', rep.content)
 
                 # This check was added to detect invalid format of "Readme.txt" who can cause a crashe
@@ -147,7 +147,7 @@ class ModuleWpEnum(Attack):
 
             req = Request(f'{url}/wp-content/themes/{theme}/readme.txt')
             rep = await self.crawler.async_get(req)
-            if rep.status == 200:
+            if rep.is_success:
                 version = re.search(r'tag:\s*([\d.]+)', rep.content)
                 # This check was added to detect invalid format of "Readme.txt" who can cause a crashe
                 if version:

--- a/wapitiCore/attack/mod_xss.py
+++ b/wapitiCore/attack/mod_xss.py
@@ -152,7 +152,7 @@ class ModuleXss(Attack):
                 self.network_errors += 1
             else:
                 if (
-                        response.status not in (301, 302, 303) and
+                        not response.is_redirect and
                         valid_xss_content_type(evil_request) and
                         check_payload(
                             self.DATA_DIR,
@@ -201,7 +201,7 @@ class ModuleXss(Attack):
                     # stop trying payloads and jump to the next parameter
                     break
 
-                if response.status == 500 and not saw_internal_error:
+                if response.is_server_error and not saw_internal_error:
                     if xss_param == "QUERY_STRING":
                         anom_msg = Messages.MSG_QS_500
                     else:

--- a/wapitiCore/attack/mod_xxe.py
+++ b/wapitiCore/attack/mod_xxe.py
@@ -207,7 +207,7 @@ class ModuleXxe(Attack):
                     vulnerable_parameter = True
                     continue
 
-                if response.status == 500 and not saw_internal_error:
+                if response.is_server_error and not saw_internal_error:
                     saw_internal_error = True
                     if parameter == "QUERY_STRING":
                         anom_msg = Messages.MSG_QS_500

--- a/wapitiCore/net/page.py
+++ b/wapitiCore/net/page.py
@@ -491,6 +491,44 @@ class Page:
         return not self.is_external_to_domain(url)
 
     @property
+    def is_success(self) -> bool:
+        """
+        A property which is `True` for 2xx status codes, `False` otherwise.
+        """
+        return self._response.is_success
+
+    @property
+    def is_redirect(self) -> bool:
+        """
+        A property which is `True` for 3xx status codes, `False` otherwise.
+
+        Note that not all responses with a 3xx status code indicate a URL redirect.
+
+        """
+        return self._response.is_redirect
+
+    @property
+    def is_client_error(self) -> bool:
+        """
+        A property which is `True` for 4xx status codes, `False` otherwise.
+        """
+        return self._response.is_client_error
+
+    @property
+    def is_server_error(self) -> bool:
+        """
+        A property which is `True` for 5xx status codes, `False` otherwise.
+        """
+        return self._response.is_server_error
+
+    @property
+    def is_error(self) -> bool:
+        """
+        A property which is `True` for 4xx and 5xx status codes, `False` otherwise.
+        """
+        return self._response.is_error
+
+    @property
     def title(self):
         """Returns the content of the title HTML tag"""
         if self.soup.head is not None:


### PR DESCRIPTION
## Description
Currently, Wapiti uses hardcoded status codes to verify if a request is successful or not.  
In this pull request, I have added 5 methods to determine if the status of a request is:  
- successful (2xx status codes)
- redirect (3xx status codes)
- error (4xx and 5xx status codes)
- client_error (4xx status codes)
- server_error (5xx status codes)

I have replaced these hardcoded status codes with these methods.

## Related Issue(s)
fixes #253 
