### PR TITLE
Integration test utility maker

### DIFF
--- a/doc/integration_system.md
+++ b/doc/integration_system.md
@@ -7,6 +7,7 @@ Table of content
     - [Integration test creation guide](#integration-test-creation-guide)
     - [Creating and understanding filters](#creating-and-understanding-filters)
     - [Miscellaneous and notes](#miscellaneous-and-notes)
+- [The automated way](#the-automated-way)
 ----
 
 ## Working principle
@@ -339,3 +340,21 @@ The produced output will be:
 - If you want to mutualize a service between some integration tests, make sure to create a specific folder next to the ``test_*`` ones (like ``endpoint``, ``dns-endpoint``, etc.) to store its config files and make it agnostic from any tests 
 - Sometimes, when running the CI locally on limited hardware, some containers may appears as unhealthy and stop [run.sh](../tests/integration/run.sh). This is mostly due to the databases not ready for some services. Don't hesitate to increase ``DEFAULT_HEALTHCHECKS_RETRIES`` in the [.env](../tests/integration/.env) file. 
 - When creating a ``docker-compose.setup.yml`` file, write paths as if you were in the parent directory since the project path is in [the integration folder](../tests/integration/)
+- If for any reason you want to completely delete a test (not disabling it), you can simply remove its associated folder.  
+
+## The automated way
+
+To avoid repetitive task, the script [init_test.sh](../tests/integration/init_test.sh) has been created. It setups default integration tests by:
+
+- Creating a folder with the supplied name
+- Creating the assertion folder
+- making a symlink to the default [check.sh](../tests/integration/check.sh)
+- Creating a default ``behavior.json`` with the supplied name
+- Creating a default [docker-compose.setup.yml](docker-compose.dummy.yml)
+
+So you can focus on things that will vary among all those files. You may need to remove some generated content inside those files (even remove the symlink) to adjust the test to your needs.
+This script is able to create as many integration tests as you supply them by argument:
+```Bash
+./init_test.sh test_dummy_1 test_dummy_2 test_dummy_3
+```
+It will also check if your tests start by the prefix ``test_`` and if you are using the name of a test that already exists

--- a/tests/integration/init_test.sh
+++ b/tests/integration/init_test.sh
@@ -1,0 +1,134 @@
+#!/bin/bash
+
+TEMPLATE_DOCKER_COMPOSE_FILE='
+version: '\''3.9'\''
+
+# Use the shortcuts you need and remove unused ones
+x-default_php_setup:
+  &default_php_setup
+  image: php${PHP_HASH}
+  networks:
+    - test-network
+
+x-healthcheck_web:
+  &healthcheck_web
+  healthcheck:
+    test: ${DEFAULT_WEB_HEALTHCHECK_COMMAND}
+    interval: ${DEFAULT_HEALTHCHECKS_INTERVAL}
+    timeout: ${DEFAULT_HEALTHCHECKS_TIMEOUT}
+    start_period: ${DEFAULT_HEALTHCHECKS_START_PERIOD}
+    retries: ${DEFAULT_HEALTHCHECKS_RETRIES}
+
+x-default_mysql_setup:
+  &default_mysql_setup
+  image: mysql${MYSQL_HASH}
+  networks:
+    - test-network
+
+x-healthcheck_mysql:
+  &healthcheck_mysql
+  healthcheck:
+    test: ${DEFAULT_MYSQL_HEALTHCHECK_COMMAND}
+    start_period: ${DEFAULT_HEALTHCHECKS_START_PERIOD}
+    interval: ${DEFAULT_HEALTHCHECKS_INTERVAL}
+    timeout: ${DEFAULT_HEALTHCHECKS_TIMEOUT}
+    retries: ${DEFAULT_HEALTHCHECKS_RETRIES}
+
+services:
+  # Enter your services here
+  INT_TEST_NAME:
+    #build:
+    #  context: ./test_INT_TEST_NAME/
+    #  dockerfile: Dockerfile
+    #  args:
+    #   PHP_HASH_TAG: ${PHP_HASH}
+    #<<: *healthcheck_web
+    #networks:
+    #  - test-network
+    #
+    # or 
+    #
+    #<< [ *default_php_setup, *healthcheck_web]
+    volumes:
+      - ./test_INT_TEST_NAME/php/src:/var/www/html
+
+
+
+  # Wapiti container 
+  wapiti:
+    build:
+      context: "../../"
+      dockerfile: "./tests/integration/wapiti/Dockerfile.integration"
+      no_cache: true
+    container_name: wapiti
+    volumes:
+      - ./.test:/home/
+    networks:
+      - test-network
+    command: "${TESTS}"
+    depends_on:
+      INT_TEST_NAME:
+        condition: service_healthy
+      # Don'\''t forget dependencies
+
+networks:
+  test-network:
+';
+
+TEMPLATE_BEHAVIOR_FILE='{
+    "INT_TEST_NAME":{
+        "modules": "",
+        "supplementary_argument": "",
+        "report_filter_tree": {},
+        "targets":[
+            {
+                "name": ""
+            }
+        ]
+    }
+}';
+
+
+# exit upon any error
+set -o errexit;
+
+# exit upon using undeclared variables
+set -o nounset;
+
+# Placing ourselves in the right directory
+cd "$(dirname "$0")";
+
+# Checking part:
+# check if any test must be created
+if (( ${#@} == 0 )); then
+    echo "no iteration test provided";
+    exit 1;
+fi
+
+# Iterating through tests to check them 
+all_tests="$(find . -maxdepth 1 -type d -name "test_*" -printf "%P ")"
+declare -A uniqueness
+for arg in "$@"; do
+    if [[ ! "$arg" =~ ^"test_".* ]]; then
+      echo "integration test name of \"${arg}\" not conform";
+      exit 1;
+    elif [[ "$all_tests" =~ .*"$arg".* ]];then
+      # Checking if any test name already exist
+      echo "integration test \"${arg}\" already exist";
+      exit 1;
+    elif [[ -v uniqueness[$arg] ]]; then
+      echo "duplicate arg $arg"
+      exit 1;
+    fi
+    uniqueness[$arg]=
+done
+# End of checking part
+
+# Iterating through tests to create 
+for arg in "$@"; do
+    mkdir -p "${arg}/assertions";
+    ln -s ../../check.sh "${arg}/assertions/check.sh";
+    mkdir -p "${arg}/php/src";
+    echo "${TEMPLATE_BEHAVIOR_FILE//INT_TEST_NAME/${arg}}" > "${arg}/behavior.json";
+    echo "${TEMPLATE_DOCKER_COMPOSE_FILE//INT_TEST_NAME/${arg#test_}}" > "${arg}/docker-compose.setup.yml";
+done; 

--- a/tests/integration/test_crawler_auth/docker-compose.setup.yml
+++ b/tests/integration/test_crawler_auth/docker-compose.setup.yml
@@ -1,6 +1,5 @@
 version: '3.9'
 
-# Following the DRY philosophy
 x-default_php_setup:
   &default_php_setup
   image: php${PHP_HASH}
@@ -14,21 +13,6 @@ x-healthcheck_web:
     interval: ${DEFAULT_HEALTHCHECKS_INTERVAL}
     timeout: ${DEFAULT_HEALTHCHECKS_TIMEOUT}
     start_period: ${DEFAULT_HEALTHCHECKS_START_PERIOD}
-    retries: ${DEFAULT_HEALTHCHECKS_RETRIES}
-
-x-default_mysql_setup:
-  &default_mysql_setup
-  image: mysql${MYSQL_HASH}
-  networks:
-    - test-network
-
-x-healthcheck_mysql:
-  &healthcheck_mysql
-  healthcheck:
-    test: ${DEFAULT_MYSQL_HEALTHCHECK_COMMAND}
-    start_period: ${DEFAULT_HEALTHCHECKS_START_PERIOD}
-    interval: ${DEFAULT_HEALTHCHECKS_INTERVAL}
-    timeout: ${DEFAULT_HEALTHCHECKS_TIMEOUT}
     retries: ${DEFAULT_HEALTHCHECKS_RETRIES}
 
 services:

--- a/tests/integration/test_crawler_redirect/docker-compose.setup.yml
+++ b/tests/integration/test_crawler_redirect/docker-compose.setup.yml
@@ -1,6 +1,5 @@
 version: '3.9'
 
-# Following the DRY philosophy
 x-default_php_setup:
   &default_php_setup
   image: php${PHP_HASH}
@@ -14,21 +13,6 @@ x-healthcheck_web:
     interval: ${DEFAULT_HEALTHCHECKS_INTERVAL}
     timeout: ${DEFAULT_HEALTHCHECKS_TIMEOUT}
     start_period: ${DEFAULT_HEALTHCHECKS_START_PERIOD}
-    retries: ${DEFAULT_HEALTHCHECKS_RETRIES}
-
-x-default_mysql_setup:
-  &default_mysql_setup
-  image: mysql${MYSQL_HASH}
-  networks:
-    - test-network
-
-x-healthcheck_mysql:
-  &healthcheck_mysql
-  healthcheck:
-    test: ${DEFAULT_MYSQL_HEALTHCHECK_COMMAND}
-    start_period: ${DEFAULT_HEALTHCHECKS_START_PERIOD}
-    interval: ${DEFAULT_HEALTHCHECKS_INTERVAL}
-    timeout: ${DEFAULT_HEALTHCHECKS_TIMEOUT}
     retries: ${DEFAULT_HEALTHCHECKS_RETRIES}
 
 services:

--- a/tests/integration/test_mod_backup/docker-compose.setup.yml
+++ b/tests/integration/test_mod_backup/docker-compose.setup.yml
@@ -1,6 +1,5 @@
 version: '3.9'
 
-# Following the DRY philosophy
 x-default_php_setup:
   &default_php_setup
   image: php${PHP_HASH}
@@ -16,20 +15,6 @@ x-healthcheck_web:
     start_period: ${DEFAULT_HEALTHCHECKS_START_PERIOD}
     retries: ${DEFAULT_HEALTHCHECKS_RETRIES}
 
-x-default_mysql_setup:
-  &default_mysql_setup
-  image: mysql${MYSQL_HASH}
-  networks:
-    - test-network
-
-x-healthcheck_mysql:
-  &healthcheck_mysql
-  healthcheck:
-    test: ${DEFAULT_MYSQL_HEALTHCHECK_COMMAND}
-    start_period: ${DEFAULT_HEALTHCHECKS_START_PERIOD}
-    interval: ${DEFAULT_HEALTHCHECKS_INTERVAL}
-    timeout: ${DEFAULT_HEALTHCHECKS_TIMEOUT}
-    retries: ${DEFAULT_HEALTHCHECKS_RETRIES}
 
 services:
   # Apache server for the backup module

--- a/tests/integration/test_mod_brute_login_form/docker-compose.setup.yml
+++ b/tests/integration/test_mod_brute_login_form/docker-compose.setup.yml
@@ -1,6 +1,5 @@
 version: '3.9'
 
-# Following the DRY philosophy
 x-default_php_setup:
   &default_php_setup
   image: php${PHP_HASH}
@@ -16,20 +15,6 @@ x-healthcheck_web:
     start_period: ${DEFAULT_HEALTHCHECKS_START_PERIOD}
     retries: ${DEFAULT_HEALTHCHECKS_RETRIES}
 
-x-default_mysql_setup:
-  &default_mysql_setup
-  image: mysql${MYSQL_HASH}
-  networks:
-    - test-network
-
-x-healthcheck_mysql:
-  &healthcheck_mysql
-  healthcheck:
-    test: ${DEFAULT_MYSQL_HEALTHCHECK_COMMAND}
-    start_period: ${DEFAULT_HEALTHCHECKS_START_PERIOD}
-    interval: ${DEFAULT_HEALTHCHECKS_INTERVAL}
-    timeout: ${DEFAULT_HEALTHCHECKS_TIMEOUT}
-    retries: ${DEFAULT_HEALTHCHECKS_RETRIES}
 
 services:
   # Apache container for the brute_login_form module

--- a/tests/integration/test_mod_buster/docker-compose.setup.yml
+++ b/tests/integration/test_mod_buster/docker-compose.setup.yml
@@ -1,6 +1,5 @@
 version: '3.9'
 
-# Following the DRY philosophy
 x-default_php_setup:
   &default_php_setup
   image: php${PHP_HASH}
@@ -14,21 +13,6 @@ x-healthcheck_web:
     interval: ${DEFAULT_HEALTHCHECKS_INTERVAL}
     timeout: ${DEFAULT_HEALTHCHECKS_TIMEOUT}
     start_period: ${DEFAULT_HEALTHCHECKS_START_PERIOD}
-    retries: ${DEFAULT_HEALTHCHECKS_RETRIES}
-
-x-default_mysql_setup:
-  &default_mysql_setup
-  image: mysql${MYSQL_HASH}
-  networks:
-    - test-network
-
-x-healthcheck_mysql:
-  &healthcheck_mysql
-  healthcheck:
-    test: ${DEFAULT_MYSQL_HEALTHCHECK_COMMAND}
-    start_period: ${DEFAULT_HEALTHCHECKS_START_PERIOD}
-    interval: ${DEFAULT_HEALTHCHECKS_INTERVAL}
-    timeout: ${DEFAULT_HEALTHCHECKS_TIMEOUT}
     retries: ${DEFAULT_HEALTHCHECKS_RETRIES}
 
 services:

--- a/tests/integration/test_mod_cookieflags/docker-compose.setup.yml
+++ b/tests/integration/test_mod_cookieflags/docker-compose.setup.yml
@@ -1,6 +1,5 @@
 version: '3.9'
 
-# Following the DRY philosophy
 x-default_php_setup:
   &default_php_setup
   image: php${PHP_HASH}
@@ -16,20 +15,6 @@ x-healthcheck_web:
     start_period: ${DEFAULT_HEALTHCHECKS_START_PERIOD}
     retries: ${DEFAULT_HEALTHCHECKS_RETRIES}
 
-x-default_mysql_setup:
-  &default_mysql_setup
-  image: mysql${MYSQL_HASH}
-  networks:
-    - test-network
-
-x-healthcheck_mysql:
-  &healthcheck_mysql
-  healthcheck:
-    test: ${DEFAULT_MYSQL_HEALTHCHECK_COMMAND}
-    start_period: ${DEFAULT_HEALTHCHECKS_START_PERIOD}
-    interval: ${DEFAULT_HEALTHCHECKS_INTERVAL}
-    timeout: ${DEFAULT_HEALTHCHECKS_TIMEOUT}
-    retries: ${DEFAULT_HEALTHCHECKS_RETRIES}
 
 services:
   # Apache container for the cookieflags module

--- a/tests/integration/test_mod_crlf/docker-compose.setup.yml
+++ b/tests/integration/test_mod_crlf/docker-compose.setup.yml
@@ -1,6 +1,5 @@
 version: '3.9'
 
-# Following the DRY philosophy
 x-default_php_setup:
   &default_php_setup
   image: php${PHP_HASH}
@@ -16,20 +15,6 @@ x-healthcheck_web:
     start_period: ${DEFAULT_HEALTHCHECKS_START_PERIOD}
     retries: ${DEFAULT_HEALTHCHECKS_RETRIES}
 
-x-default_mysql_setup:
-  &default_mysql_setup
-  image: mysql${MYSQL_HASH}
-  networks:
-    - test-network
-
-x-healthcheck_mysql:
-  &healthcheck_mysql
-  healthcheck:
-    test: ${DEFAULT_MYSQL_HEALTHCHECK_COMMAND}
-    start_period: ${DEFAULT_HEALTHCHECKS_START_PERIOD}
-    interval: ${DEFAULT_HEALTHCHECKS_INTERVAL}
-    timeout: ${DEFAULT_HEALTHCHECKS_TIMEOUT}
-    retries: ${DEFAULT_HEALTHCHECKS_RETRIES}
 
 services:
   # Apache container for the crlf module

--- a/tests/integration/test_mod_csp/docker-compose.setup.yml
+++ b/tests/integration/test_mod_csp/docker-compose.setup.yml
@@ -1,6 +1,5 @@
 version: '3.9'
 
-# Following the DRY philosophy
 x-default_php_setup:
   &default_php_setup
   image: php${PHP_HASH}
@@ -16,20 +15,6 @@ x-healthcheck_web:
     start_period: ${DEFAULT_HEALTHCHECKS_START_PERIOD}
     retries: ${DEFAULT_HEALTHCHECKS_RETRIES}
 
-x-default_mysql_setup:
-  &default_mysql_setup
-  image: mysql${MYSQL_HASH}
-  networks:
-    - test-network
-
-x-healthcheck_mysql:
-  &healthcheck_mysql
-  healthcheck:
-    test: ${DEFAULT_MYSQL_HEALTHCHECK_COMMAND}
-    start_period: ${DEFAULT_HEALTHCHECKS_START_PERIOD}
-    interval: ${DEFAULT_HEALTHCHECKS_INTERVAL}
-    timeout: ${DEFAULT_HEALTHCHECKS_TIMEOUT}
-    retries: ${DEFAULT_HEALTHCHECKS_RETRIES}
 
 services:
   # Apache container for the csp module

--- a/tests/integration/test_mod_csrf/docker-compose.setup.yml
+++ b/tests/integration/test_mod_csrf/docker-compose.setup.yml
@@ -1,6 +1,5 @@
 version: '3.9'
 
-# Following the DRY philosophy
 x-default_php_setup:
   &default_php_setup
   image: php${PHP_HASH}
@@ -14,21 +13,6 @@ x-healthcheck_web:
     interval: ${DEFAULT_HEALTHCHECKS_INTERVAL}
     timeout: ${DEFAULT_HEALTHCHECKS_TIMEOUT}
     start_period: ${DEFAULT_HEALTHCHECKS_START_PERIOD}
-    retries: ${DEFAULT_HEALTHCHECKS_RETRIES}
-
-x-default_mysql_setup:
-  &default_mysql_setup
-  image: mysql${MYSQL_HASH}
-  networks:
-    - test-network
-
-x-healthcheck_mysql:
-  &healthcheck_mysql
-  healthcheck:
-    test: ${DEFAULT_MYSQL_HEALTHCHECK_COMMAND}
-    start_period: ${DEFAULT_HEALTHCHECKS_START_PERIOD}
-    interval: ${DEFAULT_HEALTHCHECKS_INTERVAL}
-    timeout: ${DEFAULT_HEALTHCHECKS_TIMEOUT}
     retries: ${DEFAULT_HEALTHCHECKS_RETRIES}
 
 services:

--- a/tests/integration/test_mod_drupal_enum/docker-compose.setup.yml
+++ b/tests/integration/test_mod_drupal_enum/docker-compose.setup.yml
@@ -1,12 +1,5 @@
 version: '3.9'
 
-# Following the DRY philosophy
-x-default_php_setup:
-  &default_php_setup
-  image: php${PHP_HASH}
-  networks:
-    - test-network
-
 x-healthcheck_web:
   &healthcheck_web
   healthcheck:

--- a/tests/integration/test_mod_exec/docker-compose.setup.yml
+++ b/tests/integration/test_mod_exec/docker-compose.setup.yml
@@ -1,6 +1,5 @@
 version: '3.9'
 
-# Following the DRY philosophy
 x-default_php_setup:
   &default_php_setup
   image: php${PHP_HASH}
@@ -14,21 +13,6 @@ x-healthcheck_web:
     interval: ${DEFAULT_HEALTHCHECKS_INTERVAL}
     timeout: ${DEFAULT_HEALTHCHECKS_TIMEOUT}
     start_period: ${DEFAULT_HEALTHCHECKS_START_PERIOD}
-    retries: ${DEFAULT_HEALTHCHECKS_RETRIES}
-
-x-default_mysql_setup:
-  &default_mysql_setup
-  image: mysql${MYSQL_HASH}
-  networks:
-    - test-network
-
-x-healthcheck_mysql:
-  &healthcheck_mysql
-  healthcheck:
-    test: ${DEFAULT_MYSQL_HEALTHCHECK_COMMAND}
-    start_period: ${DEFAULT_HEALTHCHECKS_START_PERIOD}
-    interval: ${DEFAULT_HEALTHCHECKS_INTERVAL}
-    timeout: ${DEFAULT_HEALTHCHECKS_TIMEOUT}
     retries: ${DEFAULT_HEALTHCHECKS_RETRIES}
 
 services:

--- a/tests/integration/test_mod_file/docker-compose.setup.yml
+++ b/tests/integration/test_mod_file/docker-compose.setup.yml
@@ -1,6 +1,5 @@
 version: '3.9'
 
-# Following the DRY philosophy
 x-default_php_setup:
   &default_php_setup
   image: php${PHP_HASH}
@@ -14,21 +13,6 @@ x-healthcheck_web:
     interval: ${DEFAULT_HEALTHCHECKS_INTERVAL}
     timeout: ${DEFAULT_HEALTHCHECKS_TIMEOUT}
     start_period: ${DEFAULT_HEALTHCHECKS_START_PERIOD}
-    retries: ${DEFAULT_HEALTHCHECKS_RETRIES}
-
-x-default_mysql_setup:
-  &default_mysql_setup
-  image: mysql${MYSQL_HASH}
-  networks:
-    - test-network
-
-x-healthcheck_mysql:
-  &healthcheck_mysql
-  healthcheck:
-    test: ${DEFAULT_MYSQL_HEALTHCHECK_COMMAND}
-    start_period: ${DEFAULT_HEALTHCHECKS_START_PERIOD}
-    interval: ${DEFAULT_HEALTHCHECKS_INTERVAL}
-    timeout: ${DEFAULT_HEALTHCHECKS_TIMEOUT}
     retries: ${DEFAULT_HEALTHCHECKS_RETRIES}
 
 services:

--- a/tests/integration/test_mod_htaccess/docker-compose.setup.yml
+++ b/tests/integration/test_mod_htaccess/docker-compose.setup.yml
@@ -1,12 +1,5 @@
 version: '3.9'
 
-# Following the DRY philosophy
-x-default_php_setup:
-  &default_php_setup
-  image: php${PHP_HASH}
-  networks:
-    - test-network
-
 x-healthcheck_web:
   &healthcheck_web
   healthcheck:
@@ -14,21 +7,6 @@ x-healthcheck_web:
     interval: ${DEFAULT_HEALTHCHECKS_INTERVAL}
     timeout: ${DEFAULT_HEALTHCHECKS_TIMEOUT}
     start_period: ${DEFAULT_HEALTHCHECKS_START_PERIOD}
-    retries: ${DEFAULT_HEALTHCHECKS_RETRIES}
-
-x-default_mysql_setup:
-  &default_mysql_setup
-  image: mysql${MYSQL_HASH}
-  networks:
-    - test-network
-
-x-healthcheck_mysql:
-  &healthcheck_mysql
-  healthcheck:
-    test: ${DEFAULT_MYSQL_HEALTHCHECK_COMMAND}
-    start_period: ${DEFAULT_HEALTHCHECKS_START_PERIOD}
-    interval: ${DEFAULT_HEALTHCHECKS_INTERVAL}
-    timeout: ${DEFAULT_HEALTHCHECKS_TIMEOUT}
     retries: ${DEFAULT_HEALTHCHECKS_RETRIES}
 
 services:

--- a/tests/integration/test_mod_http_headers/docker-compose.setup.yml
+++ b/tests/integration/test_mod_http_headers/docker-compose.setup.yml
@@ -1,12 +1,5 @@
 version: '3.9'
 
-# Following the DRY philosophy
-x-default_php_setup:
-  &default_php_setup
-  image: php${PHP_HASH}
-  networks:
-    - test-network
-
 x-healthcheck_web:
   &healthcheck_web
   healthcheck:
@@ -14,21 +7,6 @@ x-healthcheck_web:
     interval: ${DEFAULT_HEALTHCHECKS_INTERVAL}
     timeout: ${DEFAULT_HEALTHCHECKS_TIMEOUT}
     start_period: ${DEFAULT_HEALTHCHECKS_START_PERIOD}
-    retries: ${DEFAULT_HEALTHCHECKS_RETRIES}
-
-x-default_mysql_setup:
-  &default_mysql_setup
-  image: mysql${MYSQL_HASH}
-  networks:
-    - test-network
-
-x-healthcheck_mysql:
-  &healthcheck_mysql
-  healthcheck:
-    test: ${DEFAULT_MYSQL_HEALTHCHECK_COMMAND}
-    start_period: ${DEFAULT_HEALTHCHECKS_START_PERIOD}
-    interval: ${DEFAULT_HEALTHCHECKS_INTERVAL}
-    timeout: ${DEFAULT_HEALTHCHECKS_TIMEOUT}
     retries: ${DEFAULT_HEALTHCHECKS_RETRIES}
 
 services:

--- a/tests/integration/test_mod_https_redirect/docker-compose.setup.yml
+++ b/tests/integration/test_mod_https_redirect/docker-compose.setup.yml
@@ -1,12 +1,5 @@
 version: '3.9'
 
-# Following the DRY philosophy
-x-default_php_setup:
-  &default_php_setup
-  image: php${PHP_HASH}
-  networks:
-    - test-network
-
 x-healthcheck_web:
   &healthcheck_web
   healthcheck:
@@ -16,23 +9,7 @@ x-healthcheck_web:
     start_period: ${DEFAULT_HEALTHCHECKS_START_PERIOD}
     retries: ${DEFAULT_HEALTHCHECKS_RETRIES}
 
-x-default_mysql_setup:
-  &default_mysql_setup
-  image: mysql${MYSQL_HASH}
-  networks:
-    - test-network
-
-x-healthcheck_mysql:
-  &healthcheck_mysql
-  healthcheck:
-    test: ${DEFAULT_MYSQL_HEALTHCHECK_COMMAND}
-    start_period: ${DEFAULT_HEALTHCHECKS_START_PERIOD}
-    interval: ${DEFAULT_HEALTHCHECKS_INTERVAL}
-    timeout: ${DEFAULT_HEALTHCHECKS_TIMEOUT}
-    retries: ${DEFAULT_HEALTHCHECKS_RETRIES}
-
 services:
-
   # Apache container for the https_redirect module
   https_redirect:
     build:

--- a/tests/integration/test_mod_log4shell/docker-compose.setup.yml
+++ b/tests/integration/test_mod_log4shell/docker-compose.setup.yml
@@ -1,36 +1,5 @@
 version: '3.9'
 
-# Following the DRY philosophy
-x-default_php_setup:
-  &default_php_setup
-  image: php${PHP_HASH}
-  networks:
-    - test-network
-
-x-healthcheck_web:
-  &healthcheck_web
-  healthcheck:
-    test: ${DEFAULT_WEB_HEALTHCHECK_COMMAND}
-    interval: ${DEFAULT_HEALTHCHECKS_INTERVAL}
-    timeout: ${DEFAULT_HEALTHCHECKS_TIMEOUT}
-    start_period: ${DEFAULT_HEALTHCHECKS_START_PERIOD}
-    retries: ${DEFAULT_HEALTHCHECKS_RETRIES}
-
-x-default_mysql_setup:
-  &default_mysql_setup
-  image: mysql${MYSQL_HASH}
-  networks:
-    - test-network
-
-x-healthcheck_mysql:
-  &healthcheck_mysql
-  healthcheck:
-    test: ${DEFAULT_MYSQL_HEALTHCHECK_COMMAND}
-    start_period: ${DEFAULT_HEALTHCHECKS_START_PERIOD}
-    interval: ${DEFAULT_HEALTHCHECKS_INTERVAL}
-    timeout: ${DEFAULT_HEALTHCHECKS_TIMEOUT}
-    retries: ${DEFAULT_HEALTHCHECKS_RETRIES}
-
 services:
   # Apache container for the log4shell module
   log4shell:

--- a/tests/integration/test_mod_methods/docker-compose.setup.yml
+++ b/tests/integration/test_mod_methods/docker-compose.setup.yml
@@ -1,6 +1,5 @@
 version: '3.9'
 
-# Following the DRY philosophy
 x-default_php_setup:
   &default_php_setup
   image: php${PHP_HASH}
@@ -14,21 +13,6 @@ x-healthcheck_web:
     interval: ${DEFAULT_HEALTHCHECKS_INTERVAL}
     timeout: ${DEFAULT_HEALTHCHECKS_TIMEOUT}
     start_period: ${DEFAULT_HEALTHCHECKS_START_PERIOD}
-    retries: ${DEFAULT_HEALTHCHECKS_RETRIES}
-
-x-default_mysql_setup:
-  &default_mysql_setup
-  image: mysql${MYSQL_HASH}
-  networks:
-    - test-network
-
-x-healthcheck_mysql:
-  &healthcheck_mysql
-  healthcheck:
-    test: ${DEFAULT_MYSQL_HEALTHCHECK_COMMAND}
-    start_period: ${DEFAULT_HEALTHCHECKS_START_PERIOD}
-    interval: ${DEFAULT_HEALTHCHECKS_INTERVAL}
-    timeout: ${DEFAULT_HEALTHCHECKS_TIMEOUT}
     retries: ${DEFAULT_HEALTHCHECKS_RETRIES}
 
 services:

--- a/tests/integration/test_mod_permanentxss/docker-compose.setup.yml
+++ b/tests/integration/test_mod_permanentxss/docker-compose.setup.yml
@@ -1,12 +1,5 @@
 version: '3.9'
 
-# Following the DRY philosophy
-x-default_php_setup:
-  &default_php_setup
-  image: php${PHP_HASH}
-  networks:
-    - test-network
-
 x-healthcheck_web:
   &healthcheck_web
   healthcheck:
@@ -14,21 +7,6 @@ x-healthcheck_web:
     interval: ${DEFAULT_HEALTHCHECKS_INTERVAL}
     timeout: ${DEFAULT_HEALTHCHECKS_TIMEOUT}
     start_period: ${DEFAULT_HEALTHCHECKS_START_PERIOD}
-    retries: ${DEFAULT_HEALTHCHECKS_RETRIES}
-
-x-default_mysql_setup:
-  &default_mysql_setup
-  image: mysql${MYSQL_HASH}
-  networks:
-    - test-network
-
-x-healthcheck_mysql:
-  &healthcheck_mysql
-  healthcheck:
-    test: ${DEFAULT_MYSQL_HEALTHCHECK_COMMAND}
-    start_period: ${DEFAULT_HEALTHCHECKS_START_PERIOD}
-    interval: ${DEFAULT_HEALTHCHECKS_INTERVAL}
-    timeout: ${DEFAULT_HEALTHCHECKS_TIMEOUT}
     retries: ${DEFAULT_HEALTHCHECKS_RETRIES}
 
 services:

--- a/tests/integration/test_mod_redirect/docker-compose.setup.yml
+++ b/tests/integration/test_mod_redirect/docker-compose.setup.yml
@@ -1,6 +1,5 @@
 version: '3.9'
 
-# Following the DRY philosophy
 x-default_php_setup:
   &default_php_setup
   image: php${PHP_HASH}
@@ -14,21 +13,6 @@ x-healthcheck_web:
     interval: ${DEFAULT_HEALTHCHECKS_INTERVAL}
     timeout: ${DEFAULT_HEALTHCHECKS_TIMEOUT}
     start_period: ${DEFAULT_HEALTHCHECKS_START_PERIOD}
-    retries: ${DEFAULT_HEALTHCHECKS_RETRIES}
-
-x-default_mysql_setup:
-  &default_mysql_setup
-  image: mysql${MYSQL_HASH}
-  networks:
-    - test-network
-
-x-healthcheck_mysql:
-  &healthcheck_mysql
-  healthcheck:
-    test: ${DEFAULT_MYSQL_HEALTHCHECK_COMMAND}
-    start_period: ${DEFAULT_HEALTHCHECKS_START_PERIOD}
-    interval: ${DEFAULT_HEALTHCHECKS_INTERVAL}
-    timeout: ${DEFAULT_HEALTHCHECKS_TIMEOUT}
     retries: ${DEFAULT_HEALTHCHECKS_RETRIES}
 
 services:

--- a/tests/integration/test_mod_shellshock/docker-compose.setup.yml
+++ b/tests/integration/test_mod_shellshock/docker-compose.setup.yml
@@ -1,12 +1,5 @@
 version: '3.9'
 
-# Following the DRY philosophy
-x-default_php_setup:
-  &default_php_setup
-  image: php${PHP_HASH}
-  networks:
-    - test-network
-
 x-healthcheck_web:
   &healthcheck_web
   healthcheck:
@@ -14,21 +7,6 @@ x-healthcheck_web:
     interval: ${DEFAULT_HEALTHCHECKS_INTERVAL}
     timeout: ${DEFAULT_HEALTHCHECKS_TIMEOUT}
     start_period: ${DEFAULT_HEALTHCHECKS_START_PERIOD}
-    retries: ${DEFAULT_HEALTHCHECKS_RETRIES}
-
-x-default_mysql_setup:
-  &default_mysql_setup
-  image: mysql${MYSQL_HASH}
-  networks:
-    - test-network
-
-x-healthcheck_mysql:
-  &healthcheck_mysql
-  healthcheck:
-    test: ${DEFAULT_MYSQL_HEALTHCHECK_COMMAND}
-    start_period: ${DEFAULT_HEALTHCHECKS_START_PERIOD}
-    interval: ${DEFAULT_HEALTHCHECKS_INTERVAL}
-    timeout: ${DEFAULT_HEALTHCHECKS_TIMEOUT}
     retries: ${DEFAULT_HEALTHCHECKS_RETRIES}
 
 services:

--- a/tests/integration/test_mod_sql/docker-compose.setup.yml
+++ b/tests/integration/test_mod_sql/docker-compose.setup.yml
@@ -1,12 +1,5 @@
 version: '3.9'
 
-# Following the DRY philosophy
-x-default_php_setup:
-  &default_php_setup
-  image: php${PHP_HASH}
-  networks:
-    - test-network
-
 x-healthcheck_web:
   &healthcheck_web
   healthcheck:
@@ -14,21 +7,6 @@ x-healthcheck_web:
     interval: ${DEFAULT_HEALTHCHECKS_INTERVAL}
     timeout: ${DEFAULT_HEALTHCHECKS_TIMEOUT}
     start_period: ${DEFAULT_HEALTHCHECKS_START_PERIOD}
-    retries: ${DEFAULT_HEALTHCHECKS_RETRIES}
-
-x-default_mysql_setup:
-  &default_mysql_setup
-  image: mysql${MYSQL_HASH}
-  networks:
-    - test-network
-
-x-healthcheck_mysql:
-  &healthcheck_mysql
-  healthcheck:
-    test: ${DEFAULT_MYSQL_HEALTHCHECK_COMMAND}
-    start_period: ${DEFAULT_HEALTHCHECKS_START_PERIOD}
-    interval: ${DEFAULT_HEALTHCHECKS_INTERVAL}
-    timeout: ${DEFAULT_HEALTHCHECKS_TIMEOUT}
     retries: ${DEFAULT_HEALTHCHECKS_RETRIES}
 
 services:

--- a/tests/integration/test_mod_ssrf/docker-compose.setup.yml
+++ b/tests/integration/test_mod_ssrf/docker-compose.setup.yml
@@ -1,6 +1,5 @@
 version: '3.9'
 
-# Following the DRY philosophy
 x-default_php_setup:
   &default_php_setup
   image: php${PHP_HASH}
@@ -14,21 +13,6 @@ x-healthcheck_web:
     interval: ${DEFAULT_HEALTHCHECKS_INTERVAL}
     timeout: ${DEFAULT_HEALTHCHECKS_TIMEOUT}
     start_period: ${DEFAULT_HEALTHCHECKS_START_PERIOD}
-    retries: ${DEFAULT_HEALTHCHECKS_RETRIES}
-
-x-default_mysql_setup:
-  &default_mysql_setup
-  image: mysql${MYSQL_HASH}
-  networks:
-    - test-network
-
-x-healthcheck_mysql:
-  &healthcheck_mysql
-  healthcheck:
-    test: ${DEFAULT_MYSQL_HEALTHCHECK_COMMAND}
-    start_period: ${DEFAULT_HEALTHCHECKS_START_PERIOD}
-    interval: ${DEFAULT_HEALTHCHECKS_INTERVAL}
-    timeout: ${DEFAULT_HEALTHCHECKS_TIMEOUT}
     retries: ${DEFAULT_HEALTHCHECKS_RETRIES}
 
 services:

--- a/tests/integration/test_mod_timesql/docker-compose.setup.yml
+++ b/tests/integration/test_mod_timesql/docker-compose.setup.yml
@@ -1,12 +1,5 @@
 version: '3.9'
 
-# Following the DRY philosophy
-x-default_php_setup:
-  &default_php_setup
-  image: php${PHP_HASH}
-  networks:
-    - test-network
-
 x-healthcheck_web:
   &healthcheck_web
   healthcheck:
@@ -15,12 +8,6 @@ x-healthcheck_web:
     timeout: ${DEFAULT_HEALTHCHECKS_TIMEOUT}
     start_period: ${DEFAULT_HEALTHCHECKS_START_PERIOD}
     retries: ${DEFAULT_HEALTHCHECKS_RETRIES}
-
-x-default_mysql_setup:
-  &default_mysql_setup
-  image: mysql${MYSQL_HASH}
-  networks:
-    - test-network
 
 x-healthcheck_mysql:
   &healthcheck_mysql

--- a/tests/integration/test_mod_wapp/docker-compose.setup.yml
+++ b/tests/integration/test_mod_wapp/docker-compose.setup.yml
@@ -1,36 +1,5 @@
 version: '3.9'
 
-# Following the DRY philosophy
-x-default_php_setup:
-  &default_php_setup
-  image: php${PHP_HASH}
-  networks:
-    - test-network
-
-x-healthcheck_web:
-  &healthcheck_web
-  healthcheck:
-    test: ${DEFAULT_WEB_HEALTHCHECK_COMMAND}
-    interval: ${DEFAULT_HEALTHCHECKS_INTERVAL}
-    timeout: ${DEFAULT_HEALTHCHECKS_TIMEOUT}
-    start_period: ${DEFAULT_HEALTHCHECKS_START_PERIOD}
-    retries: ${DEFAULT_HEALTHCHECKS_RETRIES}
-
-x-default_mysql_setup:
-  &default_mysql_setup
-  image: mysql${MYSQL_HASH}
-  networks:
-    - test-network
-
-x-healthcheck_mysql:
-  &healthcheck_mysql
-  healthcheck:
-    test: ${DEFAULT_MYSQL_HEALTHCHECK_COMMAND}
-    start_period: ${DEFAULT_HEALTHCHECKS_START_PERIOD}
-    interval: ${DEFAULT_HEALTHCHECKS_INTERVAL}
-    timeout: ${DEFAULT_HEALTHCHECKS_TIMEOUT}
-    retries: ${DEFAULT_HEALTHCHECKS_RETRIES}
-
 services:
   # Nginx container for the wapp module
   wapp:

--- a/tests/integration/test_mod_wp_enum/docker-compose.setup.yml
+++ b/tests/integration/test_mod_wp_enum/docker-compose.setup.yml
@@ -1,21 +1,5 @@
 version: '3.9'
 
-# Following the DRY philosophy
-x-default_php_setup:
-  &default_php_setup
-  image: php${PHP_HASH}
-  networks:
-    - test-network
-
-x-healthcheck_web:
-  &healthcheck_web
-  healthcheck:
-    test: ${DEFAULT_WEB_HEALTHCHECK_COMMAND}
-    interval: ${DEFAULT_HEALTHCHECKS_INTERVAL}
-    timeout: ${DEFAULT_HEALTHCHECKS_TIMEOUT}
-    start_period: ${DEFAULT_HEALTHCHECKS_START_PERIOD}
-    retries: ${DEFAULT_HEALTHCHECKS_RETRIES}
-
 x-default_mysql_setup:
   &default_mysql_setup
   image: mysql${MYSQL_HASH}

--- a/tests/integration/test_mod_xss/docker-compose.setup.yml
+++ b/tests/integration/test_mod_xss/docker-compose.setup.yml
@@ -1,6 +1,5 @@
 version: '3.9'
 
-# Following the DRY philosophy
 x-default_php_setup:
   &default_php_setup
   image: php${PHP_HASH}
@@ -14,21 +13,6 @@ x-healthcheck_web:
     interval: ${DEFAULT_HEALTHCHECKS_INTERVAL}
     timeout: ${DEFAULT_HEALTHCHECKS_TIMEOUT}
     start_period: ${DEFAULT_HEALTHCHECKS_START_PERIOD}
-    retries: ${DEFAULT_HEALTHCHECKS_RETRIES}
-
-x-default_mysql_setup:
-  &default_mysql_setup
-  image: mysql${MYSQL_HASH}
-  networks:
-    - test-network
-
-x-healthcheck_mysql:
-  &healthcheck_mysql
-  healthcheck:
-    test: ${DEFAULT_MYSQL_HEALTHCHECK_COMMAND}
-    start_period: ${DEFAULT_HEALTHCHECKS_START_PERIOD}
-    interval: ${DEFAULT_HEALTHCHECKS_INTERVAL}
-    timeout: ${DEFAULT_HEALTHCHECKS_TIMEOUT}
     retries: ${DEFAULT_HEALTHCHECKS_RETRIES}
 
 services:

--- a/tests/integration/test_mod_xxe/docker-compose.setup.yml
+++ b/tests/integration/test_mod_xxe/docker-compose.setup.yml
@@ -1,6 +1,5 @@
 version: '3.9'
 
-# Following the DRY philosophy
 x-default_php_setup:
   &default_php_setup
   image: php${PHP_HASH}
@@ -14,21 +13,6 @@ x-healthcheck_web:
     interval: ${DEFAULT_HEALTHCHECKS_INTERVAL}
     timeout: ${DEFAULT_HEALTHCHECKS_TIMEOUT}
     start_period: ${DEFAULT_HEALTHCHECKS_START_PERIOD}
-    retries: ${DEFAULT_HEALTHCHECKS_RETRIES}
-
-x-default_mysql_setup:
-  &default_mysql_setup
-  image: mysql${MYSQL_HASH}
-  networks:
-    - test-network
-
-x-healthcheck_mysql:
-  &healthcheck_mysql
-  healthcheck:
-    test: ${DEFAULT_MYSQL_HEALTHCHECK_COMMAND}
-    start_period: ${DEFAULT_HEALTHCHECKS_START_PERIOD}
-    interval: ${DEFAULT_HEALTHCHECKS_INTERVAL}
-    timeout: ${DEFAULT_HEALTHCHECKS_TIMEOUT}
     retries: ${DEFAULT_HEALTHCHECKS_RETRIES}
 
 services:


### PR DESCRIPTION
Added a script tool to generate default configuration when doing integration tests
The documentation has been updated about that and as Docker shorthands are now hardcoded in the script, I pruned the unecessary ones in the various ``docker-compose.setup.yml`` files