### PR TITLE
Ensure Persister and Crawler are initialized before updating modules

### DIFF
--- a/tests/cli/test_options.py
+++ b/tests/cli/test_options.py
@@ -1,10 +1,11 @@
+import sys
 from asyncio import Event
 from unittest import mock
 
 import pytest
 from wapitiCore.attack.attack import common_modules, all_modules, passive_modules
 from wapitiCore.net import Request
-from wapitiCore.main.wapiti import Wapiti
+from wapitiCore.main.wapiti import Wapiti, wapiti_main
 
 
 @pytest.mark.asyncio
@@ -86,3 +87,23 @@ async def test_options():
         await cli._init_attacks(stop_event)
         activated_modules = {module.name for module in cli.attacks if module.do_get or module.do_post}
         assert activated_modules == set(common_modules)
+
+@pytest.mark.asyncio
+@mock.patch("wapitiCore.main.wapiti.Wapiti.update")
+@mock.patch("sys.exit")
+async def test_update_with_modules(mock_update, _):
+    testargs = ["wapiti", "--update", "-m", "wapp,nikto"]
+    with mock.patch.object(sys, 'argv', testargs):
+        with mock.patch("wapitiCore.main.wapiti.Wapiti.update") as mock_update:
+            await wapiti_main()
+            mock_update.assert_called_once_with("wapp,nikto")
+
+@pytest.mark.asyncio
+@mock.patch("wapitiCore.main.wapiti.Wapiti.update")
+@mock.patch("sys.exit")
+async def test_update_without_modules(mock_update, _):
+    testargs = ["wapiti", "--update"]
+    with mock.patch.object(sys, 'argv', testargs):
+        with mock.patch("wapitiCore.main.wapiti.Wapiti.update") as mock_update:
+            await wapiti_main()
+            mock_update.assert_called_once_with(None)

--- a/wapitiCore/main/wapiti.py
+++ b/wapitiCore/main/wapiti.py
@@ -913,6 +913,8 @@ async def wapiti_main():
         wap.set_logfile(args.log)
 
     if args.update:
+        await wap.init_persister()
+        await wap.init_crawler()
         logging.log("GREEN", _("[*] Updating modules"))
         attack_options = {"level": args.level, "timeout": args.timeout}
         wap.set_attack_options(attack_options)


### PR DESCRIPTION
Running `wapiti --update` is failing because the persister and crawler are not initialized. This is an attempt to fix #305.

This PR must be merged after #306.