### PR TITLE
Add XML content-type verification in wp_enum

### DIFF
--- a/tests/attack/test_mod_wp_enum.py
+++ b/tests/attack/test_mod_wp_enum.py
@@ -219,7 +219,34 @@ async def test_wp_version():
         )
     )
 
+    # test with no content-type, should be skipped
     respx.get("http://perdu.com/feed/").mock(
+        return_value=httpx.Response(
+            200,
+            text='<?xml version="1.0" encoding="UTF-8"?>\
+                <rss version="2.0">\
+                    <channel>\
+                        <generator>https://wordpress.org/?v=4.3.2</generator>\
+                    </channel>\
+                </rss>'
+        )
+    )
+
+    # test with content-type different from XML, should be skipped
+    respx.get("http://perdu.com/comments/feed/").mock(
+        return_value=httpx.Response(
+            200,
+            text='<?xml version="1.0" encoding="UTF-8"?>\
+                <rss version="2.0">\
+                    <channel>\
+                        <generator>https://wordpress.org/?v=5.4.3</generator>\
+                    </channel>\
+                </rss>',
+            headers={"content-type":"text/html, charset=UTF-8"}
+        )
+    )
+
+    respx.get("http://perdu.com/feed/rss/").mock(
         return_value=httpx.Response(
             200,
             text='<?xml version="1.0" encoding="UTF-8"?>\
@@ -227,7 +254,8 @@ async def test_wp_version():
                     <channel>\
                         <generator>https://wordpress.org/?v=5.8.2</generator>\
                     </channel>\
-                </rss>'
+                </rss>',
+            headers={"content-type":"application/rss+xml, charset=UTF-8"}
         )
     )
 

--- a/wapitiCore/attack/mod_wp_enum.py
+++ b/wapitiCore/attack/mod_wp_enum.py
@@ -9,7 +9,7 @@ from wapitiCore.attack.attack import Attack
 from wapitiCore.definitions.fingerprint import NAME as TECHNO_DETECTED
 from wapitiCore.definitions.fingerprint import WSTG_CODE as TECHNO_DETECTED_WSTG_CODE
 from wapitiCore.definitions.fingerprint_webapp import NAME as WEB_APP_VERSIONED
-from wapitiCore.main.log import log_blue, logging
+from wapitiCore.main.log import log_blue, log_orange, logging
 from wapitiCore.net.response import Response
 from wapitiCore.net import Request
 
@@ -54,7 +54,10 @@ class ModuleWpEnum(Attack):
             request = Request(f"{url}{'' if url.endswith('/') else '/'}{rss_url}", "GET")
             response: Response = await self.crawler.async_send(request, follow_redirects=True)
 
-            if not response.content or response.is_error:
+            if not response.content or response.is_error or "content-type" not in response.headers:
+                continue
+            if "xml" not in response.headers["content-type"]:
+                log_orange(f"Response content-type for {rss_url} is not XML")
                 continue
             root = ET.fromstring(response.content)
 


### PR DESCRIPTION
Add XML content-type verification in Wordpress version detection method since some WordPress might force a redirection to php file instead of XML file in some cases.