### PR TITLE
quickfix key comparing

### DIFF
--- a/tests/wappalyzer/test_wappalyzer.py
+++ b/tests/wappalyzer/test_wappalyzer.py
@@ -18,6 +18,9 @@ async def test_applicationdata():
     groups_text = """{
         "9": {
             "name": "Web development"
+        },
+        "7": {
+            "name": "Servers"
         }
     }"""
 
@@ -35,6 +38,13 @@ async def test_applicationdata():
             ],
             "name": "JavaScript graphics",
             "priority": 6
+        },
+        "31": {
+            "groups": [
+            7
+        ],
+        "name": "CDN",
+        "priority": 9
         }
     }"""
 
@@ -52,6 +62,23 @@ async def test_applicationdata():
             "icon": "PHP.svg",
             "url": \"\\\\.php(?:$|\\\\?)\",
             "website": "http://php.net"
+        },
+        "Akamai": {
+            "cats": [
+                31
+            ],
+            "description": "Akamai is global content delivery network (CDN) services provider for media and software delivery, and cloud security solutions.",
+            "headers": {
+                "X-Akamai-Transformed": "",
+                "X-EdgeConnect-MidMile-RTT": "",
+                "X-EdgeConnect-Origin-MEX-Latency": ""
+            },
+            "icon": "Akamai.svg",
+            "pricing": [
+                "poa"
+            ],
+            "saas": true,
+            "website": "http://akamai.com"
         },
          "A-Frame": {
             "cats": [
@@ -86,9 +113,9 @@ async def test_applicationdata():
         application_data = ApplicationData(categories_file_path, groups_file_path, technologies_file_path)
 
     assert application_data is not None
-    assert len(application_data.get_applications()) == 2
-    assert len(application_data.get_categories()) == 2
-    assert len(application_data.get_groups()) == 1
+    assert len(application_data.get_applications()) == 3
+    assert len(application_data.get_categories()) == 3
+    assert len(application_data.get_groups()) == 2
 
     target_url = "http://perdu.com/"
 
@@ -101,7 +128,8 @@ async def test_applicationdata():
             headers=[
                 ('server', 'nginx/1.19.0'),
                 ('content-type', 'text/html; charset=UTF-8'),
-                ('x-powered-by', 'PHP/5.6.40-38+ubuntu20.04.1+deb.sury.org+1')
+                ('x-powered-by', 'PHP/5.6.40-38+ubuntu20.04.1+deb.sury.org+1'),
+                ('x-akamai-transformed', 'another text value')
             ]
         )
     )
@@ -112,10 +140,19 @@ async def test_applicationdata():
     wappalyzer = Wappalyzer(application_data, page, {})
     result = wappalyzer.detect()
 
-    assert len(result) == 1
+    # Value based detection result
+    assert len(result) == 2
     assert result.get("PHP") is not None
     assert len(result.get("PHP").get("categories")) == 1
     assert result.get("PHP").get("categories")[0] == "Programming languages"
     assert len(result.get("PHP").get("groups")) == 1
     assert result.get("PHP").get("groups")[0] == "Web development"
+
+    # Key based detection result
+    assert result.get("Akamai") is not None
+    assert len(result.get("Akamai").get("categories")) == 1
+    assert result.get("Akamai").get("categories")[0] == "CDN"
+    assert len(result.get("Akamai").get("groups")) == 1
+    assert result.get("Akamai").get("groups")[0] == "Servers"
+
     assert result.get("A-Frame") is None

--- a/wapitiCore/wappalyzer/wappalyzer.py
+++ b/wapitiCore/wappalyzer/wappalyzer.py
@@ -306,7 +306,10 @@ def detect_versions_normalize_dict(rules: dict, contents) -> Set[str]:
         if key in contents:
             # regex_params is a list : [{"application_pattern": "..", "regex": "re.compile(..)"}, ...]
             for i, _ in enumerate(regex_params):
-                if re.search(regex_params[i]['regex'], contents[key]):
+                # If the regex fails, it can be due to the fact that we are looking for the key instead
+                # The value can be set to the key so we compare
+                if re.search(regex_params[i]['regex'], contents[key]) or\
+                        regex_params[i]['application_pattern'] == key:
                     # Use that special string to show we detected the app once but not necessarily a version
                     versions.add("__detected__")
                     versions.update(extract_version(regex_params[i], contents[key]))


### PR DESCRIPTION
This MR in an echo to #413 

# The Issue 
As said in the previous MR, sometimes in the database you can find empty values for some keys, for example in the header of the following JSON:
```JSON
 "Akamai": {
    "cats": [
      31
    ],
    "description": "Akamai is global content delivery network (CDN) services provider for media and software delivery, and cloud security solutions.",
    "headers": {
      "X-Akamai-Transformed": "",
      "X-EdgeConnect-MidMile-RTT": "",
      "X-EdgeConnect-Origin-MEX-Latency": ""
    },
    "icon": "Akamai.svg",
    "pricing": [
      "poa"
    ],
    "saas": true,
    "website": "http://akamai.com"
  }
```

It means that we are looking for the keys instead of a regex value, and the work to recognize keys instead of values has started [here](https://github.com/wapiti-scanner/wapiti/blob/9c91017c016ec82df9f0ebf78cd2040a34b1c93b/wapitiCore/wappalyzer/wappalyzer.py#LL131C1-L136C39) where we copy the key inside the value of the dictionary, but the comparison is never made since we compare only contents [in the detect_versions_normalize_dict function](https://github.com/RMI78/wapiti/blob/4504a777232b37d80a34a060518ff66d86da32ef/wapitiCore/wappalyzer/wappalyzer.py#L299C1-L315C1).

To extend our example, let's admit Wapiti scrapped a web page having the following headers:
```txt
 X-Akamai-Transformed: 1234,
 X-EdgeConnect-MidMile-RTT: "blabla",
 X-EdgeConnect-Origin-MEX-Latency: "oh-my-god"
```
Wapiti has in its memory the headers from the database modified accordingly to [here](https://github.com/wapiti-scanner/wapiti/blob/9c91017c016ec82df9f0ebf78cd2040a34b1c93b/wapitiCore/wappalyzer/wappalyzer.py#LL131C1-L136C39) (literally the same link as above), so something like 
```txt
 X-Akamai-Transformed: X-Akamai-Transformed,
 X-EdgeConnect-MidMile-RTT: X-Akamai-Transformed,
 X-EdgeConnect-Origin-MEX-Latency: X-Akamai-Transformed
```
And will compare ``1234`` to  ``X-Akamai-Transformed``, ``"blabla"`` to ``X-EdgeConnect-MidMile-RTT`` and so on which make Wapiti silent toward a non-negligible number of techs since not only headers are involved but every empty string in the database (meta, headers and cookies are concerned as far as I went)

# The solution
In the function detect_versions_normalize_dict, in case the regex fails, we look for a direct comparison between the value of our database (which is nothing but the copied key if the string was formerly empty) and the key of our response. 

# Limitations
It would be cleaner to have the key of the database along instead of copying it inside the value, but it requires a bigger workaround since the scope of detect_version_normalize_dict is way beyond the scope of the variables containing the keys. Plus, the keys were already copied in the value as if someone wanted it that way. 

Force-push 1 and 2 : Auto-formating undoing
Force-push 3: added unit-test to limit coverage loss