### PR TITLE
Rework mod_methods

### DIFF
--- a/tests/attack/test_mod_methods.py
+++ b/tests/attack/test_mod_methods.py
@@ -20,27 +20,45 @@ async def test_trivial():
         "http://perdu.com/dav/",
     ]
 
-    # Link to test the module if there is nothing to discover
+    # First case: We reply to OPTIONS with a short list of allowed methods
     respx.options(mocking_links[0]).mock(
         return_value=httpx.Response(200, text="Default page", headers={"Allow": "GET,POST,HEAD"})
     )
+
+    # Here they are
     respx.get(mocking_links[0]).mock(
         return_value=httpx.Response(200, text="Body from GET option")
     )
+    respx.post(mocking_links[0]).mock(
+        return_value=httpx.Response(200, text="Body from GET option")
+    )
+    respx.head(mocking_links[0]).mock(
+        return_value=httpx.Response(200, text="")
+    )
 
-    # Link to test the module in the following cases:
-    # - Different server code and different body
-    # - Same server code and same body
+    # Second case: more HTTP methods possible
     respx.options(mocking_links[1]).mock(
         # Method OPTIONS that discover the other methods
         return_value=httpx.Response(200, text="Private section", headers={"Allow": "GET,POST,HEAD,PUT,DELETE"})
     )
+
+    # Not interesting
+    respx.head(mocking_links[1]).mock(
+        return_value=httpx.Response(200, text="")
+    )
+    # Used as reference for comparison
     respx.get(mocking_links[1]).mock(
         return_value=httpx.Response(200, text="Body from GET option")
     )
+    # Same as reference
+    respx.post(mocking_links[1]).mock(
+        return_value=httpx.Response(200, text="Body from GET option")
+    )
+    # Should be detected
     respx.put(mocking_links[1]).mock(
         return_value=httpx.Response(500, text="Body from PUT method")
     )
+    # Same as reference
     respx.delete(mocking_links[1]).mock(
         return_value=httpx.Response(200, text="Body from GET option")
     )
@@ -58,28 +76,29 @@ async def test_trivial():
         )
         all_requests.append((request, response))
 
-    crawler_configuration = CrawlerConfiguration(
-        Request("http://perdu.com/"), timeout=1)
+    crawler_configuration = CrawlerConfiguration(Request("http://perdu.com/"), timeout=1)
+
     async with AsyncCrawler.with_configuration(crawler_configuration) as crawler:
         options = {"timeout": 10, "level": 2}
 
-        module = ModuleMethods(crawler, persister, options,
-                               Event(), crawler_configuration)
+        module = ModuleMethods(crawler, persister, options, Event(), crawler_configuration)
         module.do_get = True
         for request, response in all_requests:
             await module.attack(request, response)
 
         assert persister.add_payload.call_count == 2
-        # Below, tuple containing string (link) followed by
-        # dicts of sets which are their wanted/unwanted method associated
-        check_strings = (mocking_links[1], {'wanted': {'PUT'},
-                                            'unwanted': {'GET', 'POST', 'DELETE', 'HEAD'},
-                                            })
-        assert check_strings[0] in persister.add_payload.call_args_list[0][1]["info"]
-        # Check if every wanted methods is detected
-        assert any(s in persister.add_payload.call_args_list[0][1]["info"] for s in check_strings[1]['wanted'])
-        # Check for any unwanted and detected methods
-        assert not all(s in persister.add_payload.call_args_list[0][1]["info"] for s in check_strings[1]['unwanted'])
+        assert "Possible interesting methods (using OPTIONS) on http://perdu.com/: OPTIONS (200)" == (
+            persister.add_payload.call_args_list[0][1]["info"]
+        )
+        assert mocking_links[0] == persister.add_payload.call_args_list[0][1]["request"].url
+
+        assert "Possible interesting methods (using OPTIONS) on http://perdu.com/dav/: OPTIONS (200) PUT (500)" == (
+            persister.add_payload.call_args_list[1][1]["info"]
+        )
+        assert mocking_links[1] == persister.add_payload.call_args_list[1][1]["request"].url
+
+        # OPTIONS,GET,POST,HEAD then OPTIONS,GET,POST,HEAD,PUT,DELETE
+        assert len(respx.calls) == 10
 
 
 @pytest.mark.asyncio
@@ -94,10 +113,21 @@ async def test_advanced():
 
     respx.options(mocking_link).mock(
         # Method OPTIONS that discover the other methods
-        return_value=httpx.Response(200, text="Body from OPTIONS method", headers={
-                                    "Allow": "GET,POST,HEAD,PUT,DELETE,PATCH"})
+        return_value=httpx.Response(
+            200,
+            text="Body from OPTIONS method",
+            headers={"Allow": "GET,POST,HEAD,PUT,DELETE,PATCH"}
+        )
+    )
+    respx.head(mocking_link).mock(
+        # Method GET that serve as a reference
+        return_value=httpx.Response(200, text="")
     )
     respx.get(mocking_link).mock(
+        # Method GET that serve as a reference
+        return_value=httpx.Response(200, text="Body from GET method")
+    )
+    respx.post(mocking_link).mock(
         # Method GET that serve as a reference
         return_value=httpx.Response(200, text="Body from GET method")
     )
@@ -106,7 +136,7 @@ async def test_advanced():
         return_value=httpx.Response(405, text="Not supposed to reach that")
     )
     respx.put(mocking_link).mock(
-        # Method with the same server retrun code but a different body
+        # Method with the same server return code but a different body
         return_value=httpx.Response(
             200, text="Same return code but different body")
     )
@@ -122,56 +152,50 @@ async def test_advanced():
         httpx.Response(status_code=200),
         url=mocking_link
     )
-    crawler_configuration = CrawlerConfiguration(
-        Request("http://perdu.com/"), timeout=1)
+    crawler_configuration = CrawlerConfiguration(Request("http://perdu.com/"), timeout=1)
     async with AsyncCrawler.with_configuration(crawler_configuration) as crawler:
         options = {"timeout": 10, "level": 2}
 
-        module = ModuleMethods(crawler, persister, options,
-                               Event(), crawler_configuration)
+        module = ModuleMethods(crawler, persister, options, Event(), crawler_configuration)
         module.do_get = True
         await module.attack(request, response)
 
-        assert persister.add_payload.call_count == 3
-        # Below, tuple containing string (link) followed by
-        # dicts of sets which are their wanted/unwanted method associated
-        check_strings = (mocking_link, {'wanted': {'PUT', 'PATCH'},
-                                        'unwanted': {'DELETE'}
-                                        })
-        assert check_strings[0] in persister.add_payload.call_args_list[0][1]["info"]
-        for i in range(len(check_strings[1])):
-            # Check if every wanted methods is detected
-            assert any(s in persister.add_payload.call_args_list[i][1]["info"] for s in check_strings[1]['wanted'])
-            # Check for any unwanted and detected methods
-            assert not all(s in persister.add_payload.call_args_list[i][1]["info"]
-                           for s in check_strings[1]['unwanted'])
+        assert persister.add_payload.call_count == 1
+        assert (
+            "Possible interesting methods (using OPTIONS) on http://perdu.com/dummy/: "
+            "OPTIONS (200) PATCH (500) PUT (200)"
+        ) == persister.add_payload.call_args_list[0][1]["info"]
 
 
 @pytest.mark.asyncio
 @respx.mock
-async def test_blind_options():
-    # Mock a website with an empty option method
+async def test_blind_with_trace():
     mocking_link = "http://perdu.com/dummy/"
 
-    # first, we mock an empty option method
-    respx.options(mocking_link).mock(
-        return_value=httpx.Response(200, text="Body from OPTIONS method")
+    # Content bellow are the same as GET so should be ignored
+    for method in ("GET", "POST", "PUT", "OPTIONS", "HEAD", "DELETE"):
+        respx.request(method, mocking_link).mock(
+            return_value=httpx.Response(
+                200,
+                text="Welcome",
+            )
+        )
+
+    # Trace is activated and return the request
+    respx.request("TRACE", mocking_link).mock(
+        # Method with a different server return code but the same body
+        return_value=httpx.Response(200, text="TRACE /")
     )
 
-    supported_methods = ["GET", "POST", "HEAD", "TRACE", "CONNECT", "DELETE", "PUT", "PATCH"]
-    half_size_supported_methods = int(len(supported_methods)/2)
-    # We define half of the method as good, the other ones as not allowed
-    mock_responses = {}
-    for i, method in enumerate(supported_methods):
-        if i < half_size_supported_methods:
-            mock_responses.update({method: httpx.Response(200, text=f"Body from {method} method")})
-        else:
-            mock_responses.update({method: httpx.Response(405, text=f"Body from {method} method")})
+    # Patch gives something unusual
+    respx.patch(mocking_link).mock(
+        return_value=httpx.Response(200, text="This is something secret"),
+    )
 
-    for method, response in mock_responses.items():
-        respx.route(method=method, url=mocking_link).mock(
-            return_value=response
-        )
+    # Common behavior for CONNECT should be ignored
+    respx.request("CONNECT", mocking_link).mock(
+        return_value=httpx.Response(400, text="Invalid request"),
+    )
 
     persister = AsyncMock()
     request = Request(mocking_link)
@@ -180,86 +204,19 @@ async def test_blind_options():
         httpx.Response(status_code=200),
         url=mocking_link
     )
-    crawler_configuration = CrawlerConfiguration(
-        Request("http://perdu.com/"), timeout=1)
+    crawler_configuration = CrawlerConfiguration(Request("http://perdu.com/"), timeout=1)
     async with AsyncCrawler.with_configuration(crawler_configuration) as crawler:
         options = {"timeout": 10, "level": 2}
 
-        module = ModuleMethods(crawler, persister, options,
-                               Event(), crawler_configuration)
+        module = ModuleMethods(crawler, persister, options, Event(), crawler_configuration)
         module.do_get = True
         await module.attack(request, response)
 
-        assert persister.add_payload.call_count == 5
-        # Below, tuple containing string (link) followed by
-        # dicts of sets which are their wanted/unwanted method associated
-        check_strings = (mocking_link, {'wanted': set(supported_methods[:half_size_supported_methods]),
-                                        'unwanted': set(supported_methods[half_size_supported_methods:])
-                                        })
-        assert check_strings[0] in persister.add_payload.call_args_list[0][1]["info"]
-        for i, method in enumerate(supported_methods[:half_size_supported_methods]):
-            # Check if every wanted methods is detected
-            assert any(s in persister.add_payload.call_args_list[i][1]["info"] for s in check_strings[1]['wanted'])
-            # Check for any unwanted and detected methods
-            assert not all(s in persister.add_payload.call_args_list[i][1]["info"]
-                           for s in check_strings[1]['unwanted'])
+        assert persister.add_payload.call_count == 2
+        assert "HTTP TRACE method is allowed on the webserver" == persister.add_payload.call_args_list[0][1]["info"]
+        assert (
+                "Possible interesting methods (using heuristics) on http://perdu.com/dummy/: PATCH (200) TRACE (200)"
+               ) == persister.add_payload.call_args_list[1][1]["info"]
 
-
-@pytest.mark.asyncio
-@respx.mock
-async def test_not_allowed_options():
-    # This test is the same as the blind options
-    # When OPTIONS is not allowed, the module test each
-    # method separately
-    # Mock a website with an empty option method
-    mocking_link = "http://perdu.com/dummy/"
-
-    # first, we mock an empty option method
-    respx.options(mocking_link).mock(
-        return_value=httpx.Response(405, text="Body from OPTIONS method")
-    )
-    supported_methods = ["GET", "POST", "HEAD", "TRACE", "CONNECT", "DELETE", "PUT", "PATCH"]
-    half_size_supported_methods = int(len(supported_methods)/2)
-    # We define half of the method as good, the other ones as not allowed
-    mock_responses = {}
-    for i, method in enumerate(supported_methods):
-        if i < half_size_supported_methods:
-            mock_responses.update({method: httpx.Response(200, text=f"Body from {method} method")})
-        else:
-            mock_responses.update({method: httpx.Response(405, text=f"Body from {method} method")})
-
-    for method, response in mock_responses.items():
-        respx.route(method=method, url=mocking_link).mock(
-            return_value=response
-        )
-
-    persister = AsyncMock()
-    request = Request(mocking_link)
-    request.path_id = 1
-    response = Response(
-        httpx.Response(status_code=200),
-        url=mocking_link
-    )
-    crawler_configuration = CrawlerConfiguration(
-        Request("http://perdu.com/"), timeout=1)
-    async with AsyncCrawler.with_configuration(crawler_configuration) as crawler:
-        options = {"timeout": 10, "level": 2}
-
-        module = ModuleMethods(crawler, persister, options,
-                               Event(), crawler_configuration)
-        module.do_get = True
-        await module.attack(request, response)
-
-        assert persister.add_payload.call_count == 4
-        # Below, tuple containing string (link) followed by
-        # dicts of sets which are their wanted/unwanted method associated
-        check_strings = (mocking_link, {'wanted': set(supported_methods[:half_size_supported_methods]),
-                                        'unwanted': set(supported_methods[half_size_supported_methods:])
-                                        })
-        assert check_strings[0] in persister.add_payload.call_args_list[0][1]["info"]
-        for i, method in enumerate(supported_methods[:half_size_supported_methods]):
-            # Check if every wanted methods is detected
-            assert any(s in persister.add_payload.call_args_list[i][1]["info"] for s in check_strings[1]['wanted'])
-            # Check for any unwanted and detected methods
-            assert not all(s in persister.add_payload.call_args_list[i][1]["info"]
-                           for s in check_strings[1]['unwanted'])
+        # All HTTP verbs should have been used
+        assert len({call.request.method for call in respx.calls}) == 9


### PR DESCRIPTION
Made some changes to mod_methods to address several issues:

- module said it was comparing the response with the one for GET which was not always the case
- as many report entries that interesting HTTP methods allowed
- very verbose output
- some common behavior not filtered (for example CONNECT without argument usually gives a 400 error)

Also added a check to report presence of TRACE is activated on the server