### PR TITLE
Rework htp module

### DIFF
--- a/tests/attack/test_mod_htp.py
+++ b/tests/attack/test_mod_htp.py
@@ -383,8 +383,30 @@ async def test_attack():
             ["1.0", "1.1", "1.2", "1.2.1", "1.3", "1.4", "1.5", "1.6"],
             [["1.2", "1.2.1", "1.3"], ["1.3", "1.4"], ["1.5", "1.5"], ["1.0", "1.2"]],
             ["1.0", "1.1", "1.2", "1.2.1", "1.3", "1.4", "1.5"],
-        ]
+        ],
+        [
+            ["1.0", "1.1", "1.2", "1.2.1", "1.3", "1.3.1"],
+            [["0.7", "1.3"], ["1.2", "1.4"]],
+            ["1.2", "1.2.1", "1.3"],
+        ],
+        [
+            ["0.8", "1.1", "1.2", "1.2.1", "1.3", "1.3.1"],
+            [["0.7", "1.3"], ["1.3.2", "1.4"]],
+            ["1.3"],
+        ],
+        [
+            ["1.0", "1.1", "1.2", "1.2.1", "1.3", "1.3.1"],
+            [["0.7", "0.8"], ["1.3.2", "1.4"]],
+            [],
+        ],
     ],
+    ids=[
+        "regular test #1",
+        "regular test #2",
+        "missing start end end of range",
+        "only one matching version",
+        "no matching version",
+    ]
 )
 def test_get_matching_technology_versions(known_versions, detected_versions, matching_versions):
     assert matching_versions == get_matching_versions(known_versions, detected_versions)

--- a/wapitiCore/attack/mod_drupal_enum.py
+++ b/wapitiCore/attack/mod_drupal_enum.py
@@ -47,7 +47,7 @@ class ModuleDrupalEnum(Attack):
             task = asyncio.create_task(self.get_url_hash(root_url, path))
             tasks.add(task)
 
-            while True:
+            while tasks:
                 done_tasks, pending_tasks = await asyncio.wait(
                     tasks,
                     timeout=0.01,


### PR DESCRIPTION
htp module has several drawbacks:

* it is slow
* inconsistency in sqlite DB may generate crashes (see below)
* a range can be given while there is a single matching version
* some version strings are odd (eg: `from 10.0.0-alpha1 to start` for Drupal)
* there are frequent false positives

## inconsistency

`ValueError: '4.2.1-rc2' is not in list` for Wordpress

```
sqlite> select * from version where technology = "WordPress" and version like '4.2.1%';
|WordPress|4.2.1
|WordPress|4.2.10
|WordPress|4.2.11
|WordPress|4.2.12
|WordPress|4.2.13
|WordPress|4.2.14
|WordPress|4.2.15
|WordPress|4.2.16
|WordPress|4.2.17
|WordPress|4.2.18
|WordPress|4.2.19
```

So it looks like a version is known for a given hash for that version is not part of the `version` table

## frequent false positives

Detected magento2 technology seems to match versions from 2.3.0 to 2.4.4
Detected WordPress technology seems to match versions from 3.1 to 6.0
Detected joomla-cms technology seems to match version 4.0.0-alpha4x

I can fix some stuff like speed and deal with some inconsistency but the DB may also needs some fixes