### PR TITLE
changes on run.sh and check.sh

### DIFF
--- a/tests/integration/check.sh
+++ b/tests/integration/check.sh
@@ -30,7 +30,7 @@ MODULE_NAME=$(basename "$(realpath ..)")
 declare -a assertions
 mapfile -t assertions < <(find . -name "*.json")
 if [[ ${#assertions[@]} -eq 0 ]]; then 
-    die "Error: No assertions found in module $MODULE_NAME"
+    die "Error: No assertions found in module ${MODULE_NAME}"
 fi
 
 # Since the assertions and the target reports must have the same name 
@@ -47,10 +47,10 @@ done
 # we can safely use indexes to compare
 declare -a outputs
 for target in "${targets_name[@]}"; do
-    outputs+=("$(realpath "../../.test/$MODULE_NAME/$target.out")")
+    outputs+=("$(realpath "../../.test/${MODULE_NAME}/${target}.out")")
 done
 if [[ ${#outputs[@]} -eq 0 ]]; then 
-    die "Error: No targets found in module $MODULE_NAME"
+    die "Error: No targets found in module ${MODULE_NAME}"
 fi
 
 # A special case is if we don't get the same number of reports as they are targets.
@@ -64,13 +64,13 @@ EXIT_CODE=0
 # Comparing outputs and assertions :
 for i in "${!outputs[@]}"; do
     if [[ "$(cat "${outputs[$i]}")" != "$(cat "${assertions[$i]}")" ]]; then
-        echo -e "Assertion $(basename "${assertions[$i]}" .json) of module $MODULE_NAME is ${RED}not respected:${NC}"
+        echo -e "Assertion $(basename "${assertions[$i]}" .json) of module ${MODULE_NAME} is ${RED}not respected:${NC}"
         echo "< : assertion"
         echo "> : output"
         diff <(jq --sort-keys . "${outputs[$i]}") <(jq --sort-keys . "${assertions[$i]}") || echo "---End of diff of assertion $(basename "${assertions[$i]}" .json) module ${MODULE_NAME}---"
         EXIT_CODE=1
     else 
-        echo -e "Assertion $(basename "${assertions[$i]}" .json) of module $MODULE_NAME is ${GREEN}respected${NC}"
+        echo -e "Assertion $(basename "${assertions[$i]}" .json) of module ${MODULE_NAME} is ${GREEN}respected${NC}"
     fi 
 done
 

--- a/tests/integration/run.sh
+++ b/tests/integration/run.sh
@@ -13,8 +13,9 @@ test_mod_timesql \
 test_mod_wapp "
 
 # Normalize spaces for shell substitution
-if [[ ! -z "$TESTS" ]]; then
-    export TESTS="$(echo "$TESTS" | xargs) "
+if [[ -n "${TESTS}" ]]; then
+    TESTS="$(echo "$TESTS" | xargs) " 
+    export TESTS
 fi
 
 # exit upon any error
@@ -69,7 +70,7 @@ docker compose  --progress quiet -f docker-compose.setup.yml up --abort-on-conta
 
 declare -a asserters=()
 # If the TESTS env variable is supplied, we will only check the specified tests
-if [[ ! -z "$TESTS" ]]; then
+if [[ -n "${TESTS}" ]]; then
     # Assuming all the tests in the TESTS variable are well written and exist
     mapfile -t asserters < <(echo -e "${TESTS// /\/assertions\/check.sh\\n}" |  head -n -1)
 else


### PR DESCRIPTION
Those are 2 patches for the integration test system:
- Variables expansions in strings are normalized with curvy braces
- a debug mode has been implemented to show the logs of all containers while there will all be silent in normal mode (except Wapiti)

TL;DR: see commits titles