### PR TITLE
Plugin mechanism to support custom and/or complicated website authentication

### DIFF
--- a/wapitiCore/main/wapiti.py
+++ b/wapitiCore/main/wapiti.py
@@ -52,7 +52,7 @@ from wapitiCore.net import jsoncookie
 from wapitiCore.net.crawler import AsyncCrawler
 from wapitiCore.net.crawler_configuration import CrawlerConfiguration
 from wapitiCore.net.intercepting_explorer import InterceptingExplorer
-from wapitiCore.net.auth import async_try_login
+from wapitiCore.net.auth import async_try_login, load_auth_script
 from wapitiCore.net.explorer import Explorer
 from wapitiCore.net.sql_persister import SqlPersister
 from wapitiCore.net import Request, Response
@@ -1150,6 +1150,9 @@ async def wapiti_main():
                     wap.set_auth_state(is_logged_in, form, auth_url, args.auth_type)
                     for url in excluded_urls:
                         wap.add_excluded_url(url)
+
+                if "auth_script" in args:
+                    await load_auth_script(args.auth_script, wap.crawler_configuration, auth_url, args.headless)
 
                 await wap.load_scan_state()
                 loop.add_signal_handler(signal.SIGINT, inner_ctrl_c_signal_handler)

--- a/wapitiCore/net/auth.py
+++ b/wapitiCore/net/auth.py
@@ -189,7 +189,7 @@ async def load_auth_script(
     try:
         await module.run(crawler_configuration, auth_url, headless)
     except AttributeError:
-        logging.error(f"run() method seems to be missing in your auth script")
+        logging.error("run() method seems to be missing in your auth script")
         sys.exit(1)
     except TypeError as exception:
-        raise RuntimeError(f"The provided auth script seems to have some syntax issues") from exception
+        raise RuntimeError("The provided auth script seems to have some syntax issues") from exception

--- a/wapitiCore/parsers/commandline.py
+++ b/wapitiCore/parsers/commandline.py
@@ -111,6 +111,14 @@ def parse_args():
     )
 
     parser.add_argument(
+        "--auth-script",
+        dest="auth_script",
+        default=argparse.SUPPRESS,
+        help=_("Use a custom Python authentication plugin"),
+        metavar="FILENAME"
+    )
+
+    parser.add_argument(
         "-c", "--cookie",
         help=_("Set a JSON cookie file to use.") + " " + _(
             "You can also pass 'firefox' or 'chrome' to load cookies from your browser."


### PR DESCRIPTION
Some web authentication mechanisms rely on using tokens received from xml/json responses or set using javascript.

Some websites also may ask for human validation (solving a captcha, giving the answer to a simple question, etc)

Even if a focus is made to improve authentication, Wapiti will never be able to support all auth mechanisms hence the need of providing a way for users to bring their own auth scripts to Wapiti.

The way it works is:
- specify a Python script using `--auth-script` option
- the script must have an async function called run with the following prototype:

```python
async def run(crawler_configuration: CrawlerConfiguration, auth_url: str, headless: str = "no")
```

It is up to the script to do whatever it needs to solve the authentication.

At the end, the script should overwrite some values on the `CrawlerConfiguration` object so Wapiti can use the data (tokens, custom headers, cookies, etc) that were obtained.

Here is an example of an auth script to login on juice-shop (do not reuse the script as is because credentials may expire) :

```python
import json                                                                                                            
from http.cookiejar import Cookie                                                                                      
                                                                                                                       
from wapitiCore.net import Request                                                                                     
from wapitiCore.net.crawler import AsyncCrawler                                                                        
from wapitiCore.net.crawler_configuration import CrawlerConfiguration                                                  
                                                                                                                       
async def run(crawler_configuration: CrawlerConfiguration, auth_url: str, headless: str = "no"):                       
    # Instantiate an AsyncCrawler                                                                                      
    async with AsyncCrawler.with_configuration(crawler_configuration) as crawler:                                      
        # Forge the login request                                                                                      
        request = Request(                                                                                             
                "https://juice-shop.herokuapp.com/rest/user/login",                                                    
                post_params='{"email":"toto@toto.com","password":"123456"}',                                           
                enctype="application/json"                                                                             
        )                                                                                                              
        # Send it                                                                                                      
        response = await crawler.async_post(request)                                                                   
        data = response.json                                                                                           
        if not data:                                                                                                   
            print("authentication failed")                                                                             
            exit()                                                                                                     
                                                                                                                       
        # Extract the token from the JSON response                                                                     
        token = data["authentication"]["token"]                                                                        
        print(f"token is {token}")

        # Create a cookie with the token found in JSON data                                                            
        cookie = Cookie(                                                                                               
            version=0,                                                                                                 
            name="token",                                                                                              
            value=token,                                                                                               
            port=None,                                                                                                 
            port_specified=False,                                                                                      
            domain="juice-shop.herokuapp.com",                                                                         
            domain_specified=True,                                                                                     
            domain_initial_dot=False,                                                                                  
            path="/",                                                                                                  
            path_specified=True,                                                                                       
            secure=False,                                                                                              
            expires=None,                                                                                              
            discard=True,                                                                                              
            comment=None,                                                                                              
            comment_url=None,                                                                                          
            rest={'HttpOnly': None},                                                                                   
            rfc2109=False                                                                                              
        )                                                                                                              
        # Set it on the current crawler                                                                                
        crawler.cookie_jar.set_cookie(cookie)                                                                          
        # Try it                                                                                                       
        request = Request(                                                                                             
                "https://juice-shop.herokuapp.com/rest/user/whoami",                                                   
        )                                                                                                              
        response = await crawler.async_get(                                                                            
                request,                                                                                               
        )                                                                                                              
        try:                                                                                                           
            print(f'Login successful with user ID {response.json["user"]["id"]}')                                      
        except KeyError:                                                                                               
            print("Authentication failed")                                                                             
            exit()                                                                                                     
                                                                                                                       
        # Overwrite cookies on crawler configuration so Wapiti can use them for scanning and attacks
        crawler_configuration.cookies = crawler.cookie_jar
```