### PR TITLE
Add headless Dockerfile

### DIFF
--- a/Dockerfile.headless
+++ b/Dockerfile.headless
@@ -1,0 +1,56 @@
+FROM debian:bullseye-slim as build
+
+ENV DEBIAN_FRONTEND=noninteractive \
+  LANG=en_US.UTF-8
+
+WORKDIR /usr/src/app
+
+RUN apt update \
+  && apt install python3 python3-pip python3-setuptools ca-certificates -y \
+  && apt clean -yq \
+  && apt autoremove -yq \
+  && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* \
+  && truncate -s 0 /var/log/*log
+
+COPY . .
+
+RUN python3 setup.py install
+
+FROM debian:bullseye-slim
+
+ARG firefox_ver=105.0
+ARG geckodriver_ver=0.31.0
+ARG build_rev=0
+
+ENV DEBIAN_FRONTEND=noninteractive \
+  LANG=en_US.UTF-8 \
+  PYTHONDONTWRITEBYTECODE=1 \
+  PATH=$PATH:/opt/firefox
+
+RUN apt update \
+  && apt install python3 python3-setuptools curl bzip2 -y \
+  && apt-get install -y --no-install-recommends --no-install-suggests \
+    `apt-cache depends firefox-esr | awk '/Depends:/{print$2}'` \
+    # additional 'firefox-esl' dependencies which is not in 'depends' list
+    libasound2 libxt6 libxtst6 \
+  && apt clean -yq \
+  && apt autoremove -yq \
+  && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* \
+  && truncate -s 0 /var/log/*log
+
+RUN curl -fL -o /tmp/firefox.tar.bz2 \
+         https://ftp.mozilla.org/pub/firefox/releases/${firefox_ver}/linux-x86_64/en-GB/firefox-${firefox_ver}.tar.bz2 \
+ && tar -xjf /tmp/firefox.tar.bz2 -C /tmp/ \
+ && mv /tmp/firefox /opt/firefox \
+    \
+ # Download and install geckodriver
+ && curl -fL -o /tmp/geckodriver.tar.gz \
+         https://github.com/mozilla/geckodriver/releases/download/v${geckodriver_ver}/geckodriver-v${geckodriver_ver}-linux64.tar.gz \
+ && tar -xzf /tmp/geckodriver.tar.gz -C /tmp/ \
+ && chmod +x /tmp/geckodriver \
+ && mv /tmp/geckodriver /usr/local/bin/
+
+COPY --from=build /usr/local/lib/python3.9/dist-packages/ /usr/local/lib/python3.9/dist-packages/
+COPY --from=build /usr/local/bin/wapiti /usr/local/bin/wapiti-getcookie /usr/local/bin/
+
+ENTRYPOINT ["wapiti"]


### PR DESCRIPTION
The current docker image at https://hub.docker.com/r/cyberwatch/wapiti cannot use the new `--headless` flag because firefox and firefox-geckodriver are required.

I tried to update the current Dockerfile to install both firefox and firefox-geckodriver, but the size of the image went from 190MB to 650MB. Instead, this PR adds a Dockerfile dedicated to build a wapiti image that supports headless mode.

This has been tested by running the following command with the build image:

```sh
docker run wapiti -u http://angular.testsparker.com/ -m "sql" -v 2 --store-session=sessions/ --store-config=sessions/ --flush-session --color --headless hidden
```

Closes #320 