### PR TITLE
Fix keys lowering in wapp module

### DIFF
--- a/tests/integration/test_mod_wapp/assertions/wapp_other_mock_index.wiki.jsp.html.json
+++ b/tests/integration/test_mod_wapp/assertions/wapp_other_mock_index.wiki.jsp.html.json
@@ -147,6 +147,16 @@
             {
                 "method": "GET",
                 "path": "/other_mock/index.wiki.jsp.html",
+                "info": "{\"name\": \"Open Journal Systems\", \"versions\": [], \"cpe\": \"cpe:2.3:a:public_knowledge_project:open_journal_systems:*:*:*:*:*:*:*:*\", \"categories\": [\"DMS\"], \"groups\": [\"Content\"]}",
+                "http_request": "GET /other_mock/index.wiki.jsp.html HTTP/1.1",
+                "wstg": [
+                    "WSTG-INFO-02",
+                    "WSTG-INFO-08"
+                ]
+            },
+            {
+                "method": "GET",
+                "path": "/other_mock/index.wiki.jsp.html",
                 "info": "{\"name\": \"PHP\", \"versions\": [], \"cpe\": \"cpe:2.3:a:php:php:*:*:*:*:*:*:*:*\", \"categories\": [\"Programming languages\"], \"groups\": [\"Web development\"]}",
                 "http_request": "GET /other_mock/index.wiki.jsp.html HTTP/1.1",
                 "wstg": [

--- a/wapitiCore/wappalyzer/wappalyzer.py
+++ b/wapitiCore/wappalyzer/wappalyzer.py
@@ -303,15 +303,17 @@ def detect_versions_normalize_dict(rules: dict, contents) -> Set[str]:
     Add a new version of application if the content matches
     """
     versions = set()
+    lowercase_keys_content = {key.lower(): value for key, value in contents.items()}
     for (key, regex_params) in rules.items():
-        if key in contents:
+        # If the key is in lowercase, we erase 'contents' by its lowercased-key version
+        if (key in contents) or (key in (contents := lowercase_keys_content)):
             # regex_params is a list : [{"application_pattern": "..", "regex": "re.compile(..)"}, ...]
             for i, _ in enumerate(regex_params):
                 for content_value in contents[key]:
                     # If the regex fails, it can be due to the fact that we are looking for the key instead
                     # The value can be set to the key so we compare
                     if re.search(regex_params[i]['regex'], content_value) or\
-                       regex_params[i]['application_pattern'] == key:
+                       regex_params[i]['application_pattern'] == key.lower():
                         # Use that special string to show we detected the app once but not necessarily a version
                         versions.add("__detected__")
                         versions.update(extract_version(regex_params[i], content_value))


### PR DESCRIPTION
Still patching #413 

## The issue
Now we have a comparison with keys when values are empty, but as described [here](https://github.com/wapiti-scanner/wapiti/blob/2484cde92120bf7df2298768afa8df5ccaa070c5/wapitiCore/wappalyzer/wappalyzer.py#L90-L92) all keys from meta, headers, cookies and dom are lowercased when normalizing the database. 

This is not the case with keys inputted in the module from the content. This fix lower all keys on the fly as soon as we compare them. 

Unit tests will come in a separated MR for every previous MR I made

## Example

```JSON
 "Open Journal Systems": {
    "cats": [
      50
    ],
    "cookies": {
      "OJSSID": ""
    },
    "cpe": "cpe:2.3:a:public_knowledge_project:open_journal_systems:*:*:*:*:*:*:*:*",
    "description": "Open Journal Systems (OJS) is an open-source software application for managing and publishing scholarly journals.",
    "icon": "Open Journal Systems.png",
    "implies": "PHP",
    "meta": {
      "generator": "Open Journal Systems(?: ([\\d.]+))?\\;version:\\1"
    },
    "website": "https://pkp.sfu.ca/ojs"
  }
```
This is in the database (this isn't the only technology doing this), the only cookie will be transformed to ``ojssid`` for comparing, whether the real cookie is still ``OJSSID`` in the wild and the comparison will fail if not lowered


EDIT:
Patching this issue will make the CI go red (in  the integration part) because wapp will detect more techs, an assertion regeneration is required on the ``test_mod_wapp`` after a rebase of this MR