### PR TITLE
Support Python 3.12

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -41,7 +41,7 @@ jobs:
     runs-on: ubuntu-22.04
     strategy:
       matrix:
-        python-version: ["3.10", "3.11"]
+        python-version: ["3.10", "3.11", "3.12"]
     steps:
     - uses: actions/checkout@v4
     - name: Set up Python ${{ matrix.python-version }}

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -6,6 +6,7 @@ stages:
 variables:
   PYTHON_10_IMAGE: "docker.io/library/python:3.10-slim-bullseye"
   PYTHON_11_IMAGE: "docker.io/library/python:3.11-slim-bullseye"
+  PYTHON_12_IMAGE: "docker.io/library/python:3.12-slim-bullseye"
   ACCESS_TOKEN_NAME: "gitlab-ci-token"
 
 check_coding_style:
@@ -37,7 +38,7 @@ test-python:
         $CI_PIPELINE_SOURCE == "merge_request_event"
   parallel:
     matrix:
-      - PYTHON_IMAGE: [$PYTHON_10_IMAGE, $PYTHON_11_IMAGE]
+      - PYTHON_IMAGE: [$PYTHON_10_IMAGE, $PYTHON_11_IMAGE, $PYTHON_12_IMAGE]
   image: $PYTHON_IMAGE
   before_script:
     - python -c "import sys; print(sys.version)"

--- a/README.rst
+++ b/README.rst
@@ -23,7 +23,7 @@ http://wapiti-scanner.github.io/
 
 Requirements
 ============
-In order to work correctly, Wapiti needs Python 3.10 or 3.11
+In order to work correctly, Wapiti needs Python 3.10, 3.11 or 3.12
 
 All Python module dependencies will be installed automatically if you use the setup.py script or `pip install wapiti3`
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,6 +26,7 @@ classifiers = [
         "Programming Language :: Python :: 3",
         "Programming Language :: Python :: 3.10",
         "Programming Language :: Python :: 3.11",
+        "Programming Language :: Python :: 3.12",
         "Topic :: Security",
         "Topic :: Internet :: WWW/HTTP :: Indexing/Search",
         "Topic :: Software Development :: Testing"

--- a/tests/attack/test_mod_ssl.py
+++ b/tests/attack/test_mod_ssl.py
@@ -28,13 +28,17 @@ from wapitiCore.attack.mod_ssl import (
 def https_server(cert_directory: str):
     server_address = ("127.0.0.1", 4443)
     httpd = http.server.HTTPServer(server_address, http.server.SimpleHTTPRequestHandler)
-    httpd.socket = ssl.wrap_socket(
-        httpd.socket,
-        server_side=True,
+
+    # Create an SSL context
+    context = ssl.SSLContext(ssl.PROTOCOL_TLS_SERVER)
+    context.load_cert_chain(
         certfile=os.path.join(cert_directory, "cert.pem"),
-        keyfile=os.path.join(cert_directory, "key.pem"),
-        ssl_version=ssl.PROTOCOL_TLS
+        keyfile=os.path.join(cert_directory, "key.pem")
     )
+
+    # Wrap the socket with the context
+    httpd.socket = context.wrap_socket(httpd.socket, server_side=True)
+
     httpd.serve_forever()
 
 

--- a/tests/integration/wapiti/Dockerfile.integration
+++ b/tests/integration/wapiti/Dockerfile.integration
@@ -31,7 +31,7 @@ RUN apt-get -y update &&\
   rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* &&\
   truncate -s 0 /var/log/*log
 
-COPY --from=build /usr/local/lib/python3.12/dist-packages/ /usr/local/lib/python3.12/dist-packages/
+COPY --from=build /usr/local/lib/python3.12/site-packages/ /usr/local/lib/python3.12/site-packages/
 COPY --from=build /usr/local/bin/wapiti /usr/local/bin/wapiti-getcookie /usr/local/bin/
 
 # Create the Wapiti config directory

--- a/tests/integration/wapiti/Dockerfile.integration
+++ b/tests/integration/wapiti/Dockerfile.integration
@@ -1,4 +1,4 @@
-FROM debian:bookworm-slim AS build
+FROM python:3.12-slim AS build
 
 ENV DEBIAN_FRONTEND=noninteractive \
   LANG=en_US.UTF-8
@@ -17,7 +17,7 @@ COPY . .
 
 RUN pip3 install . requests --break-system-packages
 
-FROM debian:bookworm-slim
+FROM python:3.12-slim
 
 ENV DEBIAN_FRONTEND=noninteractive \
   LANG=en_US.UTF-8 \
@@ -31,7 +31,7 @@ RUN apt-get -y update &&\
   rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* &&\
   truncate -s 0 /var/log/*log
 
-COPY --from=build /usr/local/lib/python3.11/dist-packages/ /usr/local/lib/python3.11/dist-packages/
+COPY --from=build /usr/local/lib/python3.12/dist-packages/ /usr/local/lib/python3.12/dist-packages/
 COPY --from=build /usr/local/bin/wapiti /usr/local/bin/wapiti-getcookie /usr/local/bin/
 
 # Create the Wapiti config directory


### PR DESCRIPTION
Adds Python 3.12 in pyproject.tom and also in Gitlab CI

I had to explicitely add setuptools as a dependency for Wapiti to work (guess it was previously installed from a removed dependency and worked that way)