### PR TITLE
Update firefox and geekodrive to the last version in Dockerfile.headless

### DIFF
--- a/Dockerfile.headless
+++ b/Dockerfile.headless
@@ -18,8 +18,8 @@ RUN pip3 install . --break-system-packages
 
 FROM debian:bookworm-slim
 
-ARG firefox_ver=118.0
-ARG geckodriver_ver=0.33.0
+ARG firefox_ver=124.0
+ARG geckodriver_ver=0.34.0
 
 ENV DEBIAN_FRONTEND=noninteractive \
   LANG=en_US.UTF-8 \


### PR DESCRIPTION
### Description

Upgrade firefox and geekodriver in the headless docker image.

- Upgrade firefox from 118.0 to 124.0
- Upgrade geekodriver from 0.33.0 to 0.34.0