### PR TITLE
Deprecate X-XSS-Protection header

### DIFF
--- a/wapitiCore/attack/mod_http_headers.py
+++ b/wapitiCore/attack/mod_http_headers.py
@@ -20,7 +20,7 @@ from httpx import RequestError
 from wapitiCore.attack.attack import Attack
 from wapitiCore.definitions.http_headers import (
     NAME, WSTG_CODE_CONTENT_TYPE_OPTIONS, WSTG_CODE_FRAME_OPTIONS,
-    WSTG_CODE_STRICT_TRANSPORT_SECURITY, WSTG_CODE_XSS_PROTECTION)
+    WSTG_CODE_STRICT_TRANSPORT_SECURITY)
 from wapitiCore.language.vulnerability import _
 from wapitiCore.main.log import log_blue, log_green, log_red
 from wapitiCore.net.page import Page
@@ -28,7 +28,6 @@ from wapitiCore.net.web import Request
 
 INFO_HSTS = _("Strict-Transport-Security is not set")
 INFO_XCONTENT_TYPE = _("X-Content-Type-Options is not set")
-INFO_XSS_PROTECTION = _("X-XSS-Protection is not set")
 INFO_XFRAME_OPTIONS = _("X-Frame-Options is not set")
 
 
@@ -36,7 +35,6 @@ class ModuleHttpHeaders(Attack):
     """Evaluate the security of HTTP headers."""
     name = "http_headers"
     check_list_xframe = ['deny', 'sameorigin', 'allow-from']
-    check_list_xss = ['1']
     check_list_xcontent = ['nosniff']
     check_list_hsts = ['max-age=']
 
@@ -46,12 +44,6 @@ class ModuleHttpHeaders(Attack):
             "info": INFO_XFRAME_OPTIONS,
             "log": _("Checking X-Frame-Options :"),
             "wstg": WSTG_CODE_FRAME_OPTIONS
-        },
-        "X-XSS-Protection": {
-            "list": check_list_xss,
-            "info": INFO_XSS_PROTECTION,
-            "log": _("Checking X-XSS-Protection :"),
-            "wstg": WSTG_CODE_XSS_PROTECTION
         },
         "X-Content-Type-Options": {
             "list": check_list_xcontent,

--- a/wapitiCore/definitions/http_headers.py
+++ b/wapitiCore/definitions/http_headers.py
@@ -46,6 +46,10 @@ SOLUTION = _(
 
 REFERENCES = [
     {
+        "title": "OWASP Secure Headers Project Best Practices",
+        "url": "https://owasp.org/www-project-secure-headers/#div-bestpractices"
+    },
+    {
         "title": "Netsparker: HTTP Security Headers: An Easy Way to Harden Your Web Applications",
         "url": "https://www.netsparker.com/blog/web-security/http-security-headers/"
     },


### PR DESCRIPTION
The X-XSS-Protection header has been deprecated.

This PR removes the associated check.