### PR TITLE
Reduce image test size

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -7,7 +7,7 @@ on: [push, pull_request]
 jobs:
   code_style:
     name: Code Style Analysis
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v2
       - name: Set up Python
@@ -25,7 +25,7 @@ jobs:
           pylint-ignore --rcfile=.pylintrc *.py wapitiCore
 
   docker:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v2
       - name: Set up Docker
@@ -38,7 +38,7 @@ jobs:
           docker build .
 
   build:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     strategy:
       matrix:
         python-version: ["3.9", "3.10", "3.11"]

--- a/Dockerfile.test
+++ b/Dockerfile.test
@@ -1,13 +1,18 @@
 FROM ubuntu:22.04
+
 ENV DEBIAN_FRONTEND noninteractive
-RUN apt-get update
-RUN apt-get install ca-certificates -y
+
+RUN apt update \
+ && apt install ca-certificates python3 python3-pip php8.1-cli php8.1-xml -y --no-install-recommends \
+ && apt clean -yq \
+ && apt autoremove -yq \
+ && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* \
+ && truncate -s 0 /var/log/*log
+
 RUN update-ca-certificates
-RUN apt-get install python3 python3-pip -y
-RUN apt-get install php8.1-cli php8.1-xml -y --no-install-recommends
 RUN python3 -c "import sys; print(sys.version)"
 RUN python3 -m pip install --upgrade pip
-RUN pip3 install -U setuptools
+RUN pip3 install -U setuptools --no-cache-dir
 RUN mkdir /usr/src/app
 
 ENV LANG en_US.UTF-8
@@ -18,5 +23,5 @@ WORKDIR /usr/src/app
 
 COPY . .
 
-RUN pip3 install .[test]
+RUN pip3 install .[test] --no-cache-dir
 CMD ["pytest"]

--- a/Dockerfile.test
+++ b/Dockerfile.test
@@ -1,4 +1,4 @@
-FROM ubuntu:latest
+FROM ubuntu:22.04
 ENV DEBIAN_FRONTEND noninteractive
 RUN apt-get update
 RUN apt-get install ca-certificates -y


### PR DESCRIPTION
This MR features simple operations to reduce the test docker image.

With these changess, we build a 40% lighter image.
First, we regroup all apt install lines, so we can remove cache on the
same layer.

Then we remove pip3 cache, which is absolutely not negligible.