### PR TITLE
Fix empty and multiple values headers

### DIFF
--- a/wapitiCore/parsers/html_parser.py
+++ b/wapitiCore/parsers/html_parser.py
@@ -209,6 +209,21 @@ class Html:
         return metas
 
     @property
+    def multi_meta(self) -> List[Tuple[str, str]]:
+        """Returns a list of tuples of all metas tags with name attribute as the first element of the tuple and content
+           attribute as last element of the tuple. Useful when multiple meta tags have the same name but different
+           content.
+        """
+        metas = []
+        if self.soup.head is not None:
+            for meta_tag in self.soup.head.find_all("meta", attrs={"name": True, "content": True}, content=True):
+                tag_name = meta_tag["name"].lower().strip()
+                if tag_name:
+                    metas.append((tag_name, meta_tag["content"]))
+
+        return metas
+
+    @property
     def description(self) -> str:
         """Returns the content of the meta description tag in the HTML header.
 

--- a/wapitiCore/wappalyzer/wappalyzer.py
+++ b/wapitiCore/wappalyzer/wappalyzer.py
@@ -3,6 +3,7 @@ import os
 import re
 import warnings
 from typing import Set
+from collections import defaultdict
 from soupsieve.util import SelectorSyntaxError
 
 from wapitiCore.net.crawler import Response
@@ -306,10 +307,14 @@ def detect_versions_normalize_dict(rules: dict, contents) -> Set[str]:
         if key in contents:
             # regex_params is a list : [{"application_pattern": "..", "regex": "re.compile(..)"}, ...]
             for i, _ in enumerate(regex_params):
-                if re.search(regex_params[i]['regex'], contents[key]):
-                    # Use that special string to show we detected the app once but not necessarily a version
-                    versions.add("__detected__")
-                    versions.update(extract_version(regex_params[i], contents[key]))
+                for content_value in contents[key]:
+                    # If the regex fails, it can be due to the fact that we are looking for the key instead
+                    # The value can be set to the key so we compare
+                    if re.search(regex_params[i]['regex'], content_value) or\
+                       regex_params[i]['application_pattern'] == key:
+                        # Use that special string to show we detected the app once but not necessarily a version
+                        versions.add("__detected__")
+                        versions.update(extract_version(regex_params[i], content_value))
 
     return versions
 
@@ -330,12 +335,24 @@ class Wappalyzer:
         self._url = web_content.url
         self._html_code = web_content.content
         # Copy some values to make sure they aren't processed more than once
+        # List based attributes:
         self.html = Html(self._html_code, self._url)
         self._scripts = self.html.scripts[:]
-        self._cookies = dict(web_content.cookies)
-        self._headers = web_content.headers
-        self._metas = dict(self.html.metas)
         self._js = js
+
+        # dict(web_content.headers)->{"Server":"Nginx, Apache, Redis" ...}
+        # With the workaround below ->{"Server":["Nginx", "Apache", "Redis"] ...}
+        # Way better for processing instead of splitting on " ,"
+        self._headers = defaultdict(list)
+        for attribute, value in web_content.headers.multi_items():
+            self._headers[attribute].append(value)
+        # Same with meta tags
+        self._metas = defaultdict(list)
+        for attribute, value in self.html.multi_meta:
+            self._metas[attribute].append(value)
+        # Cookies can't have multiple values so parsing singletons lists is okay
+        # That said, all the keys in the database are in lowercases
+        self._cookies = {key.lower(): [value] for key, value in web_content.cookies.items()}
 
     def detect_application_versions(self, application: dict) -> Set[str]:
         """


### PR DESCRIPTION
@devl00p,  @bretfourbe, @fwininger 
While testing the wapp module that use wappalyzer, I realized the module mess up with some headers configurations

Firstly, when the regex is empty in our JSON file, we replace it with its attribute as you can see [here](https://github.com/wapiti-scanner/wapiti/blob/9c91017c016ec82df9f0ebf78cd2040a34b1c93b/wapitiCore/wappalyzer/wappalyzer.py#LL131C1-L136C39)
But then we compare this value (the copied attribute) with its value from the response instead of checking if it is simply here, which will not raise it.

The second bug I found was with headers that have multiple values for the same attribute. Let's admit a response has 2 headers `Server` (which will most likely never happens for this attribute but whatever):
```Text
Server : this 
Server : that
```
The code use to concatenate each value from attributes in a dictionary with a single string that way:
```JSON
{
   "Server": "this, that"
}
```
Which will make some regexes fail: admitting we can detect a technology thanks to its server attribute "that" by its regex, which is "^that$". It will not work as the regex is expecting the string to start and end with this word. As this behavior comes from HTTPX, you can find [more information here](https://www.python-httpx.org/quickstart/#response-headers).

Instead of using a split method (because we can't take for granted the fact that all the attributes will never have a " ," as values inside of them) I safely reparsed the dictionary from the httpx.Header object, so now we have a dictionary that looks more like this:
```JSON
{
   "Server": ["this", "that"]
}
```
And the regex search for each element.

I also found a third bug in which the keys provided by the JSON database are set in lowercases, meanwhile the keys of the dictionary made by the httpx.Response for the cookies are in uppercase. I lowered down all the keys, so it can detect all the technos
 
Finally, I've written some more unit tests for those cases to check that everything runs smoothly.

EDIT 1:  I found out that 
```Python
 expected_result = [
            '{"name": "Astra Widgets", "versions": ["1.5.4"], "categories": ["WordPress plugins", "Widgets"], "groups": ["Add-ons", "Other"]}',
            '{"name": "PHP", "versions": [], "categories": ["Programming languages"], "groups": ["Web development"]}'

        ]
for arg in persister.add_payload.call_args_list:
            assert arg[1]["info"] in expected_result
```
Is a bad way to check the units tests since we can put technos in expected values that couldn't be in the persister, so I patched them using sets instead which guarantees the existence and uniqueness of each expected strings: 
```Python
 expected_result = [
            '{"name": "Astra Widgets", "versions": ["1.5.4"], "categories": ["WordPress plugins", "Widgets"], "groups": ["Add-ons", "Other"]}',
            '{"name": "PHP", "versions": [], "categories": ["Programming languages"], "groups": ["Web development"]}'

        ]
assert set([arg[1]['info'] for arg in persister.add_payload.call_args_list]) == expected_result
```
It turned out that there were more bugs involved than simply the headers, I'll keep working on them even tho the name of the MR is loosing its meaning as this patch is growing bigger

EDIT 2:
In the unit test file, for the DOM, a techno (Joomla) implied by another one (Sellacious) was missing, so I added it and some attributes were set to id whereas they have to be set to class according to the JSON.
I encountered the same issue with the meta tags that I've experienced with the headers tags (the fact that as they are stored in a dictionary, every tag with the same name will be squashed into one regardless of their content). This made me add a new method in the HTML parser to allow a list of tuples ``(name, content)`` so they are all unique (and use the same format as multi_items() from httpx.Headers), and I reparsed them as a dictionary of lists in the Wappalyzer class just like the headers

All the unit tests are now green, and I haven't found anymore bugs so far 