### PR TITLE
Fix bad WSTG code for bad cookie attribute

### DIFF
--- a/wapitiCore/definitions/http_only.py
+++ b/wapitiCore/definitions/http_only.py
@@ -22,7 +22,7 @@ TYPE = "vulnerability"
 NAME = "HttpOnly Flag cookie"
 SHORT_NAME = NAME
 
-WSTG_CODE = ["WSTG-CONF-07", "WSTG-SESS-02"]
+WSTG_CODE = ["WSTG-SESS-02"]
 
 DESCRIPTION = (
     "HttpOnly is an additional flag included in a Set-Cookie HTTP response header."
@@ -34,13 +34,6 @@ DESCRIPTION = (
 SOLUTION = "While creation of the cookie, make sure to set the HttpOnly Flag to True."
 
 REFERENCES = [
-    {
-        "title": "OWASP: HTTP Strict Transport Security",
-        "url": (
-            "https://owasp.org/www-project-web-security-testing-guide/stable/4-Web_Application_Security_Testing/"
-            "02-Configuration_and_Deployment_Management_Testing/07-Test_HTTP_Strict_Transport_Security"
-        )
-    },
     {
         "title": "OWASP: Testing for Cookies Attributes",
         "url": (


### PR DESCRIPTION
Retrait du code WSTG relatif à HSTS pour les tests sur les mauvais attributs de cookies.