### PR TITLE
Speed up `--update` option test

### DIFF
--- a/tests/cli/test_options.py
+++ b/tests/cli/test_options.py
@@ -101,10 +101,10 @@ async def test_update_with_modules(mock_update, _):
 
 @pytest.mark.asyncio
 @mock.patch("wapitiCore.main.wapiti.Wapiti.update")
-@mock.patch("sys.exit")
-async def test_update_without_modules(mock_update, _):
+async def test_update_without_modules(mock_update):
+    """Ensure that no module should be updated when no module is requested."""
     testargs = ["wapiti", "--update"]
     with mock.patch.object(sys, 'argv', testargs):
-        with mock.patch("wapitiCore.main.wapiti.Wapiti.update") as mock_update:
+        with pytest.raises(SystemExit):
             await wapiti_main()
             mock_update.assert_called_once_with(None)


### PR DESCRIPTION
The variable `mock_update` is already defined with a pytest fixture. There is no need to create it again inside a `with` bloc.

Furthermore, patching `sys.exit` ensures that the pytest command does not exit while running the test, but replacing `sys.exit` with a no-op means that the program won't stop after the update. As a consequence, the test execute all the attack modules. Using `pytest.raises` instead to catch the exception ensure the program ends after the update. This reduces the execution time of the test from 3s to 0.6s.