### PR TITLE
Feature/openredirect doubleslash

### DIFF
--- a/tests/attack/test_mod_redirect.py
+++ b/tests/attack/test_mod_redirect.py
@@ -46,6 +46,24 @@ async def test_redirect_detection():
         ]
 
 
+
+@pytest.mark.asyncio
+async def test_redirect_detection_no_url():
+    persister = AsyncMock()
+    request = Request("http://127.0.0.1:65080/open_redirect_nourl.php?url=toto")
+    crawler_configuration = CrawlerConfiguration(Request("http://127.0.0.1:65080/"), timeout=1)
+    async with AsyncCrawler.with_configuration(crawler_configuration) as crawler:
+        options = {"timeout": 10, "level": 2}
+
+        module = ModuleRedirect(crawler, persister, options, Event())
+        await module.attack(request)
+
+        assert persister.add_payload.call_args_list[0][1]["module"] == "redirect"
+        assert persister.add_payload.call_args_list[0][1]["category"] == _("Open Redirect")
+        assert persister.add_payload.call_args_list[0][1]["request"].get_params == [
+            ['url', '//openbugbounty.org/']
+        ]
+
 @pytest.mark.asyncio
 @respx.mock
 async def test_whole_stuff():

--- a/tests/attack/test_mod_redirect.py
+++ b/tests/attack/test_mod_redirect.py
@@ -46,7 +46,6 @@ async def test_redirect_detection():
         ]
 
 
-
 @pytest.mark.asyncio
 async def test_redirect_detection_no_url():
     persister = AsyncMock()
@@ -55,7 +54,7 @@ async def test_redirect_detection_no_url():
     async with AsyncCrawler.with_configuration(crawler_configuration) as crawler:
         options = {"timeout": 10, "level": 2}
 
-        module = ModuleRedirect(crawler, persister, options, Event())
+        module = ModuleRedirect(crawler, persister, options, Event(), crawler_configuration)
         await module.attack(request)
 
         assert persister.add_payload.call_args_list[0][1]["module"] == "redirect"
@@ -63,6 +62,7 @@ async def test_redirect_detection_no_url():
         assert persister.add_payload.call_args_list[0][1]["request"].get_params == [
             ['url', '//openbugbounty.org/']
         ]
+
 
 @pytest.mark.asyncio
 @respx.mock

--- a/tests/data/open_redirect_nourl.php
+++ b/tests/data/open_redirect_nourl.php
@@ -1,0 +1,9 @@
+<?php
+//urls are not allowed on redirect
+if (isset($_GET["url"]) && filter_var($_GET['url'], FILTER_VALIDATE_URL) === false)
+    $url = $_GET["url"];
+else
+    $url = "/";
+header("location: ".$url);
+echo "plop";
+?>

--- a/wapitiCore/attack/mod_redirect.py
+++ b/wapitiCore/attack/mod_redirect.py
@@ -17,6 +17,7 @@
 # along with this program; if not, write to the Free Software
 # Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 from typing import Optional
+from urllib.parse import urlparse
 
 from httpx import RequestError
 
@@ -36,7 +37,7 @@ class ModuleRedirect(Attack):
     MSG_VULN = _("Open Redirect")
     do_get = True
     do_post = False
-    payloads = ("https://openbugbounty.org/", Flags())
+    payloads = [("https://openbugbounty.org/", Flags()), ("//openbugbounty.org/", Flags())]
 
     def __init__(self, crawler, persister, attack_options, stop_event, crawler_configuration):
         super().__init__(crawler, persister, attack_options, stop_event, crawler_configuration)
@@ -56,7 +57,7 @@ class ModuleRedirect(Attack):
 
             html = Html(response.content, mutated_request.url)
             all_redirections = {response.redirection_url} | html.all_redirections
-            if any(url.startswith("https://openbugbounty.org/") for url in all_redirections):
+            if any(urlparse(url).netloc.endswith("openbugbounty.org") for url in all_redirections):
                 await self.add_vuln_low(
                     request_id=request.path_id,
                     category=NAME,


### PR DESCRIPTION
Detect open redirects when full urls with schema are not allowed, this uses //openbugbounty.org as a payload.

The detection mechanism had to be updated because when the scanned site is HTTP, the redirect will also be to HTTP and  if we only check HTTPS://openbugbounty.org it will not detect the openredirect.

Test cases added