### PR TITLE
Update Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,8 +12,6 @@ RUN apt update \
   && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* \
   && truncate -s 0 /var/log/*log
 
-RUN pip3 install pyasn1 
-
 COPY . .
 
 RUN python3 setup.py install

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,6 +12,8 @@ RUN apt update \
   && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* \
   && truncate -s 0 /var/log/*log
 
+RUN pip3 install pyasn1 
+
 COPY . .
 
 RUN python3 setup.py install

--- a/setup.py
+++ b/setup.py
@@ -122,6 +122,7 @@ if a script is vulnerable.""",
         "httpcore>=0.15.0",
         "mitmproxy==8.0.0",
         "h11==0.12",
+        "pyasn1==0.4.8"
     ],
     extras_require={
         "NTLM": ["httpx-ntlm"],


### PR DESCRIPTION
Solve this error `ImportError: cannot import name 'tagMap' from 'pyasn1.codec.ber.encoder' (/usr/local/lib/python3.9/dist-packages/pyasn1-0.5.0rc1-py3.9.egg/pyasn1/codec/ber/encoder.py)` when build and running from Dockerfile

```
Traceback (most recent call last):
  File "/usr/local/bin/wapiti", line 33, in <module>
    sys.exit(load_entry_point('wapiti3==3.1.3', 'console_scripts', 'wapiti')())
  File "/usr/local/bin/wapiti", line 25, in importlib_load_entry_point
    return next(matches).load()
  File "/usr/lib/python3.9/importlib/metadata.py", line 77, in load
    module = import_module(match.group('module'))
  File "/usr/lib/python3.9/importlib/__init__.py", line 127, in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
  File "<frozen importlib._bootstrap>", line 1030, in _gcd_import
  File "<frozen importlib._bootstrap>", line 1007, in _find_and_load
  File "<frozen importlib._bootstrap>", line 986, in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 680, in _load_unlocked
  File "<frozen importlib._bootstrap_external>", line 790, in exec_module
  File "<frozen importlib._bootstrap>", line 228, in _call_with_frames_removed
  File "/usr/local/lib/python3.9/dist-packages/wapiti3-3.1.3-py3.9.egg/wapitiCore/main/wapiti.py", line 51, in <module>
    from wapitiCore.net.intercepting_explorer import InterceptingExplorer
  File "/usr/local/lib/python3.9/dist-packages/wapiti3-3.1.3-py3.9.egg/wapitiCore/net/intercepting_explorer.py", line 23, in <module>
    from mitmproxy import addons
  File "/usr/local/lib/python3.9/dist-packages/mitmproxy-8.0.0-py3.9.egg/mitmproxy/addons/__init__.py", line 16, in <module>
    from mitmproxy.addons import proxyauth
  File "/usr/local/lib/python3.9/dist-packages/mitmproxy-8.0.0-py3.9.egg/mitmproxy/addons/proxyauth.py", line 10, in <module>
    import ldap3
  File "/usr/local/lib/python3.9/dist-packages/ldap3-2.9.1-py3.9.egg/ldap3/__init__.py", line 141, in <module>
    from .core.connection import Connection
  File "/usr/local/lib/python3.9/dist-packages/ldap3-2.9.1-py3.9.egg/ldap3/core/connection.py", line 38, in <module>
    from ..extend import ExtendedOperationsRoot
  File "/usr/local/lib/python3.9/dist-packages/ldap3-2.9.1-py3.9.egg/ldap3/extend/__init__.py", line 29, in <module>
    from .microsoft.dirSync import DirSync
  File "/usr/local/lib/python3.9/dist-packages/ldap3-2.9.1-py3.9.egg/ldap3/extend/microsoft/dirSync.py", line 27, in <module>
    from ...protocol.microsoft import dir_sync_control, extended_dn_control, show_deleted_control
  File "/usr/local/lib/python3.9/dist-packages/ldap3-2.9.1-py3.9.egg/ldap3/protocol/microsoft.py", line 32, in <module>
    from .controls import build_control
  File "/usr/local/lib/python3.9/dist-packages/ldap3-2.9.1-py3.9.egg/ldap3/protocol/controls.py", line 27, in <module>
    from ..utils.asn1 import encode
  File "/usr/local/lib/python3.9/dist-packages/ldap3-2.9.1-py3.9.egg/ldap3/utils/asn1.py", line 50, in <module>
    from pyasn1.codec.ber.encoder import tagMap, typeMap, AbstractItemEncoder
ImportError: cannot import name 'tagMap' from 'pyasn1.codec.ber.encoder' (/usr/local/lib/python3.9/dist-packages/pyasn1-0.5.0rc1-py3.9.egg/pyasn1/codec/ber/encoder.py)
```