### PR TITLE
Detect HTML injection in xss modules via non-js payload

### DIFF
--- a/tests/attack/test_mod_permanentxss.py
+++ b/tests/attack/test_mod_permanentxss.py
@@ -6,11 +6,12 @@ import pytest
 import respx
 
 from tests import AsyncIterator
-from wapitiCore.attack.attack import Parameter, ParameterSituation
+from wapitiCore.attack.attack import Parameter, ParameterSituation, PayloadType
 from wapitiCore.net.classes import CrawlerConfiguration
 from wapitiCore.net import Request
 from wapitiCore.net.crawler import AsyncCrawler
 from wapitiCore.attack.mod_permanentxss import ModulePermanentxss
+from wapitiCore.net.xss_utils import PayloadInfo
 
 values = ["iamgroot"]
 
@@ -26,9 +27,19 @@ def add_value(request):
     return httpx.Response(200, text="Comment saved")
 
 
+def store_and_return_stored_value(request):
+    global values
+    values.append(request.url.params.get("message"))
+    return httpx.Response(
+        200,
+        text="\n".join(values + ['<div id="iamgroot">success</div>']),
+        headers={"Content-Type": "text/html"}
+    )
+
+
 @pytest.mark.asyncio
 @respx.mock
-async def test_vulnerable_page():
+async def test_second_order_injection():
     respx.get("http://perdu.com/").mock(side_effect=return_stored_values)
     respx.get(url__regex=r"http://perdu\.com/comment\.php\?message=.*").mock(side_effect=add_value)
 
@@ -40,7 +51,7 @@ async def test_vulnerable_page():
     comment_request = Request("http://perdu.com/comment.php?message=Hello")
     comment_request.path_id = 2
 
-    persister.get_links.return_value = AsyncIterator([(index_request, comment_request)])
+    persister.get_links.return_value = AsyncIterator([(index_request, None), (comment_request, None)])
 
     crawler_configuration = CrawlerConfiguration(Request("http://127.0.0.1:65081/"))
     async with AsyncCrawler.with_configuration(crawler_configuration) as crawler:
@@ -61,4 +72,51 @@ async def test_vulnerable_page():
         assert persister.add_payload.call_args_list[0][1]["parameter"] == "message"
         assert persister.add_payload.call_args_list[0][1]["request"].get_params[0][1] == (
             "<ScRiPt>alert('iamgroot')</sCrIpT>"
+        )
+
+
+@pytest.mark.asyncio
+@respx.mock
+async def test_first_order_injection():
+    # Injection and rendering occurs in the same webpage
+    respx.get(url__regex=r"http://perdu\.com/comment\.php\?message=.*").mock(side_effect=store_and_return_stored_value)
+
+    # We should succeed at escaping the title tag
+    persister = AsyncMock()
+    comment_request = Request("http://perdu.com/comment.php?message=Hello")
+    comment_request.path_id = 1
+
+    evil_request = Request("http://perdu.com/comment.php?message=%3Cdiv%20id%3D%22imgroot%22%3Eyolo%3C/div%3E")
+    evil_request.path_id = 2
+
+    persister.get_links.return_value = AsyncIterator([(comment_request, None)])
+
+    crawler_configuration = CrawlerConfiguration(Request("http://127.0.0.1:65081/"))
+    async with AsyncCrawler.with_configuration(crawler_configuration) as crawler:
+        options = {"timeout": 10, "level": 2}
+
+        module = ModulePermanentxss(crawler, persister, options, Event(), crawler_configuration)
+        module.do_post = False
+        module.tried_xss["iamgroot"] = (
+            comment_request,
+            Parameter(name="message", situation=ParameterSituation.QUERY_STRING)
+        )
+        module.successful_xss["iamgroot"] = (
+            evil_request,
+            PayloadInfo(
+                payload='<div id="iamgroot">success</div>',
+                injection_type="html",
+                name="html_inject",
+                type=PayloadType.xss_closing_tag,
+            )
+        )
+
+        await module.attack(comment_request)
+
+        assert persister.add_payload.call_count
+        assert persister.add_payload.call_args_list[0][1]["module"] == "permanentxss"
+        assert persister.add_payload.call_args_list[0][1]["category"] == "Stored HTML Injection"
+        assert persister.add_payload.call_args_list[0][1]["parameter"] == "message"
+        assert persister.add_payload.call_args_list[0][1]["request"].get_params[0][1] == (
+            '<div id="imgroot">yolo</div>'
         )

--- a/tests/data/xss/no_js_possible.php
+++ b/tests/data/xss/no_js_possible.php
@@ -1,0 +1,36 @@
+<html>
+<body>
+<?php
+
+function stristr_multiple($haystack, $needles) {
+    foreach ($needles as $needle) {
+        $result = stristr($haystack, $needle);
+        if ($result !== false) {
+            return $result;
+        }
+    }
+    return false;
+}
+
+
+function filterHTML($html) {
+    // Define the regular expression pattern to match event attributes
+    $pattern = '/(?:\s+|\/)on\w+\s*=\s*(?:"[^"]*"|\'[^\']*\'|[^>\s]*)/i';
+
+    // Remove event attributes using regular expressions
+    $filteredHTML = preg_replace($pattern, '', $html);
+
+    return $filteredHTML;
+}
+
+$name = isset($_GET["name"]) ? $_GET["name"] : "anonymous coward";
+
+$name = filterHTML($name);
+$patterns = array("script", "object");
+if (stristr_multiple($name, $patterns)) {
+    // Look mah, uber-31337 xss filtering
+    $name = "anonymous hacker";
+}
+echo $name;
+?>
+

--- a/wapitiCore/attack/mod_xss.py
+++ b/wapitiCore/attack/mod_xss.py
@@ -182,7 +182,8 @@ class ModuleXss(Attack):
                         )
                 ):
                     self.successful_xss[taint] = (evil_request, xss_payload)
-                    message = f"XSS vulnerability found via injection in the parameter {xss_param.name}"
+                    message = XSS_NAME if xss_payload.injection_type == "javascript" else HTMLI_NAME
+                    message += f" vulnerability found via injection in the parameter {xss_param.name}"
                     if has_strong_csp(response, html):
                         message += ".\nWarning: Content-Security-Policy is present!"
 

--- a/wapitiCore/data/attacks/xssPayloads.ini
+++ b/wapitiCore/data/attacks/xssPayloads.ini
@@ -8,6 +8,7 @@ requirements = None
 case_sensitive = yes
 close_tag = yes
 payload_type = pattern
+injection_type = javascript
 
 ; Let's start with the most obvious XSS payloads
 [case_script_alert_quote]
@@ -440,3 +441,12 @@ value = javascript:alert(/__XSS__/)//
 case_sensitive = yes
 close_tag = no
 match_type = starts_with
+
+; Fallback to HTML injection if nothing worked
+[html_inject]
+payload = <div id="__XSS__">yolo</div>
+tag = div
+attribute = id
+value = __XSS__
+case_sensitive = yes
+injection_type = html

--- a/wapitiCore/definitions/html_injection.py
+++ b/wapitiCore/definitions/html_injection.py
@@ -1,0 +1,39 @@
+TYPE = "vulnerability"
+
+NAME = "HTML Injection"
+
+SHORT_NAME = "HTML Injection"
+
+WSTG_CODE = ["WSTG-CLNT-03"]
+
+DESCRIPTION = (
+    "HTML injection is a type of injection vulnerability that occurs when a user is able to control an input point "
+    "and is able to inject arbitrary HTML code into a vulnerable web page. "
+    "This vulnerability can allow the attacker to modify the page content seen by the victims."
+)
+
+SOLUTION = (
+    "Avoid Raw HTML Rendering: Whenever possible, avoid directly rendering user-generated content as raw HTML. "
+    "Instead, use built-in templating systems or libraries that automatically escape user input by default, "
+    "such as Django's template engine or AngularJS's ng-bind directive. "
+    "With PHP you can use the htmlspecialchars() function to convert special characters to their corresponding "
+    "HTML entities."
+)
+
+REFERENCES = (
+    {
+        "title": "OWASP: Testing for HTML Injection",
+        "url": (
+            "https://owasp.org/www-project-web-security-testing-guide/v41/4-Web_Application_Security_Testing/"
+            "11-Client_Side_Testing/03-Testing_for_HTML_Injection"
+        )
+    },
+    {
+        "title": "IMPERVA: HTML Injection",
+        "url": "https://www.imperva.com/learn/application-security/html-injection/",
+    },
+    {
+        "title": "HackTricks: Dangling Markup - HTML scriptless injection",
+        "url": "https://book.hacktricks.xyz/pentesting-web/dangling-markup-html-scriptless-injection"
+    },
+)

--- a/wapitiCore/definitions/stored_html_injection.py
+++ b/wapitiCore/definitions/stored_html_injection.py
@@ -1,0 +1,39 @@
+TYPE = "vulnerability"
+
+NAME = "Stored HTML Injection"
+
+SHORT_NAME = "Stored HTML Injection"
+
+WSTG_CODE = ["WSTG-CLNT-03"]
+
+DESCRIPTION = (
+    "HTML injection is a type of injection vulnerability that occurs when a user is able to control an input point "
+    "and is able to inject arbitrary HTML code into a vulnerable web page. "
+    "This vulnerability can allow the attacker to modify the page content seen by the victims."
+)
+
+SOLUTION = (
+    "Avoid Raw HTML Rendering: Whenever possible, avoid directly rendering user-generated content as raw HTML. "
+    "Instead, use built-in templating systems or libraries that automatically escape user input by default, "
+    "such as Django's template engine or AngularJS's ng-bind directive. "
+    "With PHP you can use the htmlspecialchars() function to convert special characters to their corresponding "
+    "HTML entities."
+)
+
+REFERENCES = (
+    {
+        "title": "OWASP: Testing for HTML Injection",
+        "url": (
+            "https://owasp.org/www-project-web-security-testing-guide/v41/4-Web_Application_Security_Testing/"
+            "11-Client_Side_Testing/03-Testing_for_HTML_Injection"
+        )
+    },
+    {
+        "title": "IMPERVA: HTML Injection",
+        "url": "https://www.imperva.com/learn/application-security/html-injection/",
+    },
+    {
+        "title": "HackTricks: Dangling Markup - HTML scriptless injection",
+        "url": "https://book.hacktricks.xyz/pentesting-web/dangling-markup-html-scriptless-injection"
+    },
+)

--- a/wapitiCore/model/__init__.py
+++ b/wapitiCore/model/__init__.py
@@ -6,6 +6,7 @@ from typing import List, Callable, Iterable, Union
 class PayloadInfo:
     payload: str
     rules: List[str]
+    injection_type: str
 
     def __init__(self, payload: str, **kwargs):  # pylint: disable=unused-argument
         self.payload = payload

--- a/wapitiCore/net/xss_utils.py
+++ b/wapitiCore/net/xss_utils.py
@@ -30,11 +30,13 @@ from wapitiCore.net import Response
 # Everything under those tags will be treated as text
 from wapitiCore.parsers.html_parser import Html
 
+
 @dataclasses.dataclass
 class PayloadInfo:
     payload: str
     type: PayloadType
     name: str
+    injection_type: str
 
 
 NONEXEC_PARENTS = {
@@ -265,7 +267,8 @@ def load_payloads_from_ini(filename, external_endpoint) -> List[Dict[str, str]]:
             "attribute": config_reader[section]["attribute"],
             "value": clean_value,
             "case_sensitive": config_reader.getboolean(section, "case_sensitive", fallback=True),
-            "close_tag": config_reader.getboolean(section, "close_tag", fallback=True)
+            "close_tag": config_reader.getboolean(section, "close_tag", fallback=True),
+            "injection_type": config_reader[section]["injection_type"],
         }
 
         if "requirements" in config_reader[section]:
@@ -335,7 +338,12 @@ def apply_attrval_context(context: Dict[str, str], payloads: List[Dict[str, str]
                         continue
 
                 result.append(
-                    PayloadInfo(payload=js_code, type=PayloadType.xss_non_closing_tag, name=payload_infos["name"])
+                    PayloadInfo(
+                        payload=js_code,
+                        type=PayloadType.xss_non_closing_tag,
+                        name=payload_infos["name"],
+                        injection_type=payload_infos["injection_type"],
+                    )
                 )
 
         else:
@@ -359,7 +367,14 @@ def apply_attrval_context(context: Dict[str, str], payloads: List[Dict[str, str]
                 js_code += "</" + context["non_exec_parent"] + ">"
 
             js_code += payload_infos["payload"].replace("__XSS__", code)
-            result.append(PayloadInfo(payload=js_code, type=PayloadType.xss_closing_tag, name=payload_infos["name"]))
+            result.append(
+                PayloadInfo(
+                    payload=js_code,
+                    type=PayloadType.xss_closing_tag,
+                    name=payload_infos["name"],
+                    injection_type=payload_infos["injection_type"],
+                )
+            )
 
     return result
 
@@ -381,7 +396,12 @@ def apply_attrname_context(context: Dict[str, str], payloads: List[Dict[str, str
                 js_code += payload_infos["payload"].replace("__XSS__", code)
 
                 result.append(
-                    PayloadInfo(payload=js_code, type=PayloadType.xss_closing_tag, name=payload_infos["name"])
+                    PayloadInfo(
+                        payload=js_code,
+                        type=PayloadType.xss_closing_tag,
+                        name=payload_infos["name"],
+                        injection_type=payload_infos["injection_type"],
+                    )
                 )
 
     return result
@@ -405,7 +425,12 @@ def apply_tagname_context(context: Dict[str, str], payloads: List[Dict[str, str]
 
                 js_code = js_code[1:]  # use independent payloads, just remove the first character (<)
                 result.append(
-                    PayloadInfo(payload=js_code, type=PayloadType.xss_closing_tag, name=payload_infos["name"])
+                    PayloadInfo(
+                        payload=js_code,
+                        type=PayloadType.xss_closing_tag,
+                        name=payload_infos["name"],
+                        injection_type=payload_infos["injection_type"],
+                    )
                 )
     else:
         for payload_infos in payloads:
@@ -418,7 +443,12 @@ def apply_tagname_context(context: Dict[str, str], payloads: List[Dict[str, str]
                     js_code += "</" + context["non_exec_parent"] + ">"
                 js_code += payload_infos["payload"].replace("__XSS__", code)
                 result.append(
-                    PayloadInfo(payload=js_code, type=PayloadType.xss_closing_tag, name=payload_infos["name"])
+                    PayloadInfo(
+                        payload=js_code,
+                        type=PayloadType.xss_closing_tag,
+                        name=payload_infos["name"],
+                        injection_type=payload_infos["injection_type"],
+                    )
                 )
 
     return result
@@ -445,7 +475,12 @@ def apply_text_context(context: Dict[str, str], payloads: List[Dict[str, str]], 
         else:
             js_code = prefix + payload_infos["payload"].replace("__XSS__", code)
             result.append(
-                PayloadInfo(payload=js_code, type=PayloadType.xss_closing_tag, name=payload_infos["name"])
+                PayloadInfo(
+                    payload=js_code,
+                    type=PayloadType.xss_closing_tag,
+                    name=payload_infos["name"],
+                    injection_type=payload_infos["injection_type"],
+                )
             )
 
     return result
@@ -472,7 +507,12 @@ def apply_comment_context(context: Dict[str, str], payloads: List[Dict[str, str]
         else:
             js_code = prefix + payload_infos["payload"].replace("__XSS__", code)
             result.append(
-                PayloadInfo(payload=js_code, type=PayloadType.xss_closing_tag, name=payload_infos["name"])
+                PayloadInfo(
+                    payload=js_code,
+                    type=PayloadType.xss_closing_tag,
+                    name=payload_infos["name"],
+                    injection_type=payload_infos["injection_type"],
+                )
             )
 
     return result


### PR DESCRIPTION
Idea I wanted to implement for quite some time: in some cases a WAF can block our JS payloads but HTML injection is still possible. This is often the indication that XSS is still possible but would require more work (obfuscation, etc)

The aim of that PR is to add a payload without JS and use it as a fallback if no JS payloads succeeded before.

I also fixed some bugs I discovered in `mod_permanentxss` and added some tests