### PR TITLE
Drupal : retirer requêtes /sites /misc/test/error

### DIFF
--- a/tests/attack/test_mod_drupal_enum.py
+++ b/tests/attack/test_mod_drupal_enum.py
@@ -57,7 +57,7 @@ async def test_version_detected():
         data = changelog.read()
 
     # Response to tell that Drupal is used
-    respx.get("http://perdu.com/sites/").mock(return_value=httpx.Response(200))
+    respx.get("http://perdu.com/core/misc/drupal.js").mock(return_value=httpx.Response(200))
 
     # Response for changelog.txt
     respx.get("http://perdu.com/CHANGELOG.txt").mock(return_value=httpx.Response(200, text=data))
@@ -97,7 +97,7 @@ async def test_multi_versions_detected():
         data = maintainers.read()
 
     # Response to tell that Drupal is used
-    respx.get("http://perdu.com/sites/").mock(return_value=httpx.Response(200))
+    respx.get("http://perdu.com/core/misc/drupal.js").mock(return_value=httpx.Response(200))
 
     # Response for  maintainers.txt
     respx.get("http://perdu.com/core/MAINTAINERS.txt").mock(return_value=httpx.Response(200, text=data))
@@ -136,7 +136,7 @@ async def test_version_not_detected():
         data = changelog.read()
 
     # Response to tell that Drupal is used
-    respx.get("http://perdu.com/sites/").mock(return_value=httpx.Response(200))
+    respx.get("http://perdu.com/misc/drupal.js").mock(return_value=httpx.Response(200))
 
     # Response for edited changelog.txt
     respx.get("http://perdu.com/CHANGELOG.txt").mock(return_value=httpx.Response(200, text=data))

--- a/tests/attack/test_mod_drupal_enum.py
+++ b/tests/attack/test_mod_drupal_enum.py
@@ -26,6 +26,9 @@ async def test_no_drupal():
         )
     )
 
+    # Response to check that we have no more false positives
+    respx.get("http://perdu.com/core/misc/drupal.js").mock(return_value=httpx.Response(200))
+
     respx.get(url__regex=r"http://perdu.com/.*?").mock(return_value=httpx.Response(404))
 
     persister = AsyncMock()
@@ -57,7 +60,7 @@ async def test_version_detected():
         data = changelog.read()
 
     # Response to tell that Drupal is used
-    respx.get("http://perdu.com/core/misc/drupal.js").mock(return_value=httpx.Response(200))
+    respx.get("http://perdu.com/core/misc/drupal.js").mock(return_value=httpx.Response(200, headers={"Content-Type": "application/javascript"}))
 
     # Response for changelog.txt
     respx.get("http://perdu.com/CHANGELOG.txt").mock(return_value=httpx.Response(200, text=data))
@@ -97,7 +100,7 @@ async def test_multi_versions_detected():
         data = maintainers.read()
 
     # Response to tell that Drupal is used
-    respx.get("http://perdu.com/core/misc/drupal.js").mock(return_value=httpx.Response(200))
+    respx.get("http://perdu.com/core/misc/drupal.js").mock(return_value=httpx.Response(200, headers={"Content-Type": "application/javascript"}))
 
     # Response for  maintainers.txt
     respx.get("http://perdu.com/core/MAINTAINERS.txt").mock(return_value=httpx.Response(200, text=data))
@@ -136,7 +139,7 @@ async def test_version_not_detected():
         data = changelog.read()
 
     # Response to tell that Drupal is used
-    respx.get("http://perdu.com/misc/drupal.js").mock(return_value=httpx.Response(200))
+    respx.get("http://perdu.com/misc/drupal.js").mock(return_value=httpx.Response(200, headers={"Content-Type": "application/javascript"}))
 
     # Response for edited changelog.txt
     respx.get("http://perdu.com/CHANGELOG.txt").mock(return_value=httpx.Response(200, text=data))

--- a/wapitiCore/attack/mod_drupal_enum.py
+++ b/wapitiCore/attack/mod_drupal_enum.py
@@ -117,7 +117,11 @@ class ModuleDrupalEnum(Attack):
             except Exception as exception:
                 logging.exception(exception)
             else:
-                if response.is_success:
+                if (
+                    response.is_success
+                    and "content-type" in response.headers
+                    and "application/javascript" in response.headers["content-type"]
+                   ):
                     return True
         return False
 

--- a/wapitiCore/attack/mod_drupal_enum.py
+++ b/wapitiCore/attack/mod_drupal_enum.py
@@ -107,7 +107,7 @@ class ModuleDrupalEnum(Attack):
             self.versions = set.intersection(*[set(versions) for versions in versions.values()])
 
     async def check_drupal(self, url):
-        check_list = ['sites/', 'core/misc/drupal.js', 'misc/drupal.js', 'misc/test/error/404/ispresent.html']
+        check_list = ['core/misc/drupal.js', 'misc/drupal.js']
         for item in check_list:
             request = Request(f'{url}{item}')
             try:


### PR DESCRIPTION
Cette PR vise à limiter certains faux positifs que l'on récupère sur des sites qui acceptent les requêtes sur /sites et /misc/test/error, et qui nous font dire qu'on a du Drupal en face.

Or, c'est pas des éléments discriminants super pertinents, car en plus la plupart des sites Drupal bien configurés ont le /sites qui renvoie du 403.

Le plus propre est donc de se concentrer sur les fichiers JS où là un code 200 peut légitimer le fait de dire que c'est du Drupal.

Je vous laisse regarder le tout pour voir si mon interprétation est correcte :).

Si c'est le cas, alors je vous laisse faire les modifs éventuelles, et rebase + merger le tout !