### PR TITLE
Better detection is_logged_in

### DIFF
--- a/tests/data/logged_in_failed_explicit.html
+++ b/tests/data/logged_in_failed_explicit.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>This is a test page</title>
+</head>
+<body>
+
+    Welcome. Failed to login, please try again.
+
+</body>
+</html>

--- a/tests/data/logged_in_failed_implicit.html
+++ b/tests/data/logged_in_failed_implicit.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>This is a test page</title>
+</head>
+<body>
+
+    Welcome. Unfortunately, login didn't succced
+
+</body>
+</html>

--- a/tests/parsers/test_html_parser.py
+++ b/tests/parsers/test_html_parser.py
@@ -228,7 +228,17 @@ def test_base_other_links():
 
         assert page.html_redirections == ["http://perdu.com/blog/adblock.html"]
 
-def test_logged_in():
+def test_logged_in_success():
     with open("tests/data/logged_in.html") as data_body:
         page = Html(data_body.read(), "http://perdu.com/index.php")
         assert page.is_logged_in()
+
+def test_logged_in_failed_implicit():
+    with open("tests/data/logged_in_failed_implicit.html") as data_body:
+        page = Html(data_body.read(), "http://perdu.com/index.php")
+        assert not page.is_logged_in()
+
+def test_logged_in_failed_explicit():
+    with open("tests/data/logged_in_failed_explicit.html") as data_body:
+        page = Html(data_body.read(), "http://perdu.com/index.php")
+        assert not page.is_logged_in()

--- a/wapitiCore/parsers/html_parser.py
+++ b/wapitiCore/parsers/html_parser.py
@@ -17,6 +17,18 @@ from wapitiCore.net import Request, make_absolute
 from wapitiCore.parsers.javascript import extract_js_redirections
 
 DISCONNECT_REGEX = r'(?i)((log|sign)\s?(out|off)|disconnect|déconnexion)'
+CONNECT_ERROR_REGEX = r'(invalid|'\
+                      r'authentication failed|'\
+                      r'denied|'\
+                      r'incorrect|'\
+                      r'failed|'\
+                      r'not found|'\
+                      r'expired|'\
+                      r'try again|'\
+                      r'captcha|'\
+                      r'two-factors|'\
+                      r'verify your email|'\
+                      r'erreur)'
 
 
 def not_empty(original_function):
@@ -612,5 +624,9 @@ class Html:
                 disconnect_urls.append(link)
         return disconnect_urls
 
-    def is_logged_in(self):
+    def is_logged_in(self) -> bool:
+        # If we find logging errors on the page
+        if self._soup.find(string=re.compile(CONNECT_ERROR_REGEX)) is not None:
+            return False
+        # If we find a disconnect button on the page
         return self._soup.find(string=re.compile(DISCONNECT_REGEX)) is not None


### PR DESCRIPTION
Answer to #317 @tarraschk 
TL;DR: This commit raise a false flag as soon as it detects error messages from the response, and unit tests have been added.

This is only a small improvement, but we can only go little by little to improve this feature, since knowing if we are logged in regardless of which website we are on is a thought challenge. 

Unless someone has a genuine idea, I leave here things that already have been explored:
- Checking redirections by replaying the request on the login page: may not work because some websites doesn't redirect when you are logged in, and doesn't redirect either when you fail to log in
- Checking cookies state before and after the attempt of login: may work but should be implemented cautiously by exploring a large amount of cases (some websites uses cookies for the sessions, some others don't + we should differentiate other cookies from the logging ones)

A good approach would be a smart combination of all those checks with a prioritizing system, but it might be a better idea to move this mechanism somewhere else than in the parser because a simple method in the html_parser wouldn't be enough. A full object might be required in the future to take advantages of all the information we can have on a higher scope

Again, we should be very cautious when improving this method since we want to minimize false negative but absolutely want to avoid false positive.