### PR TITLE
Fix headless wapp version detection

### DIFF
--- a/wapitiCore/attack/mod_wapp.py
+++ b/wapitiCore/attack/mod_wapp.py
@@ -326,12 +326,12 @@ class ModuleWapp(Attack):
                                 if version == "undefined":
                                     continue
 
-                                if not expected_format:
+                                if not expected_format or expected_format.startswith(r"\;"):
                                     if VERSION_REGEX.match(version):
                                         final_results[software] = [version]
                                     else:
                                         final_results[software] = []
-                                elif isinstance(version, str):
+                                elif isinstance(version, str) and r"\;version:" in expected_format:
                                     final_results[software] = [version]
                                 # Other cases seems to be some kind of false positives
                             # final_results.update(results)


### PR DESCRIPTION
In some cases, headless version detection will provide false positive on version value. For instance with Chart.js, the JS command `Chart` will result in a JS function.
![image](https://github.com/wapiti-scanner/wapiti/assets/27951656/f8e3e06e-2b20-41a1-a664-a26a913e53e5)
So now it ensures whether a version is wanted or not for each JS command. For instance, Chart.js is still detected with the `Chart` command but without version.
![image](https://github.com/wapiti-scanner/wapiti/assets/27951656/740c4f62-5b48-4f0d-be51-884a86fc966e)
![image](https://github.com/wapiti-scanner/wapiti/assets/27951656/d01cab56-a9d5-4d3e-b81a-7300501d1f08)


