### PR TITLE
add_logs_to_buster_module

### DIFF
--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -9,6 +9,9 @@ class AsyncIterator:
     def __aiter__(self):
         return self
 
+    def __call__(self, *args, **kwds):
+        return self
+
     async def __anext__(self):
         try:
             return next(self.iter)

--- a/tests/attack/test_mod_buster.py
+++ b/tests/attack/test_mod_buster.py
@@ -1,5 +1,5 @@
 from unittest import mock
-from unittest.mock import Mock, patch
+from unittest.mock import AsyncMock, patch
 from asyncio import Event
 
 import httpx
@@ -27,12 +27,12 @@ async def test_whole_stuff():
     respx.get("http://perdu.com/admin/authconfig.php").mock(return_value=httpx.Response(200, text="Hello there"))
     respx.get(url__regex=r"http://perdu\.com/.*").mock(return_value=httpx.Response(404))
 
-    persister = Mock()
+    persister = AsyncMock()
 
     request = Request("http://perdu.com/")
     request.path_id = 1
     # Buster module will get requests from the persister
-    persister.get_links.return_value = AsyncIterator([(request, None)])
+    persister.get_links = AsyncIterator([(request, None)])
 
     crawler_configuration = CrawlerConfiguration(Request("http://perdu.com/"), timeout=1)
     async with AsyncCrawler.with_configuration(crawler_configuration) as crawler:
@@ -46,7 +46,11 @@ async def test_whole_stuff():
             module.DATA_DIR = ""
             module.PATHS_FILE = "wordlist.txt"
             module.do_get = True
-            await module.attack(request, None)
+            await module.attack(request)
 
             assert module.known_dirs == ["http://perdu.com/", "http://perdu.com/admin/"]
             assert module.known_pages == ["http://perdu.com/config.inc", "http://perdu.com/admin/authconfig.php"]
+        assert persister.add_payload.call_count == 3
+        assert "http://perdu.com/admin" in persister.add_payload.call_args_list[0][1]["info"]
+        assert "http://perdu.com/config.inc" in persister.add_payload.call_args_list[1][1]["info"]
+        assert "http://perdu.com/admin/authconfig.php" in persister.add_payload.call_args_list[2][1]["info"]

--- a/wapitiCore/definitions/buster.py
+++ b/wapitiCore/definitions/buster.py
@@ -1,0 +1,26 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+TYPE = "additional"
+
+NAME = "Review Webserver Metafiles for Information Leakage"
+SHORT_NAME = NAME
+
+WSTG_CODE = ["WSTG-INFO-03"]
+
+DESCRIPTION = (
+    "Test various metadata files for information leakage of the web application’s path(s), or functionality"
+)
+
+SOLUTION = (
+    "This is only for informational purposes."
+)
+
+REFERENCES = [
+    {
+        "title": "OWASP: Review Webserver Metafiles for Information Leakage",
+        "url": (
+            "https://owasp.org/www-project-web-security-testing-guide/v42/4-Web_Application_Security_Testing/"
+            "01-Information_Gathering/03-Review_Webserver_Metafiles_for_Information_Leakage"
+        )
+    }
+]


### PR DESCRIPTION
Answer to #406 greatly inspired by #410 
I took the work of @OussamaBeng and tested it on websites. It was indeed working, but the unit tests messed up because of some asynchronous misconfiguration in the mocking system. I managed to bypass this problem by making the ``AsyncIterator`` object returning itself on its call  dunder and added some assertions to ensure that everything was indeed in the report.

I've also simplified the code by reducing its cyclomatic complexity 