### PR TITLE
Update php7.4 to php8.1 in github actions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -53,7 +53,7 @@ jobs:
     - name: Install dependencies
       run: |
         sudo apt-get update
-        sudo apt-get install php7.4-cli php7.4-xml -y --no-install-recommends
+        sudo apt-get install php8.1-cli php8.1-xml -y --no-install-recommends
         python -m pip install --upgrade pip
         pip install -U setuptools
         pip3 install .[sslyze]


### PR DESCRIPTION
Update php7.4 to php8.1 in github actions since Ubuntu image moved from Ubuntu 20.04 to Ubuntu 22.04.