### PR TITLE
Passer l'image wapiti en debian 12

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:bullseye-slim as build
+FROM debian:bookworm-slim as build
 
 ENV DEBIAN_FRONTEND=noninteractive \
   LANG=en_US.UTF-8
@@ -14,13 +14,14 @@ RUN apt update \
 
 COPY . .
 
-RUN pip3 install .
+RUN pip3 install . --break-system-packages
 
-FROM debian:bullseye-slim
+FROM debian:bookworm-slim
 
 ENV DEBIAN_FRONTEND=noninteractive \
   LANG=en_US.UTF-8 \
-  PYTHONDONTWRITEBYTECODE=1
+  PYTHONDONTWRITEBYTECODE=1 \
+  OPENSSL_CONF='/etc/wapiti/openssl_conf'
 
 RUN apt update \
   && apt install python3 python3-setuptools -y \
@@ -29,7 +30,8 @@ RUN apt update \
   && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* \
   && truncate -s 0 /var/log/*log
 
-COPY --from=build /usr/local/lib/python3.9/dist-packages/ /usr/local/lib/python3.9/dist-packages/
+COPY --from=build /usr/local/lib/python3.11/dist-packages/ /usr/local/lib/python3.11/dist-packages/
 COPY --from=build /usr/local/bin/wapiti /usr/local/bin/wapiti-getcookie /usr/local/bin/
+COPY --chmod=644 openssl_conf /etc/wapiti/
 
 ENTRYPOINT ["wapiti"]

--- a/openssl_conf
+++ b/openssl_conf
@@ -1,0 +1,28 @@
+# Debian 12 is shipped with openssl 3.0, which deactivate a lot of old ciphers.
+# In order to scan some old websites, we have to activate weak ciphers.
+# This conf allow the container to use the legacy provider.
+#
+# Another problem is that the Legacy Rengotiation is deactivated. Let's reactivate it.
+
+openssl_conf = openssl_init
+
+[openssl_init]
+providers = provider_sect
+ssl_conf = ssl_sect
+
+[provider_sect]
+default = default_sect
+legacy = legacy_sect
+
+[default_sect]
+activate = 1
+
+[legacy_sect]
+activate = 1
+
+[ssl_sect]
+system_default = system_default_sect
+
+[system_default_sect]
+Options = UnsafeLegacyRenegotiation
+


### PR DESCRIPTION
Le changement de version de pip induit un problème concernant les env « externally managed »

```
× This environment is externally managed
╰─> To install Python packages system-wide, try apt install
python3-xyz, where xyz is the package you are trying to
install.

If you wish to install a non-Debian-packaged Python package,
create a virtual environment using python3 -m venv path/to/venv.
Then use path/to/venv/bin/python and path/to/venv/bin/pip. Make
sure you have python3-full installed.

If you wish to install a non-Debian packaged Python application,
it may be easiest to use pipx install xyz, which will manage a
virtual environment for you. Make sure you have pipx installed.

See /usr/share/doc/python3.11/README.venv for more information.

note: If you believe this is a mistake, please contact your Python installation or OS distribution provider. You can override this, at the risk of breaking your Python installation or OS, by passing --break-system-packages.
hint: See PEP 668 for the detailed specification.
```

Utiliser un venv n'est pas possible dans notre cas d'usage, alors j'ai préféré utiliser le flag pour passer outre cette alerte.