### PR TITLE
Fix crash when missing environment variables

### DIFF
--- a/tests/attack/test_mod_htp.py
+++ b/tests/attack/test_mod_htp.py
@@ -19,7 +19,7 @@ from wapitiCore.net import Request
 @respx.mock
 async def test_must_attack():
     persister = AsyncMock()
-    home_dir = os.getenv("HOME") or os.getenv("USERPROFILE")
+    home_dir = os.getenv("HOME") or os.getenv("USERPROFILE") or "/home"
     base_dir = os.path.join(home_dir, ".wapiti")
     persister.CONFIG_DIR = os.path.join(base_dir, "config")
 
@@ -46,7 +46,7 @@ async def test_analyze_file_detection():
     )
 
     persister = AsyncMock()
-    home_dir = os.getenv("HOME") or os.getenv("USERPROFILE")
+    home_dir = os.getenv("HOME") or os.getenv("USERPROFILE") or "/home"
     base_dir = os.path.join(home_dir, ".wapiti")
     persister.CONFIG_DIR = os.path.join(base_dir, "config")
 
@@ -80,7 +80,7 @@ async def test_analyze_file_no_detection():
     )
 
     persister = AsyncMock()
-    home_dir = os.getenv("HOME") or os.getenv("USERPROFILE")
+    home_dir = os.getenv("HOME") or os.getenv("USERPROFILE") or "/home"
     base_dir = os.path.join(home_dir, ".wapiti")
     persister.CONFIG_DIR = os.path.join(base_dir, "config")
 
@@ -105,7 +105,7 @@ async def test_analyze_file_none_content():
     )
 
     persister = AsyncMock()
-    home_dir = os.getenv("HOME") or os.getenv("USERPROFILE")
+    home_dir = os.getenv("HOME") or os.getenv("USERPROFILE") or "/home"
     base_dir = os.path.join(home_dir, ".wapiti")
     persister.CONFIG_DIR = os.path.join(base_dir, "config")
 
@@ -130,7 +130,7 @@ async def test_analyze_file_request_error():
     )
 
     persister = AsyncMock()
-    home_dir = os.getenv("HOME") or os.getenv("USERPROFILE")
+    home_dir = os.getenv("HOME") or os.getenv("USERPROFILE") or "/home"
     base_dir = os.path.join(home_dir, ".wapiti")
     persister.CONFIG_DIR = os.path.join(base_dir, "config")
 
@@ -159,7 +159,7 @@ async def test_finish_no_technologies():
     )
 
     persister = AsyncMock()
-    home_dir = os.getenv("HOME") or os.getenv("USERPROFILE")
+    home_dir = os.getenv("HOME") or os.getenv("USERPROFILE") or "/home"
     base_dir = os.path.join(home_dir, ".wapiti")
     persister.CONFIG_DIR = os.path.join(base_dir, "config")
 
@@ -190,7 +190,7 @@ async def test_finish_one_range():
     )
 
     persister = AsyncMock()
-    home_dir = os.getenv("HOME") or os.getenv("USERPROFILE")
+    home_dir = os.getenv("HOME") or os.getenv("USERPROFILE") or "/home"
     base_dir = os.path.join(home_dir, ".wapiti")
     persister.CONFIG_DIR = os.path.join(base_dir, "config")
     persister.get_root_url.return_value = "http://perdu.com/"
@@ -238,7 +238,7 @@ async def test_finish_two_ranges():
     )
 
     persister = AsyncMock()
-    home_dir = os.getenv("HOME") or os.getenv("USERPROFILE")
+    home_dir = os.getenv("HOME") or os.getenv("USERPROFILE") or "/home"
     base_dir = os.path.join(home_dir, ".wapiti")
     persister.CONFIG_DIR = os.path.join(base_dir, "config")
     persister.get_root_url.return_value = "http://perdu.com/"
@@ -287,7 +287,7 @@ async def test_root_attack_root_url():
     )
 
     persister = AsyncMock()
-    home_dir = os.getenv("HOME") or os.getenv("USERPROFILE")
+    home_dir = os.getenv("HOME") or os.getenv("USERPROFILE") or "/home"
     base_dir = os.path.join(home_dir, ".wapiti")
     persister.CONFIG_DIR = os.path.join(base_dir, "config")
     persister.get_root_url.return_value = "http://perdu.com/"
@@ -336,7 +336,7 @@ async def test_attack():
     )
 
     persister = AsyncMock()
-    home_dir = os.getenv("HOME") or os.getenv("USERPROFILE")
+    home_dir = os.getenv("HOME") or os.getenv("USERPROFILE") or "/home"
     base_dir = os.path.join(home_dir, ".wapiti")
     persister.CONFIG_DIR = os.path.join(base_dir, "config")
     persister.get_root_url.return_value = "http://perdu.com/"

--- a/tests/attack/test_mod_log4shell.py
+++ b/tests/attack/test_mod_log4shell.py
@@ -39,7 +39,7 @@ async def test_read_headers():
     }
 
     persister = AsyncMock()
-    home_dir = os.getenv("HOME") or os.getenv("USERPROFILE")
+    home_dir = os.getenv("HOME") or os.getenv("USERPROFILE") or "/home"
     base_dir = os.path.join(home_dir, ".wapiti")
     persister.CONFIG_DIR = os.path.join(base_dir, "config")
 
@@ -74,7 +74,7 @@ async def test_read_headers():
 async def test_get_batch_malicious_headers():
     persister = AsyncMock()
     persister.get_root_url.return_value = "http://perdu.com"
-    home_dir = os.getenv("HOME") or os.getenv("USERPROFILE")
+    home_dir = os.getenv("HOME") or os.getenv("USERPROFILE") or "/home"
     base_dir = os.path.join(home_dir, ".wapiti")
     persister.CONFIG_DIR = os.path.join(base_dir, "config")
 
@@ -108,7 +108,7 @@ async def test_verify_dns():
             self.strings = [str(response).lower().encode("utf-8")]
 
     persister = AsyncMock()
-    home_dir = os.getenv("HOME") or os.getenv("USERPROFILE")
+    home_dir = os.getenv("HOME") or os.getenv("USERPROFILE") or "/home"
     base_dir = os.path.join(home_dir, ".wapiti")
     persister.CONFIG_DIR = os.path.join(base_dir, "config")
 
@@ -133,7 +133,7 @@ async def test_verify_dns():
 @respx.mock
 async def test_is_valid_dns():
     persister = AsyncMock()
-    home_dir = os.getenv("HOME") or os.getenv("USERPROFILE")
+    home_dir = os.getenv("HOME") or os.getenv("USERPROFILE") or "/home"
     base_dir = os.path.join(home_dir, ".wapiti")
     persister.CONFIG_DIR = os.path.join(base_dir, "config")
 
@@ -171,7 +171,7 @@ async def test_verify_headers_vuln_found():
     # When a vuln has been found
     with patch.object(Request, "http_repr", autospec=True) as mock_http_repr:
         persister = AsyncMock()
-        home_dir = os.getenv("HOME") or os.getenv("USERPROFILE")
+        home_dir = os.getenv("HOME") or os.getenv("USERPROFILE") or "/home"
         base_dir = os.path.join(home_dir, ".wapiti")
         persister.CONFIG_DIR = os.path.join(base_dir, "config")
 
@@ -220,7 +220,7 @@ async def test_verify_headers_vuln_not_found():
     with patch.object(Request, "http_repr", autospec=True) as mock_http_repr:
 
         persister = AsyncMock()
-        home_dir = os.getenv("HOME") or os.getenv("USERPROFILE")
+        home_dir = os.getenv("HOME") or os.getenv("USERPROFILE") or "/home"
         base_dir = os.path.join(home_dir, ".wapiti")
         persister.CONFIG_DIR = os.path.join(base_dir, "config")
 
@@ -250,7 +250,7 @@ async def test_verify_headers_vuln_not_found():
 @respx.mock
 async def test_must_attack():
     persister = AsyncMock()
-    home_dir = os.getenv("HOME") or os.getenv("USERPROFILE")
+    home_dir = os.getenv("HOME") or os.getenv("USERPROFILE") or "/home"
     base_dir = os.path.join(home_dir, ".wapiti")
     persister.CONFIG_DIR = os.path.join(base_dir, "config")
 
@@ -281,7 +281,7 @@ async def test_attack():
 
     persister = AsyncMock()
     persister.get_root_url.return_value = "http://perdu.com/"
-    home_dir = os.getenv("HOME") or os.getenv("USERPROFILE")
+    home_dir = os.getenv("HOME") or os.getenv("USERPROFILE") or "/home"
     base_dir = os.path.join(home_dir, ".wapiti")
     persister.CONFIG_DIR = os.path.join(base_dir, "config")
 
@@ -313,7 +313,7 @@ async def test_attack():
 
 def test_init():
     persister = AsyncMock()
-    home_dir = os.getenv("HOME") or os.getenv("USERPROFILE")
+    home_dir = os.getenv("HOME") or os.getenv("USERPROFILE") or "/home"
     base_dir = os.path.join(home_dir, ".wapiti")
     persister.CONFIG_DIR = os.path.join(base_dir, "config")
 
@@ -348,7 +348,7 @@ def test_init():
 @respx.mock
 async def test_attack_apache_struts():
     persister = AsyncMock()
-    home_dir = os.getenv("HOME") or os.getenv("USERPROFILE")
+    home_dir = os.getenv("HOME") or os.getenv("USERPROFILE") or "/home"
     base_dir = os.path.join(home_dir, ".wapiti")
     persister.CONFIG_DIR = os.path.join(base_dir, "config")
 
@@ -378,7 +378,7 @@ async def test_attack_apache_struts():
 @respx.mock
 async def test_attack_apache_druid():
     persister = AsyncMock()
-    home_dir = os.getenv("HOME") or os.getenv("USERPROFILE")
+    home_dir = os.getenv("HOME") or os.getenv("USERPROFILE") or "/home"
     base_dir = os.path.join(home_dir, ".wapiti")
     persister.CONFIG_DIR = os.path.join(base_dir, "config")
 

--- a/tests/attack/test_mod_nikto.py
+++ b/tests/attack/test_mod_nikto.py
@@ -29,7 +29,7 @@ async def test_whole_stuff():
     )
 
     persister = AsyncMock()
-    home_dir = os.getenv("HOME") or os.getenv("USERPROFILE")
+    home_dir = os.getenv("HOME") or os.getenv("USERPROFILE") or "/home"
     base_dir = os.path.join(home_dir, ".wapiti")
     persister.CONFIG_DIR = os.path.join(base_dir, "config")
 
@@ -71,7 +71,7 @@ async def test_false_positives():
     )
 
     persister = AsyncMock()
-    home_dir = os.getenv("HOME") or os.getenv("USERPROFILE")
+    home_dir = os.getenv("HOME") or os.getenv("USERPROFILE") or "/home"
     base_dir = os.path.join(home_dir, ".wapiti")
     persister.CONFIG_DIR = os.path.join(base_dir, "config")
 

--- a/tests/attack/test_mod_wapp.py
+++ b/tests/attack/test_mod_wapp.py
@@ -28,7 +28,7 @@ async def test_false_positive():
     )
 
     persister = AsyncMock()
-    home_dir = os.getenv("HOME") or os.getenv("USERPROFILE")
+    home_dir = os.getenv("HOME") or os.getenv("USERPROFILE") or "/home"
     base_dir = os.path.join(home_dir, ".wapiti")
     persister.CONFIG_DIR = os.path.join(base_dir, "config")
 
@@ -60,7 +60,7 @@ async def test_url_detection():
     )
 
     persister = AsyncMock()
-    home_dir = os.getenv("HOME") or os.getenv("USERPROFILE")
+    home_dir = os.getenv("HOME") or os.getenv("USERPROFILE") or "/home"
     base_dir = os.path.join(home_dir, ".wapiti")
     persister.CONFIG_DIR = os.path.join(base_dir, "config")
 
@@ -110,7 +110,7 @@ async def test_html_detection():
     )
 
     persister = AsyncMock()
-    home_dir = os.getenv("HOME") or os.getenv("USERPROFILE")
+    home_dir = os.getenv("HOME") or os.getenv("USERPROFILE") or "/home"
     base_dir = os.path.join(home_dir, ".wapiti")
     persister.CONFIG_DIR = os.path.join(base_dir, "config")
 
@@ -147,7 +147,7 @@ async def test_script_detection():
     )
 
     persister = AsyncMock()
-    home_dir = os.getenv("HOME") or os.getenv("USERPROFILE")
+    home_dir = os.getenv("HOME") or os.getenv("USERPROFILE") or "/home"
     base_dir = os.path.join(home_dir, ".wapiti")
     persister.CONFIG_DIR = os.path.join(base_dir, "config")
 
@@ -184,7 +184,7 @@ async def test_cookies_detection():
     )
 
     persister = AsyncMock()
-    home_dir = os.getenv("HOME") or os.getenv("USERPROFILE")
+    home_dir = os.getenv("HOME") or os.getenv("USERPROFILE") or "/home"
     base_dir = os.path.join(home_dir, ".wapiti")
     persister.CONFIG_DIR = os.path.join(base_dir, "config")
 
@@ -221,7 +221,7 @@ async def test_headers_detection():
     )
 
     persister = AsyncMock()
-    home_dir = os.getenv("HOME") or os.getenv("USERPROFILE")
+    home_dir = os.getenv("HOME") or os.getenv("USERPROFILE") or "/home"
     base_dir = os.path.join(home_dir, ".wapiti")
     persister.CONFIG_DIR = os.path.join(base_dir, "config")
 
@@ -259,7 +259,7 @@ async def test_meta_detection():
     )
 
     persister = AsyncMock()
-    home_dir = os.getenv("HOME") or os.getenv("USERPROFILE")
+    home_dir = os.getenv("HOME") or os.getenv("USERPROFILE") or "/home"
     base_dir = os.path.join(home_dir, ".wapiti")
     persister.CONFIG_DIR = os.path.join(base_dir, "config")
 
@@ -299,7 +299,7 @@ async def test_multi_detection():
     )
 
     persister = AsyncMock()
-    home_dir = os.getenv("HOME") or os.getenv("USERPROFILE")
+    home_dir = os.getenv("HOME") or os.getenv("USERPROFILE") or "/home"
     base_dir = os.path.join(home_dir, ".wapiti")
     persister.CONFIG_DIR = os.path.join(base_dir, "config")
 
@@ -336,7 +336,7 @@ async def test_implies_detection():
     )
 
     persister = AsyncMock()
-    home_dir = os.getenv("HOME") or os.getenv("USERPROFILE")
+    home_dir = os.getenv("HOME") or os.getenv("USERPROFILE") or "/home"
     base_dir = os.path.join(home_dir, ".wapiti")
     persister.CONFIG_DIR = os.path.join(base_dir, "config")
 
@@ -376,7 +376,7 @@ async def test_vulnerabilities():
     )
 
     persister = AsyncMock()
-    home_dir = os.getenv("HOME") or os.getenv("USERPROFILE")
+    home_dir = os.getenv("HOME") or os.getenv("USERPROFILE") or "/home"
     base_dir = os.path.join(home_dir, ".wapiti")
     persister.CONFIG_DIR = os.path.join(base_dir, "config")
 
@@ -431,7 +431,7 @@ async def test_merge_with_and_without_redirection():
     )
 
     persister = AsyncMock()
-    home_dir = os.getenv("HOME") or os.getenv("USERPROFILE")
+    home_dir = os.getenv("HOME") or os.getenv("USERPROFILE") or "/home"
     base_dir = os.path.join(home_dir, ".wapiti")
     persister.CONFIG_DIR = os.path.join(base_dir, "config")
 

--- a/wapitiCore/attack/attack.py
+++ b/wapitiCore/attack/attack.py
@@ -210,7 +210,7 @@ class Attack:
     require = []
 
     DATA_DIR = resource_filename("wapitiCore", os.path.join("data", "attacks"))
-    HOME_DIR = os.getenv("HOME") or os.getenv("USERPROFILE")
+    HOME_DIR = os.getenv("HOME") or os.getenv("USERPROFILE") or "home"
 
     PAYLOADS_FILE = None
 

--- a/wapitiCore/main/wapiti.py
+++ b/wapitiCore/main/wapiti.py
@@ -171,7 +171,7 @@ class Wapiti:
     Launch wapiti without arguments or with the "-h" option for more information."""
 
     REPORT_DIR = "report"
-    HOME_DIR = os.getenv("HOME") or os.getenv("USERPROFILE")
+    HOME_DIR = os.getenv("HOME") or os.getenv("USERPROFILE") or "/home"
     COPY_REPORT_DIR = os.path.join(HOME_DIR, ".wapiti", "generated_report")
 
     def __init__(self, scope_request: Request, scope="folder", session_dir=None, config_dir=None):

--- a/wapitiCore/net/sql_persister.py
+++ b/wapitiCore/net/sql_persister.py
@@ -39,7 +39,7 @@ class SqlPersister:
 
     CRAWLER_DATA_DIR_NAME = "scans"
     CONFIG_DIR_NAME = "config"
-    HOME_DIR = os.getenv("HOME") or os.getenv("USERPROFILE")
+    HOME_DIR = os.getenv("HOME") or os.getenv("USERPROFILE") or "/home"
     BASE_DIR = os.path.join(HOME_DIR, ".wapiti")
     CRAWLER_DATA_DIR = os.path.join(BASE_DIR, CRAWLER_DATA_DIR_NAME)
     CONFIG_DIR = os.path.join(BASE_DIR, CONFIG_DIR_NAME)

--- a/wapitiCore/wappalyzer/wappalyzer.py
+++ b/wapitiCore/wappalyzer/wappalyzer.py
@@ -25,7 +25,7 @@ class ApplicationData:
         """
         Initialize a new ApplicationData object.
         """
-        base_dir = os.path.join(os.getenv("HOME") or os.getenv("USERPROFILE"), ".wapiti")
+        base_dir = os.path.join(os.getenv("HOME") or os.getenv("USERPROFILE") or "/home", ".wapiti")
         default_categories_file_path = os.path.join(base_dir, "wappalyzer", "data/categories.json")
         default_groups_file_path = os.path.join(base_dir, "wappalyzer", "data/groups.json")
         default_technologies_file_path = os.path.join(base_dir, "wappalyzer", "data/technologies.json")


### PR DESCRIPTION
Fixes crash when wapiti is called without `HOME` and `USERPROFILE` environment variables. It is caused by `os.path.joins` when a home directory is None.

Reproduce using: `env -i wapiti --version` > gives error

It can be resolved by providing HOME environment variable such as:

`env -i HOME=/root wapiti --version` > prints version.

Environment variables can be missing due to different isolation approaches such as a slim Docker image or an isolated shell.

This PR/commit fixes the issue by defaulting to `/home` directory that's Linux/Unix standard when an environment variable is missing. This way the crash is avoided.