### PR TITLE
Fix #394: Network issues and crawlers improvements

### DIFF
--- a/tests/web/test_network_issues.py
+++ b/tests/web/test_network_issues.py
@@ -30,7 +30,7 @@ async def test_chunked_timeout():
     crawler_configuration = CrawlerConfiguration(request, timeout=1)
     async with AsyncCrawler.with_configuration(crawler_configuration) as crawler:
         with pytest.raises(ReadTimeout):
-            await crawler.async_send(request)
+            await crawler.async_send(request, timeout=1)
 
 
 @pytest.mark.asyncio
@@ -41,4 +41,4 @@ async def test_timeout():
     crawler_configuration = CrawlerConfiguration(request, timeout=1)
     async with AsyncCrawler.with_configuration(crawler_configuration) as crawler:
         with pytest.raises(ReadTimeout):
-            await crawler.async_send(request)
+            await crawler.async_send(request, timeout=1)

--- a/wapitiCore/attack/attack.py
+++ b/wapitiCore/attack/attack.py
@@ -310,9 +310,9 @@ class Attack:
             skip=self.options.get("skipped_parameters")
         )
 
-    async def does_timeout(self, request):
+    async def does_timeout(self, request, timeout: float = None):
         try:
-            await self.crawler.async_send(request)
+            await self.crawler.async_send(request, timeout=timeout)
         except ReadTimeout:
             return True
         except RequestError:

--- a/wapitiCore/attack/mod_timesql.py
+++ b/wapitiCore/attack/mod_timesql.py
@@ -73,10 +73,10 @@ class ModuleTimesql(Attack):
             log_verbose(f"[¨] {mutated_request}")
 
             try:
-                response = await self.crawler.async_send(mutated_request)
+                response = await self.crawler.async_send(mutated_request, timeout=self.time_to_sleep)
             except ReadTimeout:
                 # The request with time based payload did timeout, what about a regular request?
-                if await self.does_timeout(request):
+                if await self.does_timeout(request, timeout=self.time_to_sleep):
                     self.network_errors += 1
                     logging.error("[!] Too much lag from website, can't reliably test time-based blind SQL")
                     break


### PR DESCRIPTION
Fix issue #394.

* I fix the network issues with a new configuration in `crawler.py` : 
```python
self._timeout = httpx.Timeout(timeout, read=None)
```

I did many tests to decide how to do. And here is some element to compare why None is better : 

Here with 10s in read timeout
![image](https://github.com/wapiti-scanner/wapiti/assets/37926502/72f50eee-97a4-46ba-8661-94487d03a5ca)

Here with None in read timeout
![image](https://github.com/wapiti-scanner/wapiti/assets/37926502/173b7125-8ff9-4915-9a72-55d58742e02e)

The crawler is faster and crawl more URL than with 10s timeout. There is no chance to be stuck with the response delay because connect, pool and write timer are set to default or -t option.

* I also set a new param in different send request to allow the overwriting of the new crawler configuration for some modules like `timesql` and change the `read=None` to the -t or the default value.

* I change the timeout in headless crawler to fit with the -t option instead of constant value.

* I make changes with the new behaviour in test_network_issues modules.



