### PR TITLE
Fix headless explorer clean method

### DIFF
--- a/wapitiCore/net/intercepting_explorer.py
+++ b/wapitiCore/net/intercepting_explorer.py
@@ -485,9 +485,13 @@ class InterceptingExplorer(Explorer):
             if self._stopped.is_set():
                 break
 
+    def empty_queue(self):
+        while not self._queue.empty():
+            self._queue.get_nowait()
+            self._queue.task_done()
+
     async def clean(self):
-        if not self._queue.empty():
-            await self._queue.join()
+        self.empty_queue()
 
         # The headless crawler must stop when the stop event is set, let's just wait for it
         if self._headless_task:


### PR DESCRIPTION
Fix clean method for headless explorer.
`queue.join()` was blocking in most cases waiting for `queue` to be emptied but it was not done.
Now it just ensures that `queue` is empty, no more `join` needed