### PR TITLE
wappalyzer accept multiple headers and meta values

### DIFF
--- a/wapitiCore/parsers/html_parser.py
+++ b/wapitiCore/parsers/html_parser.py
@@ -209,6 +209,21 @@ class Html:
         return metas
 
     @property
+    def multi_meta(self) -> List[Tuple[str, str]]:
+        """Returns a list of tuples of all metas tags with name attribute as the first element of the tuple and content
+           attribute as last element of the tuple. Useful when multiple meta tags have the same name but different
+           content.
+        """
+        metas = []
+        if self.soup.head is not None:
+            for meta_tag in self.soup.head.find_all("meta", attrs={"name": True, "content": True}):
+                tag_name = meta_tag["name"].lower().strip()
+                if tag_name:
+                    metas.append((tag_name, meta_tag["content"]))
+
+        return metas
+
+    @property
     def description(self) -> str:
         """Returns the content of the meta description tag in the HTML header.
 


### PR DESCRIPTION
Still pursuing my work on #413 

I found out that with headers and meta having multiple values for the same attribute, the wapp module miss technologies. 
### Issue with the header
 Let's admit a response has 2 headers Server (example 1) :
```
Server : this 
Server : that
```
Or (example 2) :
```
Server : this, that
```
The code used to concatenate each value from attributes in a dictionary with a single string that way:
```Python
{
   "Server": "this, that"
}
```
Which will make some regexes fail: admitting we can detect a technology thanks to its server attribute ``that`` by its regex, which is ``^that$``. It will not work as the regex is expecting the string to start and end with this word. As this behavior comes from HTTPX, you can find [more information here](https://www.python-httpx.org/quickstart/#response-headers).

Instead of using a split method (because we can't take for granted the fact that all the attributes will never have a ", " as values inside of them) I took advantage from the httpx.Header object with its ``multi_items()`` method, so now we have a dictionary that looks like this:
```Python
{
   "Server": ["this", "that"]
}
```
and we iterate regexes through the items

Finding servers having multiple headers parsed that way (example 1) is rare, and non standard but this patch also cover the standard behavior (example 2) as mentioned in the [4.2 section of the RFC2616](https://www.ietf.org/rfc/rfc2616.txt).

### Issue with the meta tags
The issue was the same with the meta tag. Let's admit we have a page with multiple meta tag that have the same name but a different content:
```HTML
<meta name="keywords" content="John">
<meta name="keywords" content="Doe">
<meta name="keywords" content="Wasn't">
<meta name="keywords" content="Here">
```
The HTML parser will only parse then erase each one to only keep the last one. So I fixed this issue to give the same format than the HTTP headers:
```Python
{
   "keywords": ["John", "Doe", "Wasn't", "Here"]
}
```
There wasn't any ``multi_items()`` method in the HTML parser so I had to implement my own 
