### PR TITLE
Update default timeout for slow websites

### DIFF
--- a/wapitiCore/controller/wapiti.py
+++ b/wapitiCore/controller/wapiti.py
@@ -629,7 +629,7 @@ class Wapiti:
                 logging.error("Error sending crash report")
             os.unlink(traceback_file)
 
-    def set_timeout(self, timeout: float = 6.0):
+    def set_timeout(self, timeout: float = 10.0):
         """Set the timeout for the time waiting for a HTTP response"""
         self.crawler_configuration.timeout = timeout
 

--- a/wapitiCore/parsers/commandline.py
+++ b/wapitiCore/parsers/commandline.py
@@ -388,7 +388,7 @@ def parse_args():
 
     parser.add_argument(
         "-t", "--timeout",
-        type=float, default=6.0,
+        type=float, default=10.0,
         help="Set timeout for requests",
         metavar="SECONDS"
     )


### PR DESCRIPTION
Modifie la valeur par défaut du timeout pour les sites web les plus lents

Note : cela ne pénalise pas les scans de la plupart des sites, car on n'atteint pas le timetout.

Cela ne concerne donc que les sites lents, qui en l'état ne sont pas correctement scannés.

Cette modification devrait donc améliorer les analyses de sites "pas très performants" avec la config par défaut.