### PR TITLE
wrong trimming index in the report

### DIFF
--- a/tests/integration/test_mod_ssrf/assertions/smart_checker.py
+++ b/tests/integration/test_mod_ssrf/assertions/smart_checker.py
@@ -22,7 +22,7 @@ def match_trim(string_1: str, string_2: str, reg: str)-> tuple[str,str]:
     # and MUST be at the same position
     assert (match_1 := reg.search(string_1)) and (match_2 := reg.search(string_2)), \
     "Regex: no match found" 
-    return string_1[:match_1.start()]+string_1[match_2.end():],\
+    return string_1[:match_1.start()]+string_1[match_1.end():],\
            string_2[:match_2.start()]+string_2[match_2.end():]
 
 


### PR DESCRIPTION
Wrong trimming index in the report causing inequality between strings and thus, invalidate the integration test for the ssrf module 