### PR TITLE
mod_exec: Skip time based payloads if no timeout occurred

### DIFF
--- a/wapitiCore/attack/mod_exec.py
+++ b/wapitiCore/attack/mod_exec.py
@@ -165,6 +165,9 @@ class ModuleExec(Attack):
             except RequestError:
                 self.network_errors += 1
             else:
+                if payload_info.type == "time":
+                    continue
+
                 vuln_info = None
 
                 # No timeout raised, check for patterns in response


### PR DESCRIPTION
I noticed invariable issues with time-based payload in mod_exec : they always report vulnerabilities.

THe bug was introduced with the move to the new INI parser, we just need a check to ignore time basedpayloads if no timeout occurred