### PR TITLE
Add time check for time-consuming modules

### DIFF
--- a/tests/attack/test_mod_buster.py
+++ b/tests/attack/test_mod_buster.py
@@ -54,3 +54,90 @@ async def test_whole_stuff():
         assert "http://perdu.com/admin" in persister.add_payload.call_args_list[0][1]["info"]
         assert "http://perdu.com/config.inc" in persister.add_payload.call_args_list[1][1]["info"]
         assert "http://perdu.com/admin/authconfig.php" in persister.add_payload.call_args_list[2][1]["info"]
+
+
+@pytest.mark.asyncio
+@respx.mock
+async def test_max_attack_time_5():
+    # Test attacking with max_attack_time limitation
+    respx.get("http://perdu.com/").mock(return_value=httpx.Response(200, text="Default page"))
+    respx.get("http://perdu.com/admin").mock(
+        return_value=httpx.Response(301, text="Hello there", headers={"Location": "/admin/"})
+    )
+    respx.get("http://perdu.com/admin/").mock(return_value=httpx.Response(200, text="Hello there"))
+    respx.get("http://perdu.com/config.inc").mock(return_value=httpx.Response(200, text="pass = 123456"))
+    respx.get("http://perdu.com/admin/authconfig.php").mock(return_value=httpx.Response(200, text="Hello there"))
+    respx.get(url__regex=r"http://perdu\.com/.*").mock(return_value=httpx.Response(404))
+
+    persister = AsyncMock()
+
+    request = Request("http://perdu.com/")
+    request.path_id = 1
+    # Buster module will get requests from the persister
+    persister.get_links = AsyncIterator([(request, None)])
+
+    crawler_configuration = CrawlerConfiguration(Request("http://perdu.com/"), timeout=1)
+    async with AsyncCrawler.with_configuration(crawler_configuration) as crawler:
+        options = {"timeout": 10, "level": 2, "tasks": 1, "max_attack_time": 5}
+
+        files = {
+            "wordlist.txt": "nawak\nadmin\n" + 
+                "nawak\n" * 2000 + "config.inc\n" + 
+                "nawak\n" * 2000 +  "authconfig.php",
+        }
+        with mock.patch("builtins.open", get_mock_open(files)):
+            module = ModuleBuster(crawler, persister, options, Event(), crawler_configuration)
+            module.DATA_DIR = ""
+            module.PATHS_FILE = "wordlist.txt"
+            module.do_get = True
+            await module.attack(request)
+
+            assert module.known_dirs == ["http://perdu.com/", "http://perdu.com/admin/"]
+            assert module.known_pages == ["http://perdu.com/config.inc"]
+        assert persister.add_payload.call_count == 2
+        assert "http://perdu.com/admin" in persister.add_payload.call_args_list[0][1]["info"]
+        assert "http://perdu.com/config.inc" in persister.add_payload.call_args_list[1][1]["info"]
+
+
+@pytest.mark.asyncio
+@respx.mock
+async def test_max_attack_time_10():
+    # Test attacking with max_attack_time limitation
+    respx.get("http://perdu.com/").mock(return_value=httpx.Response(200, text="Default page"))
+    respx.get("http://perdu.com/admin").mock(
+        return_value=httpx.Response(301, text="Hello there", headers={"Location": "/admin/"})
+    )
+    respx.get("http://perdu.com/admin/").mock(return_value=httpx.Response(200, text="Hello there"))
+    respx.get("http://perdu.com/config.inc").mock(return_value=httpx.Response(200, text="pass = 123456"))
+    respx.get("http://perdu.com/admin/authconfig.php").mock(return_value=httpx.Response(200, text="Hello there"))
+    respx.get(url__regex=r"http://perdu\.com/.*").mock(return_value=httpx.Response(404))
+
+    persister = AsyncMock()
+
+    request = Request("http://perdu.com/")
+    request.path_id = 1
+    # Buster module will get requests from the persister
+    persister.get_links = AsyncIterator([(request, None)])
+
+    crawler_configuration = CrawlerConfiguration(Request("http://perdu.com/"), timeout=1)
+    async with AsyncCrawler.with_configuration(crawler_configuration) as crawler:
+        options = {"timeout": 10, "level": 2, "tasks": 1, "max_attack_time": 10}
+
+        files = {
+            "wordlist.txt": "nawak\nadmin\n" + 
+                "nawak\n" * 2000 + "config.inc\n" + 
+                "nawak\n" * 2000 +  "authconfig.php",
+        }
+        with mock.patch("builtins.open", get_mock_open(files)):
+            module = ModuleBuster(crawler, persister, options, Event(), crawler_configuration)
+            module.DATA_DIR = ""
+            module.PATHS_FILE = "wordlist.txt"
+            module.do_get = True
+            await module.attack(request)
+
+            assert module.known_dirs == ["http://perdu.com/", "http://perdu.com/admin/"]
+            assert module.known_pages == ["http://perdu.com/config.inc", "http://perdu.com/admin/authconfig.php"]
+        assert persister.add_payload.call_count == 3
+        assert "http://perdu.com/admin" in persister.add_payload.call_args_list[0][1]["info"]
+        assert "http://perdu.com/config.inc" in persister.add_payload.call_args_list[1][1]["info"]
+        assert "http://perdu.com/admin/authconfig.php" in persister.add_payload.call_args_list[2][1]["info"]

--- a/wapitiCore/attack/attack.py
+++ b/wapitiCore/attack/attack.py
@@ -226,6 +226,7 @@ class Attack:
         self._stop_event = stop_event
         self.options = attack_options
         self.crawler_configuration = crawler_configuration
+        self.start = 0
 
         # List of attack urls already launched in the current module
         self.attacked_get = []
@@ -285,6 +286,10 @@ class Attack:
     @property
     def external_endpoint(self):
         return self.options.get("external_endpoint", "http://wapiti3.ovh")
+
+    @property
+    def max_attack_time(self):
+        return self.options.get("max_attack_time", 0)
 
     @property
     def proto_endpoint(self):

--- a/wapitiCore/attack/mod_buster.py
+++ b/wapitiCore/attack/mod_buster.py
@@ -18,12 +18,13 @@
 # along with this program; if not, write to the Free Software
 # Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 import asyncio
-from typing import Optional
 from os.path import join as path_join
+from time import monotonic
+from typing import Optional
 
 from httpx import RequestError
 
-from wapitiCore.main.log import log_red, log_verbose
+from wapitiCore.main.log import log_red, log_verbose, logging
 from wapitiCore.attack.attack import Attack
 from wapitiCore.net import Request, Response
 from wapitiCore.definitions.buster import NAME, WSTG_CODE
@@ -99,6 +100,12 @@ class ModuleBuster(Attack):
 
         with open(path_join(self.DATA_DIR, self.PATHS_FILE), encoding="utf-8", errors="ignore") as wordlist:
             while True:
+                if monotonic() - self.start > self.max_attack_time >= 1:
+                    logging.info(
+                        f"Skipping: attack time reached for module {self.name}."
+                    )
+                    break
+
                 if pending_count < self.options["tasks"] and not self._stop_event.is_set():
                     try:
                         candidate = next(wordlist).strip()
@@ -132,6 +139,7 @@ class ModuleBuster(Attack):
                         tasks.remove(task)
 
     async def attack(self, request: Request, response: Optional[Response] = None):
+        self.start = monotonic()
         self.finished = True
         if not self.do_get:
             return

--- a/wapitiCore/attack/mod_drupal_enum.py
+++ b/wapitiCore/attack/mod_drupal_enum.py
@@ -1,7 +1,6 @@
 import asyncio
 import hashlib
 import json
-import logging
 from os.path import join as path_join
 from typing import Tuple, Optional
 from httpx import RequestError
@@ -11,7 +10,7 @@ from wapitiCore.attack.attack import Attack
 from wapitiCore.net.response import Response
 from wapitiCore.definitions.fingerprint_webapp import NAME as WEB_APP_VERSIONED
 from wapitiCore.definitions.fingerprint import NAME as TECHNO_DETECTED, WSTG_CODE
-from wapitiCore.main.log import log_blue
+from wapitiCore.main.log import log_blue, logging
 
 MSG_TECHNO_VERSIONED = "{0} {1} detected"
 MSG_NO_DRUPAL = "No Drupal Detected"

--- a/wapitiCore/attack/mod_nikto.py
+++ b/wapitiCore/attack/mod_nikto.py
@@ -18,11 +18,12 @@
 # Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 import asyncio
 import csv
-import re
 import os
 import random
-from urllib.parse import urlparse
+import re
+from time import monotonic
 from typing import List, Optional
+from urllib.parse import urlparse
 
 from httpx import RequestError
 
@@ -129,6 +130,7 @@ class ModuleNikto(Attack):
         return self.status_codes[request.path] in expected_status_codes
 
     async def attack(self, request: Request, response: Optional[Response] = None):
+        self.start = monotonic()
         try:
             with open(os.path.join(self.user_config_dir, self.NIKTO_DB), encoding='utf-8') as nikto_db_file:
                 reader = csv.reader(nikto_db_file)
@@ -150,6 +152,11 @@ class ModuleNikto(Attack):
         with open(os.path.join(self.user_config_dir, self.NIKTO_DB), encoding='utf-8') as nikto_db_file:
             reader = csv.reader(nikto_db_file)
             while True:
+                if monotonic() - self.start > self.max_attack_time >= 1:
+                    logging.info(
+                        f"Skipping: attack time reached for module {self.name}."
+                    )
+                    break
                 if pending_count < self.options["tasks"] and not self._stop_event.is_set():
                     try:
                         line = next(reader)

--- a/wapitiCore/attack/mod_wp_enum.py
+++ b/wapitiCore/attack/mod_wp_enum.py
@@ -3,6 +3,7 @@ import re
 import xml
 import xml.etree.ElementTree as ET
 from os.path import join as path_join
+from time import monotonic
 from typing import Match, Optional
 
 from wapitiCore.attack.attack import Attack
@@ -98,6 +99,12 @@ class ModuleWpEnum(Attack):
             if self._stop_event.is_set():
                 break
 
+            if monotonic() - self.start > self.max_attack_time >= 1:
+                logging.info(
+                    f"Skipping: attack time reached for module {self.name}."
+                )
+                break
+
             request = Request(f'{url}/wp-content/plugins/{plugin}/readme.txt', 'GET')
             response = await self.crawler.async_send(request)
 
@@ -154,6 +161,12 @@ class ModuleWpEnum(Attack):
     async def detect_theme(self, url):
         for theme in self.get_theme():
             if self._stop_event.is_set():
+                break
+
+            if monotonic() - self.start > self.max_attack_time >= 1:
+                logging.info(
+                    f"Skipping: attack time reached for module {self.name}."
+                )
                 break
 
             request = Request(f'{url}/wp-content/themes/{theme}/readme.txt', 'GET')
@@ -218,7 +231,7 @@ class ModuleWpEnum(Attack):
         return request.url == await self.persister.get_root_url()
 
     async def attack(self, request: Request, response: Optional[Response] = None):
-
+        self.start = monotonic()
         self.finished = True
         request_to_root = Request(request.url)
 

--- a/wapitiCore/main/wapiti.py
+++ b/wapitiCore/main/wapiti.py
@@ -242,6 +242,7 @@ async def wapiti_main():
             "tasks": args.tasks,
             "headless": wap.headless_mode,
             "excluded_urls": wap.excluded_urls,
+            "max_attack_time" : args.max_attack_time
         }
 
         if "dns_endpoint" in args:


### PR DESCRIPTION
Add max-attack-time check for time-consuming modules.

Fix https://github.com/wapiti-scanner/wapiti/issues/498