### PR TITLE
feat : use --no-cache-dir flag to pip in dockerfiles to save space

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,7 @@ RUN apt update \
 
 COPY . .
 
-RUN pip3 install . --break-system-packages
+RUN pip3 install --no-cache-dir . --break-system-packages
 
 FROM debian:bookworm-slim
 

--- a/Dockerfile.headless
+++ b/Dockerfile.headless
@@ -14,7 +14,7 @@ RUN apt update \
 
 COPY . .
 
-RUN pip3 install . --break-system-packages
+RUN pip3 install --no-cache-dir . --break-system-packages
 
 FROM debian:bookworm-slim
 

--- a/Dockerfile.test
+++ b/Dockerfile.test
@@ -11,8 +11,8 @@ RUN apt update \
 
 RUN update-ca-certificates
 RUN python3 -c "import sys; print(sys.version)"
-RUN python3 -m pip install --upgrade pip
-RUN pip3 install -U setuptools --no-cache-dir
+RUN python3 -m pip install --no-cache-dir --upgrade pip
+RUN pip3 install --no-cache-dir -U setuptools
 RUN mkdir /usr/src/app
 
 ENV LANG en_US.UTF-8
@@ -23,5 +23,5 @@ WORKDIR /usr/src/app
 
 COPY . .
 
-RUN pip3 install .[test] --no-cache-dir
+RUN pip3 install --no-cache-dir .[test]
 CMD ["pytest"]

--- a/tests/integration/wapiti/Dockerfile.integration
+++ b/tests/integration/wapiti/Dockerfile.integration
@@ -15,7 +15,7 @@ RUN apt-get -y update &&\
 
 COPY . .
 
-RUN pip3 install . requests --break-system-packages
+RUN pip3 install --no-cache-dir . requests --break-system-packages
 
 FROM debian:bookworm-slim
 


### PR DESCRIPTION
using the "--no-cache-dir" flag in pip install, make sure downloaded packages by pip don't cache on the system. This is a best practice that makes sure to fetch from a repo instead of using a local cached one. Further, in the case of Docker Containers, by restricting caching, we can reduce image size. In terms of stats, it depends upon the number of python packages multiplied by their respective size. e.g for heavy packages with a lot of dependencies it reduces a lot by don't cache pip packages.

Further, more detailed information can be found at

https://medium.com/sciforce/strategies-of-docker-images-optimization-2ca9cc5719b6