### PR TITLE
Upgrade headless docker with latest debian, firefox and geckodriver

### DIFF
--- a/Dockerfile.headless
+++ b/Dockerfile.headless
@@ -1,4 +1,4 @@
-FROM debian:bullseye-slim as build
+FROM debian:bookworm-slim as build
 
 ENV DEBIAN_FRONTEND=noninteractive \
   LANG=en_US.UTF-8
@@ -14,18 +14,18 @@ RUN apt update \
 
 COPY . .
 
-RUN pip3 install .
+RUN pip3 install . --break-system-packages
 
-FROM debian:bullseye-slim
+FROM debian:bookworm-slim
 
-ARG firefox_ver=105.0
-ARG geckodriver_ver=0.31.0
-ARG build_rev=0
+ARG firefox_ver=118.0
+ARG geckodriver_ver=0.33.0
 
 ENV DEBIAN_FRONTEND=noninteractive \
   LANG=en_US.UTF-8 \
   PYTHONDONTWRITEBYTECODE=1 \
-  PATH=$PATH:/opt/firefox
+  PATH=$PATH:/opt/firefox \
+  OPENSSL_CONF='/etc/wapiti/openssl_conf'
 
 RUN apt update \
   && apt install python3 python3-setuptools curl bzip2 -y \
@@ -48,7 +48,8 @@ RUN apt update \
   && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* \
   && truncate -s 0 /var/log/*log
 
-COPY --from=build /usr/local/lib/python3.9/dist-packages/ /usr/local/lib/python3.9/dist-packages/
+COPY --from=build /usr/local/lib/python3.11/dist-packages/ /usr/local/lib/python3.11/dist-packages/
 COPY --from=build /usr/local/bin/wapiti /usr/local/bin/wapiti-getcookie /usr/local/bin/
+COPY --chmod=644 openssl_conf /etc/wapiti/
 
 ENTRYPOINT ["wapiti"]


### PR DESCRIPTION
Upgrade the Dockerfile for headless version with:
- Debian from 11 to 12
- Firefox from 105.0 to 118.0
- gecko drive from 0.31.0 to 0.33.0