### PR TITLE
Correct a mistake in help menu about headless

### DIFF
--- a/wapitiCore/main/getcookie.py
+++ b/wapitiCore/main/getcookie.py
@@ -168,7 +168,6 @@ async def getcookie_main(arguments):
         dest="headless",
         default="no",
         help="Use a Firefox headless crawler for browsing (slower)",
-        metavar="PORT",
         choices=["no", "hidden", "visible"]
     )
 

--- a/wapitiCore/parsers/commandline.py
+++ b/wapitiCore/parsers/commandline.py
@@ -99,7 +99,6 @@ def parse_args():
         dest="headless",
         default="no",
         help="Use a Firefox headless crawler for browsing (slower)",
-        metavar="PORT",
         choices=["no", "hidden", "visible"]
     )
 


### PR DESCRIPTION
Correct a mistake in help menu : 

![image](https://github.com/wapiti-scanner/wapiti/assets/37926502/a8a70043-a436-421c-aa2d-f7c41f90c8a6)

Change `PORT` for `{no,hidden,visible}`