### PR TITLE
Remove temporary files in Docker headless image

### DIFF
--- a/Dockerfile.headless
+++ b/Dockerfile.headless
@@ -31,24 +31,22 @@ RUN apt update \
   && apt install python3 python3-setuptools curl bzip2 -y \
   && apt-get install -y --no-install-recommends --no-install-suggests \
     `apt-cache depends firefox-esr | awk '/Depends:/{print$2}'` \
-    # additional 'firefox-esl' dependencies which is not in 'depends' list
-    libasound2 libxt6 libxtst6 \
+     # additional 'firefox-esl' dependencies which is not in 'depends' list
+     libasound2 libxt6 libxtst6 \
+  && curl -fL -o /tmp/firefox.tar.bz2 \
+     https://ftp.mozilla.org/pub/firefox/releases/${firefox_ver}/linux-x86_64/en-GB/firefox-${firefox_ver}.tar.bz2 \
+  && tar -xjf /tmp/firefox.tar.bz2 -C /tmp/ \
+  && mv /tmp/firefox /opt/firefox \
+  # Download and install geckodriver
+  && curl -fL -o /tmp/geckodriver.tar.gz \
+     https://github.com/mozilla/geckodriver/releases/download/v${geckodriver_ver}/geckodriver-v${geckodriver_ver}-linux64.tar.gz \
+  && tar -xzf /tmp/geckodriver.tar.gz -C /tmp/ \
+  && chmod +x /tmp/geckodriver \
+  && mv /tmp/geckodriver /usr/local/bin/ \
   && apt clean -yq \
   && apt autoremove -yq \
   && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* \
   && truncate -s 0 /var/log/*log
-
-RUN curl -fL -o /tmp/firefox.tar.bz2 \
-         https://ftp.mozilla.org/pub/firefox/releases/${firefox_ver}/linux-x86_64/en-GB/firefox-${firefox_ver}.tar.bz2 \
- && tar -xjf /tmp/firefox.tar.bz2 -C /tmp/ \
- && mv /tmp/firefox /opt/firefox \
-    \
- # Download and install geckodriver
- && curl -fL -o /tmp/geckodriver.tar.gz \
-         https://github.com/mozilla/geckodriver/releases/download/v${geckodriver_ver}/geckodriver-v${geckodriver_ver}-linux64.tar.gz \
- && tar -xzf /tmp/geckodriver.tar.gz -C /tmp/ \
- && chmod +x /tmp/geckodriver \
- && mv /tmp/geckodriver /usr/local/bin/
 
 COPY --from=build /usr/local/lib/python3.9/dist-packages/ /usr/local/lib/python3.9/dist-packages/
 COPY --from=build /usr/local/bin/wapiti /usr/local/bin/wapiti-getcookie /usr/local/bin/


### PR DESCRIPTION
This merges the three RUN instructions into one layer and moved the removal of the content of `/tmp` at the end. Files
geckodriver.tar.gz and firefox.tar.bz2 are now removed. This reduces the image size from 663MB to 582MB (-13%).

/assign me