### PR TITLE
Add CVE findings

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,6 +47,7 @@ dependencies = [
         "mako==1.3.2",
         "markupsafe==2.1.5",
         "mitmproxy==10.2.3",
+        "packaging==24.1",
         "pyasn1==0.5.1",
         "six==1.16.0",
         "sqlalchemy==2.0.28",

--- a/tests/attack/test_mod_wapp.py
+++ b/tests/attack/test_mod_wapp.py
@@ -1,7 +1,10 @@
 import json
+import lzma
 import os
+import tempfile
 from asyncio import Event
-from unittest.mock import AsyncMock, patch, mock_open
+from pathlib import Path
+from unittest.mock import AsyncMock, patch, mock_open, ANY
 
 import httpx
 from httpx import RequestError
@@ -9,9 +12,11 @@ import pytest
 import respx
 
 from wapitiCore.attack.mod_wapp import ModuleWapp
+from wapitiCore.language.vulnerability import INFO_LEVEL, HIGH_LEVEL, MEDIUM_LEVEL
 from wapitiCore.net.crawler import AsyncCrawler
 from wapitiCore.net.classes import CrawlerConfiguration
 from wapitiCore.net import Request
+from wapitiCore.attack.attack import VULN, ADDITION
 
 
 @pytest.mark.asyncio
@@ -77,7 +82,7 @@ async def test_url_detection():
 
         await module.attack(request)
 
-        persister.add_payload.assert_called
+        persister.add_payload.assert_called()
 
         results = [
             (
@@ -181,7 +186,6 @@ async def test_dom_detection():
         options = {"timeout": 10, "level": 2}
 
         module = ModuleWapp(crawler, persister, options, Event(), crawler_configuration)
-
         await module.attack(request)
 
         assert persister.add_payload.call_count
@@ -393,7 +397,73 @@ async def test_meta_detection():
 @pytest.mark.asyncio
 @respx.mock
 async def test_multi_detection():
-    # Test if application is detected using several ways
+    # Directory where GitHub responses are stored
+    fixture_folder = Path(__file__).parent.parent / "data" / "wapp"
+
+    # Let's mock wapiti-scanner/nvd-web-cves repository
+    wordpress_json_xz_url = (
+        "https://github.com/wapiti-scanner/nvd-web-cves/releases/download/"
+        "nvd-web-cves-20240808/wordpress.json.xz"
+    )
+
+    respx.get("https://api.github.com/repos/wapiti-scanner/nvd-web-cves/releases/latest").mock(
+        return_value=httpx.Response(
+            status_code=200,
+            json={
+                "assets": [
+                    {
+                        "name": "wordpress.json.xz",
+                        "browser_download_url": wordpress_json_xz_url,
+                    },
+                ]
+            }
+        )
+    )
+
+    respx.get(wordpress_json_xz_url).mock(
+        return_value=httpx.Response(
+            status_code=200,
+            content=lzma.compress((fixture_folder / "cve.json").open("rb").read())
+        )
+    )
+
+    # Now let's mock wapiti-scanner/wappalyzer. Wappalyzer files are split over the first character of software names.
+    for letter, filename in [("m", "mysql.json"), ("p", "php.json"), ("w", "wordpress.json")]:
+        respx.get(
+            f"https://raw.githubusercontent.com/wapiti-scanner/wappalyzer/main/src/technologies/{letter}.json"
+        ).mock(
+            return_value=httpx.Response(
+                status_code=200,
+                content=(fixture_folder / filename).open("rb").read(),
+                headers={"Content-Type": "application/json"}
+            )
+        )
+
+    # Give an empty dict for all uninteresting files
+    respx.get(url__startswith="https://raw.githubusercontent.com/wapiti-scanner/wappalyzer/main/src/techno").mock(
+        return_value=httpx.Response(
+            status_code=200,
+            json={},
+        )
+    )
+
+    respx.get("https://raw.githubusercontent.com/wapiti-scanner/wappalyzer/main/src/categories.json").mock(
+        return_value=httpx.Response(
+            status_code=200,
+            content=(fixture_folder / "categories.json").open("rb").read(),
+            headers={"Content-Type": "application/json"}
+        )
+    )
+
+    respx.get("https://raw.githubusercontent.com/wapiti-scanner/wappalyzer/main/src/groups.json").mock(
+        return_value=httpx.Response(
+            status_code=200,
+            content=(fixture_folder / "groups.json").open("rb").read(),
+            headers={"Content-Type": "application/json"}
+        )
+    )
+
+    # Finally we mock the request for Wapiti to scan
     respx.get("http://perdu.com/").mock(
         return_value=httpx.Response(
             200,
@@ -408,11 +478,6 @@ async def test_multi_detection():
         )
     )
 
-    persister = AsyncMock()
-    home_dir = os.getenv("HOME") or os.getenv("USERPROFILE") or "/home"
-    base_dir = os.path.join(home_dir, ".wapiti")
-    persister.CONFIG_DIR = os.path.join(base_dir, "config")
-
     request = Request("http://perdu.com/")
     request.path_id = 1
 
@@ -420,15 +485,74 @@ async def test_multi_detection():
     async with AsyncCrawler.with_configuration(crawler_configuration) as crawler:
         options = {"timeout": 10, "level": 2}
 
-        module = ModuleWapp(crawler, persister, options, Event(), crawler_configuration)
+        with tempfile.TemporaryDirectory() as temp_dir:
+            persister = AsyncMock()
+            # To prevent any issue the config directory is a newly created temporary directory
+            persister.CONFIG_DIR = temp_dir
 
-        await module.attack(request)
+            module = ModuleWapp(crawler, persister, options, Event(), crawler_configuration)
 
-        assert persister.add_payload.call_count
-        assert persister.add_payload.call_args_list[-1][1]["info"] == (
-            '{"name": "WordPress", "versions": ["5.6.1"], "cpe": "cpe:2.3:a:wordpress:wordpress:*:*:*:*:*:*:*:*", '
-            '"categories": ["CMS", "Blogs"], "groups": ["Content"]}'
-        )
+            await module.attack(request)
+
+            # Findings:
+            # - Fingerprint for Wordpress as a technology
+            # - Fingerprint for Wordpress as a framework
+            # - Fingerprint for PHP that was deduced from Wordpress
+            # - Fingerprint for MySQL that was deduced from Wordpress
+            # - Vulnerable software for Wordpress
+            assert persister.add_payload.call_count == 5
+            assert {parameters[1]["category"] for parameters in persister.add_payload.call_args_list} == {
+                "Fingerprint web application framework",
+                "Fingerprint web technology",
+                "Vulnerable software"
+            }
+
+            persister.add_payload.assert_any_call(
+                request_id=-1,
+                payload_type=VULN,
+                module="wapp",
+                category="Fingerprint web application framework",
+                level=INFO_LEVEL,
+                request=request,
+                parameter="",
+                info='{"name": "WordPress", "versions": ["5.6.1"], "cpe": "cpe:2.3:a:wordpress:wordpress:*:*:*:*:*:*:*:*", "categories": ["CMS", "Blogs"], "groups": ["Content"]}',
+                wstg=["WSTG-INFO-08"],
+                response=ANY,
+            )
+
+            persister.add_payload.assert_any_call(
+                request_id=-1,
+                payload_type=ADDITION,
+                module="wapp",
+                category="Fingerprint web technology",
+                level=INFO_LEVEL,
+                request=request,
+                parameter="",
+                info='{"name": "PHP", "versions": [], "cpe": "cpe:2.3:a:php:php:*:*:*:*:*:*:*:*", "categories": ["Programming languages"], "groups": ["Web development"]}',
+                wstg=['WSTG-INFO-02', 'WSTG-INFO-08'],
+                response=ANY,
+            )
+
+            persister.add_payload.assert_any_call(
+                request_id=-1,
+                payload_type=VULN,
+                module="wapp",
+                category="Vulnerable software",
+                # Level is high as we use the most recent CVSS format which is CVSS 3.1 here. Score is 8.8.
+                level=HIGH_LEVEL,
+                request=request,
+                parameter="",
+                info=(
+                    "wordpress CVE-2022-21664: WordPress is a free and open-source content management system written "
+                    "in PHP and paired with a MariaDB database. Due to lack of proper sanitization in one of the "
+                    "classes, there's potential for unintended SQL queries to be executed. This has been patched in "
+                    "WordPress version 5.8.3. Older affected versions are also fixed via security release, that go "
+                    "back till 4.1.34. We strongly recommend that you keep auto-updates enabled. There are no known "
+                    "workarounds for this issue."
+                ),
+                wstg=[],
+                response=ANY,
+            )
 
 
 @pytest.mark.asyncio
@@ -560,7 +684,7 @@ async def test_merge_with_and_without_redirection():
 
         await module.attack(request)
 
-        persister.add_payload.assert_called
+        persister.add_payload.assert_called()
 
         results = [
             (
@@ -600,7 +724,8 @@ async def test_raise_on_invalid_json():
     respx.get("http://perdu.com/src/categories.json").mock(
         return_value=httpx.Response(
             200,
-            content="Test")
+            content="Test"
+        )
     )
 
     persister = AsyncMock()
@@ -626,8 +751,10 @@ async def test_raise_on_not_valid_db_url():
     respx.get(url__regex=r"http://perdu.com/.*").mock(
         return_value=httpx.Response(
             404,
-            content="Not Found")
+            content="Not Found"
+        )
     )
+
     persister = AsyncMock()
     crawler_configuration = CrawlerConfiguration(Request("http://perdu.com/"))
     async with AsyncCrawler.with_configuration(crawler_configuration) as crawler:
@@ -646,25 +773,28 @@ async def test_raise_on_not_valid_db_url():
 async def test_raise_on_value_error():
     """Tests that a ValueError is raised when calling the _load_wapp_database function when the json is not valid."""
 
-    example_json_content = json.dumps({
-        "2B Advice": {
-            "cats": [67],
-            "description": "2B Advice provides a plug-in to manage GDPR cookie consent.",
-            "icon": "2badvice.png",
-            "js": {
-                "BBCookieControler": ""
+    example_json_content = json.dumps(
+        {
+            "2B Advice": {
+                "cats": [67],
+                "description": "2B Advice provides a plug-in to manage GDPR cookie consent.",
+                "icon": "2badvice.png",
+                "js": {
+                    "BBCookieControler": ""
+                },
+                "saas": True,
+                "scriptSrc": "2badvice-cdn\\.azureedge\\.net",
+                "website": "https://www.2b-advice.com/en/data-privacy-software/cookie-consent-plugin/"
             },
-            "saas": True,
-            "scriptSrc": "2badvice-cdn\\.azureedge\\.net",
-            "website": "https://www.2b-advice.com/en/data-privacy-software/cookie-consent-plugin/"
-        },
-        "30namaPlayer": {
-            "cats": [14],
-            "description": "30namaPlayer is a modified version of Video.",
-            "dom": "section[class*='player30nama']",
-            "icon": "30namaPlayer.png",
-            "website": "https://30nama.com/"
-        }})
+            "30namaPlayer": {
+                "cats": [14],
+                "description": "30namaPlayer is a modified version of Video.",
+                "dom": "section[class*='player30nama']",
+                "icon": "30namaPlayer.png",
+                "website": "https://30nama.com/"
+            }
+        }
+    )
 
     cat_url = "http://perdu.com/src/categories.json"
     group_url = "http://perdu.com/src/groups.json"
@@ -673,13 +803,17 @@ async def test_raise_on_value_error():
     respx.get(url__regex=r"http://perdu.com/src/technologies/.*").mock(
         return_value=httpx.Response(
             200,
-            content=example_json_content)
+            content=example_json_content
+        )
     )
+
     respx.get(url__regex=r"http://perdu.com/.*").mock(
         return_value=httpx.Response(
             200,
-            content="No Json")
+            content="No Json"
+        )
     )
+
     persister = AsyncMock()
     crawler_configuration = CrawlerConfiguration(Request("http://perdu.com/"))
     async with AsyncCrawler.with_configuration(crawler_configuration) as crawler:
@@ -702,7 +836,10 @@ async def test_raise_on_request_error():
     group_url = "http://perdu.com/src/groups.json"
     tech_url = "http://perdu.com/src/technologies/"
 
-    respx.get(url__regex=r"http://perdu.com/.*").mock(side_effect=RequestError("RequestError occurred: [Errno -2] Name or service not known"))
+    respx.get(url__regex=r"http://perdu.com/.*").mock(
+        side_effect=RequestError("RequestError occurred: [Errno -2] Name or service not known")
+    )
+
     persister = AsyncMock()
     crawler_configuration = CrawlerConfiguration(Request("http://perdu.com/"))
     async with AsyncCrawler.with_configuration(crawler_configuration) as crawler:
@@ -720,10 +857,12 @@ async def test_raise_on_request_error():
 @respx.mock
 async def test_raise_on_request_error_for_dump_url():
     """Tests that a RequestError is raised when calling the _dump_url_content_to_file function with wrong URL."""
-
     url = "http://perdu.com/"
 
-    respx.get(url__regex=r"http://perdu.com/.*").mock(side_effect=RequestError("RequestError occurred: [Errno -2] Name or service not known"))
+    respx.get(url__regex=r"http://perdu.com/.*").mock(
+        side_effect=RequestError("RequestError occurred: [Errno -2] Name or service not known")
+    )
+
     persister = AsyncMock()
     crawler_configuration = CrawlerConfiguration(Request("http://perdu.com/"))
     async with AsyncCrawler.with_configuration(crawler_configuration) as crawler:
@@ -739,14 +878,12 @@ async def test_raise_on_request_error_for_dump_url():
 
 @pytest.mark.asyncio
 @respx.mock
-async def test_raise_on_request_error_for_update():
+async def test_wappalyzer_raise_on_request_error_for_update():
     """Tests that a RequestError is raised when calling the update function with wrong URL."""
+    respx.get(url__regex=r"http://perdu.com/.*").mock(
+        side_effect=RequestError("RequestError occurred: [Errno -2] Name or service not known")
+    )
 
-    url = "http://perdu.com/"
-    group_url = "http://perdu.com/src/groups.json"
-    tech_url = "http://perdu.com/src/technologies/"
-
-    respx.get(url__regex=r"http://perdu.com/.*").mock(side_effect=RequestError("RequestError occurred: [Errno -2] Name or service not known"))
     persister = AsyncMock()
     crawler_configuration = CrawlerConfiguration(Request("http://perdu.com/"))
     async with AsyncCrawler.with_configuration(crawler_configuration) as crawler:
@@ -755,25 +892,28 @@ async def test_raise_on_request_error_for_update():
         module = ModuleWapp(crawler, persister, options, Event(), crawler_configuration)
 
         with pytest.raises(RequestError) as exc_info:
-            await module.update()
+            await module.update_wappalyzer()
 
         assert exc_info.value.args[0] == "RequestError occurred: [Errno -2] Name or service not known"
 
 
 @pytest.mark.asyncio
 @respx.mock
-async def test_raise_on_value_error_for_update():
+async def test_wappalyzer_raise_on_value_error_for_update():
     """Tests that a ValueError is raised when calling the update function with URL doesn't contain a wapp DB."""
 
     respx.get(url__regex=r"http://perdu.com/src/technologies/.*").mock(
         return_value=httpx.Response(
             200,
-            content=str("{}"))
+            content=str("{}")
+        )
     )
+
     respx.get(url__regex=r"http://perdu.com/.*").mock(
         return_value=httpx.Response(
             200,
-            content="No Json")
+            content="No Json"
+        )
     )
 
     persister = AsyncMock()
@@ -784,7 +924,7 @@ async def test_raise_on_value_error_for_update():
         module = ModuleWapp(crawler, persister, options, Event(), crawler_configuration)
 
         with pytest.raises(ValueError) as exc_info:
-            await module.update()
+            await module.update_wappalyzer()
 
         assert exc_info.value.args[0] == "Invalid or empty JSON response for http://perdu.com/src/categories.json"
 
@@ -794,53 +934,63 @@ async def test_raise_on_value_error_for_update():
 async def test_private_gitlab():
     """Test for private gitlab url and token."""
 
-    techno_json_content = json.dumps({
-        "Outlook Web App from test": {
-            "cats": [30],
-            "cpe": "cpe:2.3:a:microsoft:outlook_web_access:*:*:*:*:*:*:*:*",
-            "description": "Outlook on the web is an information manager web app. It includes a web-based email client, a calendar tool, a contact manager, and a task manager.",
-            "headers": {"X-OWA-Version": "([\\d\\.]+)?\\;version:\\1"},
-            "html": "<link[^>]+/owa/auth/([\\d\\.]+)/themes/resources\\;version:\\1",
-            "icon": "Outlook.svg",
-            "implies": "Microsoft ASP.NET",
-            "js": {"IsOwaPremiumBrowser": ""},
-            "url": "/owa/auth/log(?:on|off)\\.aspx",
-            "website": "https://help.outlook.com"
-        },
-        "Microsoft ASP.NET": {
-            "cats": [18],
-            "cookies": {"ASP.NET_SessionId": "", "ASPSESSION": ""},
-            "cpe": "cpe:2.3:a:microsoft:asp.net:*:*:*:*:*:*:*:*",
-            "description": "ASP.NET is an open-source, server-side web-application framework designed for web development to produce dynamic web pages.",
-            "headers": {"X-AspNet-Version": "(.+)\\;version:\\1", "X-Powered-By": "^ASP\\.NET", "set-cookie": "\\.AspNetCore"},
-            "html": "<input[^>]+name=\"__VIEWSTATE",
-            "icon": "Microsoft ASP.NET.svg",
-            "url": "\\.aspx?(?:$|\\?)",
-            "website": "https://www.asp.net"
+    techno_json_content = json.dumps(
+        {
+            "Outlook Web App from test": {
+                "cats": [30],
+                "cpe": "cpe:2.3:a:microsoft:outlook_web_access:*:*:*:*:*:*:*:*",
+                "description": "Outlook on the web is an information manager web app. It includes a web-based email client, a calendar tool, a contact manager, and a task manager.",
+                "headers": {"X-OWA-Version": "([\\d\\.]+)?\\;version:\\1"},
+                "html": "<link[^>]+/owa/auth/([\\d\\.]+)/themes/resources\\;version:\\1",
+                "icon": "Outlook.svg",
+                "implies": "Microsoft ASP.NET",
+                "js": {"IsOwaPremiumBrowser": ""},
+                "url": "/owa/auth/log(?:on|off)\\.aspx",
+                "website": "https://help.outlook.com"
+            },
+            "Microsoft ASP.NET": {
+                "cats": [18],
+                "cookies": {"ASP.NET_SessionId": "", "ASPSESSION": ""},
+                "cpe": "cpe:2.3:a:microsoft:asp.net:*:*:*:*:*:*:*:*",
+                "description": "ASP.NET is an open-source, server-side web-application framework designed for web development to produce dynamic web pages.",
+                "headers": {
+                    "X-AspNet-Version": "(.+)\\;version:\\1",
+                    "X-Powered-By": "^ASP\\.NET",
+                    "set-cookie": "\\.AspNetCore"
+                },
+                "html": "<input[^>]+name=\"__VIEWSTATE",
+                "icon": "Microsoft ASP.NET.svg",
+                "url": "\\.aspx?(?:$|\\?)",
+                "website": "https://www.asp.net"
+            }
         }
-    })
+    )
 
-    cat_json_content = json.dumps({
-        "30": {
-            "groups": [4],
-            "name": "Webmail",
-            "priority": 2
-        },
-        "18": {
-            "groups": [9],
-            "name": "Web frameworks",
-            "priority": 7
+    cat_json_content = json.dumps(
+        {
+            "30": {
+                "groups": [4],
+                "name": "Webmail",
+                "priority": 2
+            },
+            "18": {
+                "groups": [9],
+                "name": "Web frameworks",
+                "priority": 7
+            }
         }
-    })
+    )
 
-    group_json_content = json.dumps({
-        "4": {
-            "name": "Communication"
-        },
-        "9": {
-            "name": "Web development"
+    group_json_content = json.dumps(
+        {
+            "4": {
+                "name": "Communication"
+            },
+            "9": {
+                "name": "Web development"
+            }
         }
-    })
+    )
 
     respx.get("http://perdu.com/").mock(
         return_value=httpx.Response(
@@ -866,17 +1016,20 @@ async def test_private_gitlab():
     respx.get(url__regex=r"http://perdu.com/src%2Ftechnologies%2F.*").mock(
         return_value=httpx.Response(
             200,
-            content=techno_json_content)
+            content=techno_json_content
+        )
     )
     respx.get("http://perdu.com/src%2Fcategories.json").mock(
         return_value=httpx.Response(
             200,
-            content=cat_json_content)
+            content=cat_json_content
+        )
     )
     respx.get("http://perdu.com/src%2Fgroups.json").mock(
         return_value=httpx.Response(
             200,
-            content=group_json_content)
+            content=group_json_content
+        )
     )
 
     persister = AsyncMock()
@@ -893,13 +1046,14 @@ async def test_private_gitlab():
 
         with patch.dict(os.environ, {'GITLAB_PRIVATE_TOKEN': 'test_gitlab_private_token'}):
             module = ModuleWapp(crawler, persister, options, Event(), crawler_configuration)
-            await module.update()
+            await module.update_wappalyzer()
             await module.attack(request)
 
-            persister.add_payload.assert_called
+            persister.add_payload.assert_called()
 
             results = [
-                (args[1]["payload_type"], args[1]["info"], args[1]["category"]) for args in persister.add_payload.call_args_list
+                (args[1]["payload_type"], args[1]["info"], args[1]["category"]) for args in
+                persister.add_payload.call_args_list
             ]
 
             expected_results = [
@@ -928,14 +1082,13 @@ async def test_private_gitlab():
 
 @pytest.mark.asyncio
 @respx.mock
-async def test_raise_on_not_valid_directory_for_update():
+async def test_wappalyzer_raise_on_not_valid_directory_for_update():
     """Tests that a ValueError is raised when calling update() with a directory that does not exist."""
-    wapp_dir = "/"
-
     respx.get(url__regex=r"http://perdu.com/.*").mock(
         return_value=httpx.Response(
             404,
-            content="Not Found")
+            content="Not Found"
+        )
     )
     persister = AsyncMock()
     crawler_configuration = CrawlerConfiguration(Request("http://perdu.com/"))
@@ -945,9 +1098,10 @@ async def test_raise_on_not_valid_directory_for_update():
         module = ModuleWapp(crawler, persister, options, Event(), crawler_configuration)
 
         with pytest.raises(ValueError) as exc_info:
-            await module.update()
+            await module.update_wappalyzer()
 
         assert exc_info.value.args[0] == "Update failed : Something went wrong with files in /"
+
 
 def read_directory_structure(directory_path):
     file_a_path = os.path.join(directory_path, 'categories.json')
@@ -960,19 +1114,21 @@ def read_directory_structure(directory_path):
 
     return {'categories': data_a, 'groups': data_b, 'a': data_c}
 
+
 def read_json_file(file_path):
     with open(file_path, 'r', encoding='utf-8') as file:
         return file.read()
 
+
 @pytest.mark.asyncio
 @respx.mock
-async def test_raise_on_not_valid_json_for_update():
-
+async def test_wappalyzer_raise_on_not_valid_json_for_update():
     """Tests that a ValueError is raised when calling update() with an invalid json file."""
     respx.get(url__regex=r"http://perdu.com/.*").mock(
         return_value=httpx.Response(
             404,
-            content="Not Found")
+            content="Not Found"
+        )
     )
 
     wapp_dir = "wapp/"
@@ -990,20 +1146,20 @@ async def test_raise_on_not_valid_json_for_update():
                     module = ModuleWapp(crawler, persister, options, Event(), crawler_configuration)
 
                     with pytest.raises(ValueError) as exc_info:
-                        await module.update()
+                        await module.update_wappalyzer()
 
             assert exc_info.value.args[0] == "Update failed : Something went wrong with files in wapp/"
 
 
 @pytest.mark.asyncio
 @respx.mock
-async def test_raise_on_not_valid_json_file_for_update():
-
+async def test_wappalyzer_raise_on_not_valid_json_file_for_update():
     """Tests that a ValueError is raised when calling update() with an invalid json file."""
     respx.get(url__regex=r"http://perdu.com/.*").mock(
         return_value=httpx.Response(
             404,
-            content="Not Found")
+            content="Not Found"
+        )
     )
 
     wapp_dir = "wapp/"
@@ -1021,18 +1177,20 @@ async def test_raise_on_not_valid_json_file_for_update():
                     module = ModuleWapp(crawler, persister, options, Event(), crawler_configuration)
 
                     with pytest.raises(ValueError) as exc_info:
-                        await module.update()
+                        await module.update_wappalyzer()
 
             assert exc_info.value.args[0] == "Update failed : Something went wrong with files in wapp/"
 
+
 @pytest.mark.asyncio
 @respx.mock
-async def test_raise_on_file_does_not_exist_for_update():
+async def test_wappalyzer_raise_on_file_does_not_exist_for_update():
     """Tests that a ValueError is raised when calling update() with a missing json file."""
     respx.get(url__regex=r"http://perdu.com/.*").mock(
         return_value=httpx.Response(
             404,
-            content="Not Found")
+            content="Not Found"
+        )
     )
 
     wapp_dir = "wapp/"
@@ -1050,6 +1208,64 @@ async def test_raise_on_file_does_not_exist_for_update():
                     module = ModuleWapp(crawler, persister, options, Event(), crawler_configuration)
 
                     with pytest.raises(ValueError) as exc_info:
-                        await module.update()
+                        await module.update_wappalyzer()
 
             assert exc_info.value.args[0] == "Update failed : Something went wrong with files in wapp/"
+
+
+@pytest.mark.asyncio
+async def test_get_vulnerabilities():
+    cve_data = [
+        {
+            "id": "CVE-2004-1559",
+            "description": "XSS",
+            "cvss2": 4.3,
+            "versions": [
+                "1.2"
+            ]
+        },
+        {
+            "id": "CVE-2004-1584",
+            "description": "CRLF",
+            "cvss2": 5.0,
+            "versions": [
+                "1.2"
+            ]
+        },
+        {
+            "id": "CVE-2005-1102",
+            "description": "XSS again",
+            "cvss2": 6.8,
+            "versions": [
+                [
+                    None,
+                    "<=1.5"
+                ]
+            ]
+        },
+    ]
+    crawler_configuration = CrawlerConfiguration(Request("http://perdu.com/"))
+    async with AsyncCrawler.with_configuration(crawler_configuration) as crawler:
+        options = {"timeout": 10, "level": 2}
+
+        with tempfile.TemporaryDirectory() as temp_dir:
+            persister = AsyncMock()
+            # To prevent any issue the config directory is a newly created temporary directory
+            persister.CONFIG_DIR = temp_dir
+
+            module = ModuleWapp(crawler, persister, options, Event(), crawler_configuration)
+            os.mkdir(os.path.join(temp_dir, "cves"))
+            with lzma.open(os.path.join(temp_dir, "cves", "wordpress.json.xz"), "wb") as fd:
+                fd.write(json.dumps(cve_data).encode())
+
+            results = [
+                result async for result in module.get_vulnerabilities(
+                    "Wordpress",
+                    ["1.2", "1.5"]
+                )
+            ]
+            assert results == [
+                (MEDIUM_LEVEL, "Wordpress CVE-2004-1559: XSS"),
+                (MEDIUM_LEVEL, "Wordpress CVE-2004-1584: CRLF"),
+                (MEDIUM_LEVEL, "Wordpress CVE-2005-1102: XSS again"),
+            ]

--- a/tests/cve/test_cve.py
+++ b/tests/cve/test_cve.py
@@ -1,0 +1,115 @@
+import json
+import lzma
+import os
+import tempfile
+
+import pytest
+
+from wapitiCore.attack.cve.checker import (
+    is_version_in_list,
+    cvss_score_to_wapiti_level,
+    is_cve_supported_software,
+    CVEChecker,
+)
+from wapitiCore.language.vulnerability import CRITICAL_LEVEL, HIGH_LEVEL, MEDIUM_LEVEL, LOW_LEVEL
+
+
+def test_is_cve_supported_software():
+    assert is_cve_supported_software("Next.JS") is True
+    assert is_cve_supported_software("angular.js") is True
+    assert is_cve_supported_software("tomahawkjs") is False
+    assert is_cve_supported_software("Apache") is True
+    assert is_cve_supported_software("underscore-js") is True
+
+
+def test_cvss_score_to_wapiti_level():
+    assert cvss_score_to_wapiti_level(0) == LOW_LEVEL
+    assert cvss_score_to_wapiti_level(4) == MEDIUM_LEVEL
+    assert cvss_score_to_wapiti_level(8) == HIGH_LEVEL
+    assert cvss_score_to_wapiti_level(9) == CRITICAL_LEVEL
+
+
+def test_is_version_in_list():
+    version_list = [
+        [None, "<=1.6.2"],
+        "1.6",
+        "1.6.1",
+        [">2.5", "<3.0"],
+        [">=3.0.1", "<=3.1.4"]
+    ]
+
+    # Test exact matches
+    assert is_version_in_list("1.6", version_list) is True  # Exact match
+    assert is_version_in_list("1.6.1", version_list) is True  # Exact match
+
+    # Test versions within range
+    assert is_version_in_list("1.5", version_list) is True  # True, <= 1.6.2
+    assert is_version_in_list("1.6.2", version_list) is True  # True, <= 1.6.2
+    assert is_version_in_list("2.6", version_list) is True  # True, > 2.5 and < 3.0
+    assert is_version_in_list("3.0.1", version_list) is True  # True, >= 3.0.1
+    assert is_version_in_list("3.0a", version_list) is True  # True, alpha version is before the stable one
+    assert is_version_in_list("3.0-rc1", version_list) is True  # True, RC version is before the stable one
+    assert is_version_in_list("3.1.4", version_list) is True  # True, <= 3.1.4
+
+    # Test versions outside of range
+    assert is_version_in_list("1.6.3", version_list) is False  # False
+    assert is_version_in_list("2.5", version_list) is False  # False, exactly 2.5
+    assert is_version_in_list("3.0", version_list) is False  # False, < 3.0.1
+    assert is_version_in_list("3.2", version_list) is False  # False, > 3.1.4
+
+    # Test edge cases and invalid inputs
+    assert is_version_in_list("invalid.version", version_list) is False  # False, invalid version
+    assert is_version_in_list("", version_list) is False  # False, empty string
+
+
+def test_get_cves():
+    with tempfile.TemporaryDirectory() as temp_dir:
+        os.mkdir(os.path.join(temp_dir, "cves"))
+        checker = CVEChecker(temp_dir)
+        # Software not in supported list
+        assert list(checker.get_cves("nosuchsoftware", "93.6")) == []
+        # Missing CVE file
+        assert list(checker.get_cves("apache", "93.6")) == []
+        # Corrupted file
+        with lzma.open(os.path.join(temp_dir, "cves", "apache.json.xz"), "wb") as fd:
+            fd.write(b"Ceci n'est pas du JSON")
+        assert list(checker.get_cves("apache", "1337")) == []
+        # Valid CVE data
+        cve_data = [
+            {
+                "id": "CVE-2043-31337",
+                "description": "Back to the future",
+                "cvss3.1": 8.6,
+                "versions": [
+                    [
+                        ">=93.6",
+                        None
+                    ]
+                ]
+            },
+            {
+                "id": "CVE-2023-43622",
+                "description": "This is bad",
+                "cvss3.1": 7.5,
+                "versions": [
+                    [
+                        ">=2.4.55",
+                        "<2.4.58"
+                    ]
+                ]
+            },
+            {
+                "id": "CVE-2023-45802",
+                "description": "This is bad too",
+                "cvss3.1": 5.9,
+                "versions": [
+                    [
+                        None,
+                        "<2.4.58"
+                    ]
+                ]
+            },
+        ]
+        with lzma.open(os.path.join(temp_dir, "cves", "apache.json.xz"), "wb") as fd:
+            fd.write(json.dumps(cve_data).encode())
+        assert list(checker.get_cves("apache", "2.4.57")) == cve_data[1:]

--- a/tests/data/wapp/categories.json
+++ b/tests/data/wapp/categories.json
@@ -1,0 +1,774 @@
+{
+  "1": {
+    "groups": [
+      3
+    ],
+    "name": "CMS",
+    "priority": 1
+  },
+  "2": {
+    "groups": [
+      3,
+      4,
+      18
+    ],
+    "name": "Message boards",
+    "priority": 1
+  },
+  "3": {
+    "groups": [
+      5
+    ],
+    "name": "Database managers",
+    "priority": 2
+  },
+  "4": {
+    "groups": [
+      3
+    ],
+    "name": "Documentation",
+    "priority": 2
+  },
+  "5": {
+    "groups": [
+      6
+    ],
+    "name": "Widgets",
+    "priority": 9
+  },
+  "6": {
+    "groups": [
+      1
+    ],
+    "name": "Ecommerce",
+    "priority": 1
+  },
+  "7": {
+    "groups": [
+      3,
+      10
+    ],
+    "name": "Photo galleries",
+    "priority": 1
+  },
+  "8": {
+    "groups": [
+      3
+    ],
+    "name": "Wikis",
+    "priority": 1
+  },
+  "9": {
+    "groups": [
+      5,
+      7
+    ],
+    "name": "Hosting panels",
+    "priority": 2
+  },
+  "10": {
+    "groups": [
+      8
+    ],
+    "name": "Analytics",
+    "priority": 9
+  },
+  "11": {
+    "groups": [
+      3
+    ],
+    "name": "Blogs",
+    "priority": 1
+  },
+  "12": {
+    "groups": [
+      9
+    ],
+    "name": "JavaScript frameworks",
+    "priority": 8
+  },
+  "13": {
+    "groups": [
+      3,
+      18
+    ],
+    "name": "Issue trackers",
+    "priority": 2
+  },
+  "14": {
+    "groups": [
+      10
+    ],
+    "name": "Video players",
+    "priority": 7
+  },
+  "15": {
+    "groups": [
+      3,
+      18
+    ],
+    "name": "Comment systems",
+    "priority": 9
+  },
+  "16": {
+    "groups": [
+      11
+    ],
+    "name": "Security",
+    "priority": 9
+  },
+  "17": {
+    "groups": [
+      9
+    ],
+    "name": "Font scripts",
+    "priority": 9
+  },
+  "18": {
+    "groups": [
+      9
+    ],
+    "name": "Web frameworks",
+    "priority": 7
+  },
+  "19": {
+    "groups": [
+      6
+    ],
+    "name": "Miscellaneous",
+    "priority": 10
+  },
+  "20": {
+    "groups": [
+      9
+    ],
+    "name": "Editors",
+    "priority": 4
+  },
+  "21": {
+    "groups": [
+      3
+    ],
+    "name": "LMS",
+    "priority": 1
+  },
+  "22": {
+    "groups": [
+      7
+    ],
+    "name": "Web servers",
+    "priority": 8
+  },
+  "23": {
+    "groups": [
+      7
+    ],
+    "name": "Caching",
+    "priority": 7
+  },
+  "24": {
+    "groups": [
+      3
+    ],
+    "name": "Rich text editors",
+    "priority": 5
+  },
+  "25": {
+    "groups": [
+      9
+    ],
+    "name": "JavaScript graphics",
+    "priority": 6
+  },
+  "26": {
+    "groups": [
+      9
+    ],
+    "name": "Mobile frameworks",
+    "priority": 8
+  },
+  "27": {
+    "groups": [
+      9
+    ],
+    "name": "Programming languages",
+    "priority": 5
+  },
+  "28": {
+    "groups": [
+      7
+    ],
+    "name": "Operating systems",
+    "priority": 6
+  },
+  "29": {
+    "groups": [
+      3
+    ],
+    "name": "Search engines",
+    "priority": 4
+  },
+  "30": {
+    "groups": [
+      4
+    ],
+    "name": "Webmail",
+    "priority": 2
+  },
+  "31": {
+    "groups": [
+      7
+    ],
+    "name": "CDN",
+    "priority": 9
+  },
+  "32": {
+    "groups": [
+      2
+    ],
+    "name": "Marketing automation",
+    "priority": 9
+  },
+  "33": {
+    "groups": [
+      7
+    ],
+    "name": "Web server extensions",
+    "priority": 7
+  },
+  "34": {
+    "groups": [
+      7
+    ],
+    "name": "Databases",
+    "priority": 5
+  },
+  "35": {
+    "groups": [
+      17
+    ],
+    "name": "Maps",
+    "priority": 6
+  },
+  "36": {
+    "groups": [
+      2
+    ],
+    "name": "Advertising",
+    "priority": 9
+  },
+  "37": {
+    "groups": [
+      7
+    ],
+    "name": "Network devices",
+    "priority": 2
+  },
+  "38": {
+    "groups": [
+      10,
+      7
+    ],
+    "name": "Media servers",
+    "priority": 1
+  },
+  "39": {
+    "groups": [
+      4
+    ],
+    "name": "Webcams",
+    "priority": 9
+  },
+  "41": {
+    "groups": [
+      1
+    ],
+    "name": "Payment processors",
+    "priority": 8
+  },
+  "42": {
+    "groups": [
+      8
+    ],
+    "name": "Tag managers",
+    "priority": 9
+  },
+  "44": {
+    "groups": [
+      9
+    ],
+    "name": "CI",
+    "priority": 3
+  },
+  "45": {
+    "groups": [
+      7
+    ],
+    "name": "Control systems",
+    "priority": 2
+  },
+  "46": {
+    "groups": [
+      4
+    ],
+    "name": "Remote access",
+    "priority": 1
+  },
+  "47": {
+    "groups": [
+      9
+    ],
+    "name": "Development",
+    "priority": 2
+  },
+  "48": {
+    "groups": [
+      10
+    ],
+    "name": "Network storage",
+    "priority": 2
+  },
+  "49": {
+    "groups": [
+      3
+    ],
+    "name": "Feed readers",
+    "priority": 1
+  },
+  "50": {
+    "groups": [
+      3
+    ],
+    "name": "DMS",
+    "priority": 1
+  },
+  "51": {
+    "groups": [
+      9
+    ],
+    "name": "Page builders",
+    "priority": 1
+  },
+  "52": {
+    "groups": [
+      4,
+      16
+    ],
+    "name": "Live chat",
+    "priority": 9
+  },
+  "53": {
+    "groups": [
+      2,
+      16
+    ],
+    "name": "CRM",
+    "priority": 5
+  },
+  "54": {
+    "groups": [
+      2
+    ],
+    "name": "SEO",
+    "priority": 8
+  },
+  "55": {
+    "groups": [
+      16
+    ],
+    "name": "Accounting",
+    "priority": 1
+  },
+  "56": {
+    "groups": [
+      5
+    ],
+    "name": "Cryptominers",
+    "priority": 5
+  },
+  "57": {
+    "groups": [
+      9
+    ],
+    "name": "Static site generator",
+    "priority": 1
+  },
+  "58": {
+    "groups": [
+      6
+    ],
+    "name": "User onboarding",
+    "priority": 8
+  },
+  "59": {
+    "groups": [
+      9
+    ],
+    "name": "JavaScript libraries",
+    "priority": 9
+  },
+  "60": {
+    "groups": [
+      7
+    ],
+    "name": "Containers",
+    "priority": 8
+  },
+  "62": {
+    "groups": [
+      7
+    ],
+    "name": "PaaS",
+    "priority": 8
+  },
+  "63": {
+    "groups": [
+      7
+    ],
+    "name": "IaaS",
+    "priority": 8
+  },
+  "64": {
+    "groups": [
+      7
+    ],
+    "name": "Reverse proxies",
+    "priority": 7
+  },
+  "65": {
+    "groups": [
+      7
+    ],
+    "name": "Load balancers",
+    "priority": 7
+  },
+  "66": {
+    "groups": [
+      9
+    ],
+    "name": "UI frameworks",
+    "priority": 7
+  },
+  "67": {
+    "groups": [
+      13
+    ],
+    "name": "Cookie compliance",
+    "priority": 9
+  },
+  "68": {
+    "groups": [
+      9
+    ],
+    "name": "Accessibility",
+    "priority": 9
+  },
+  "69": {
+    "groups": [
+      11
+    ],
+    "name": "Authentication",
+    "priority": 6
+  },
+  "70": {
+    "groups": [
+      11
+    ],
+    "name": "SSL/TLS certificate authorities",
+    "priority": 9
+  },
+  "71": {
+    "groups": [
+      2
+    ],
+    "name": "Affiliate programs",
+    "priority": 9
+  },
+  "72": {
+    "groups": [
+      14
+    ],
+    "name": "Appointment scheduling",
+    "priority": 9
+  },
+  "73": {
+    "groups": [
+      8
+    ],
+    "name": "Surveys",
+    "priority": 9
+  },
+  "74": {
+    "groups": [
+      8
+    ],
+    "name": "A/B Testing",
+    "priority": 9
+  },
+  "75": {
+    "groups": [
+      4,
+      2
+    ],
+    "name": "Email",
+    "priority": 9
+  },
+  "76": {
+    "groups": [
+      2
+    ],
+    "name": "Personalisation",
+    "priority": 9
+  },
+  "77": {
+    "groups": [
+      2
+    ],
+    "name": "Retargeting",
+    "priority": 9
+  },
+  "78": {
+    "groups": [
+      2
+    ],
+    "name": "RUM",
+    "priority": 9
+  },
+  "79": {
+    "groups": [
+      17
+    ],
+    "name": "Geolocation",
+    "priority": 9
+  },
+  "80": {
+    "groups": [
+      15
+    ],
+    "name": "WordPress themes",
+    "priority": 7
+  },
+  "81": {
+    "groups": [
+      15
+    ],
+    "name": "Shopify themes",
+    "priority": 7
+  },
+  "82": {
+    "groups": [
+      15
+    ],
+    "name": "Drupal themes",
+    "priority": 7
+  },
+  "83": {
+    "groups": [
+      8
+    ],
+    "name": "Browser fingerprinting",
+    "priority": 9
+  },
+  "84": {
+    "groups": [
+      1
+    ],
+    "name": "Loyalty & rewards",
+    "priority": 9
+  },
+  "85": {
+    "groups": [
+      9
+    ],
+    "name": "Feature management",
+    "priority": 9
+  },
+  "86": {
+    "groups": [
+      2
+    ],
+    "name": "Segmentation",
+    "priority": 9
+  },
+  "87": {
+    "groups": [
+      15
+    ],
+    "name": "WordPress plugins",
+    "priority": 8
+  },
+  "88": {
+    "groups": [
+      7
+    ],
+    "name": "Hosting",
+    "priority": 9
+  },
+  "89": {
+    "groups": [
+      3
+    ],
+    "name": "Translation",
+    "priority": 9
+  },
+  "90": {
+    "groups": [
+      2,
+      18
+    ],
+    "name": "Reviews",
+    "priority": 9
+  },
+  "91": {
+    "groups": [
+      1
+    ],
+    "name": "Buy now pay later",
+    "priority": 9
+  },
+  "92": {
+    "groups": [
+      7
+    ],
+    "name": "Performance",
+    "priority": 9
+  },
+  "93": {
+    "groups": [
+      14
+    ],
+    "name": "Reservations & delivery",
+    "priority": 9
+  },
+  "94": {
+    "groups": [
+      2,
+      1
+    ],
+    "name": "Referral marketing",
+    "priority": 9
+  },
+  "95": {
+    "groups": [
+      10
+    ],
+    "name": "Digital asset management",
+    "priority": 9
+  },
+  "96": {
+    "groups": [
+      2,
+      18
+    ],
+    "name": "Content curation",
+    "priority": 9
+  },
+  "97": {
+    "groups": [
+      2,
+      8
+    ],
+    "name": "Customer data platform",
+    "priority": 9
+  },
+  "98": {
+    "groups": [
+      1
+    ],
+    "name": "Cart abandonment",
+    "priority": 9
+  },
+  "99": {
+    "groups": [
+      1
+    ],
+    "name": "Shipping carriers",
+    "priority": 9
+  },
+  "100": {
+    "groups": [
+      15
+    ],
+    "name": "Shopify apps",
+    "priority": 8
+  },
+  "101": {
+    "groups": [
+      6,
+      16
+    ],
+    "name": "Recruitment & staffing",
+    "priority": 9
+  },
+  "102": {
+    "groups": [
+      1
+    ],
+    "name": "Returns",
+    "priority": 9
+  },
+  "103": {
+    "groups": [
+      1,
+      10
+    ],
+    "name": "Livestreaming",
+    "priority": 9
+  },
+  "104": {
+    "groups": [
+      14
+    ],
+    "name": "Ticket booking",
+    "priority": 9
+  },
+  "105": {
+    "groups": [
+      10
+    ],
+    "name": "Augmented reality",
+    "priority": 9
+  },
+  "106": {
+    "groups": [
+      1
+    ],
+    "name": "Cross border ecommerce",
+    "priority": 6
+  },
+  "107": {
+    "groups": [
+      1
+    ],
+    "name": "Fulfilment",
+    "priority": 6
+  },
+  "108": {
+    "groups": [
+      1
+    ],
+    "name": "Ecommerce frontends",
+    "priority": 6
+  },
+  "109": {
+    "groups": [
+      6
+    ],
+    "name": "Domain parking",
+    "priority": 9
+  },
+  "110": {
+    "groups": [
+      8
+    ],
+    "name": "Form builders",
+    "priority": 8
+  },
+  "111": {
+    "groups": [
+      6
+    ],
+    "name": "Fundraising & donations",
+    "priority": 9
+  }
+}

--- a/tests/data/wapp/cve.json
+++ b/tests/data/wapp/cve.json
@@ -1,0 +1,14 @@
+[
+    {
+        "id": "CVE-2022-21664",
+        "description": "WordPress is a free and open-source content management system written in PHP and paired with a MariaDB database. Due to lack of proper sanitization in one of the classes, there's potential for unintended SQL queries to be executed. This has been patched in WordPress version 5.8.3. Older affected versions are also fixed via security release, that go back till 4.1.34. We strongly recommend that you keep auto-updates enabled. There are no known workarounds for this issue.",
+        "cvss2": 6.5,
+        "cvss3.1": 8.8,
+        "versions": [
+            [
+                null,
+                "<5.8.3"
+            ]
+        ]
+    }
+]

--- a/tests/data/wapp/groups.json
+++ b/tests/data/wapp/groups.json
@@ -1,0 +1,53 @@
+{
+  "1": {
+    "name": "Sales"
+  },
+  "2": {
+    "name": "Marketing"
+  },
+  "3": {
+    "name": "Content"
+  },
+  "4": {
+    "name": "Communication"
+  },
+  "5": {
+    "name": "Utilities"
+  },
+  "6": {
+    "name": "Other"
+  },
+  "7": {
+    "name": "Servers"
+  },
+  "8": {
+    "name": "Analytics"
+  },
+  "9": {
+    "name": "Web development"
+  },
+  "10": {
+    "name": "Media"
+  },
+  "11": {
+    "name": "Security"
+  },
+  "13": {
+    "name": "Privacy"
+  },
+  "14": {
+    "name": "Booking"
+  },
+  "15": {
+    "name": "Add-ons"
+  },
+  "16": {
+    "name": "Business tools"
+  },
+  "17": {
+    "name": "Location"
+  },
+  "18": {
+    "name": "User generated content"
+  }
+}

--- a/tests/data/wapp/mysql.json
+++ b/tests/data/wapp/mysql.json
@@ -1,0 +1,11 @@
+{
+  "MySQL": {
+    "cats": [
+      34
+    ],
+    "cpe": "cpe:2.3:a:mysql:mysql:*:*:*:*:*:*:*:*",
+    "description": "MySQL is an open-source relational database management system.",
+    "icon": "MySQL.svg",
+    "website": "https://mysql.com"
+  }
+}

--- a/tests/data/wapp/php.json
+++ b/tests/data/wapp/php.json
@@ -1,0 +1,19 @@
+{
+  "PHP": {
+    "cats": [
+      27
+    ],
+    "cookies": {
+      "PHPSESSID": ""
+    },
+    "cpe": "cpe:2.3:a:php:php:*:*:*:*:*:*:*:*",
+    "description": "PHP is a general-purpose scripting language used for web development.",
+    "headers": {
+      "Server": "php/?([\\d.]+)?\\;version:\\1",
+      "X-Powered-By": "^php/?([\\d.]+)?\\;version:\\1"
+    },
+    "icon": "PHP.svg",
+    "url": "\\.php(?:$|\\?)",
+    "website": "https://php.net"
+  }
+}

--- a/tests/data/wapp/wordpress.json
+++ b/tests/data/wapp/wordpress.json
@@ -1,0 +1,42 @@
+{
+  "WordPress": {
+    "cats": [
+      1,
+      11
+    ],
+    "cpe": "cpe:2.3:a:wordpress:wordpress:*:*:*:*:*:*:*:*",
+    "description": "WordPress is a free and open-source content management system written in PHP and paired with a MySQL or MariaDB database. Features include a plugin architecture and a template system.",
+    "headers": {
+      "X-Pingback": "/xmlrpc\\.php$",
+      "link": "rel=\"https://api\\.w\\.org/\""
+    },
+    "html": [
+      "<link rel=[\"']stylesheet[\"'] [^>]+/wp-(?:content|includes)/",
+      "<link[^>]+s\\d+\\.wp\\.com"
+    ],
+    "icon": "WordPress.svg",
+    "implies": [
+      "PHP",
+      "MySQL"
+    ],
+    "js": {
+      "wp_username": ""
+    },
+    "meta": {
+      "generator": "^WordPress(?: ([\\d.]+))?\\;version:\\1",
+      "shareaholic:wp_version": ""
+    },
+    "oss": true,
+    "pricing": [
+      "low",
+      "recurring",
+      "freemium"
+    ],
+    "saas": true,
+    "scriptSrc": [
+      "/wp-(?:content|includes)/",
+      "wp-embed\\.min\\.js"
+    ],
+    "website": "https://wordpress.org"
+  }
+}

--- a/tests/integration/test_mod_wapp/assertions/wapp_backbonejs_index.html.json
+++ b/tests/integration/test_mod_wapp/assertions/wapp_backbonejs_index.html.json
@@ -21,6 +21,15 @@
                     "WSTG-INFO-02"
                 ]
             }
+        ],
+        "Vulnerable software": [
+            {
+                "method": "GET",
+                "path": "/backbonejs/index.html",
+                "info": "nginx CVE-2023-44487: The HTTP/2 protocol allows a denial of service (server resource consumption) because request cancellation can reset many streams quickly, as exploited in the wild in August through October 2023.",
+                "http_request": "GET /backbonejs/index.html HTTP/1.1",
+                "wstg": []
+            }
         ]
     },
     "additionals": {

--- a/tests/integration/test_mod_wapp/assertions/wapp_bootstrap_index.html.json
+++ b/tests/integration/test_mod_wapp/assertions/wapp_bootstrap_index.html.json
@@ -11,6 +11,15 @@
                     "WSTG-INFO-02"
                 ]
             }
+        ],
+        "Vulnerable software": [
+            {
+                "method": "GET",
+                "path": "/bootstrap/index.html",
+                "info": "nginx CVE-2023-44487: The HTTP/2 protocol allows a denial of service (server resource consumption) because request cancellation can reset many streams quickly, as exploited in the wild in August through October 2023.",
+                "http_request": "GET /bootstrap/index.html HTTP/1.1",
+                "wstg": []
+            }
         ]
     },
     "additionals": {

--- a/tests/integration/test_mod_wapp/assertions/wapp_jquery_index.html.json
+++ b/tests/integration/test_mod_wapp/assertions/wapp_jquery_index.html.json
@@ -21,6 +21,15 @@
                     "WSTG-INFO-02"
                 ]
             }
+        ],
+        "Vulnerable software": [
+            {
+                "method": "GET",
+                "path": "/jquery/index.html",
+                "info": "nginx CVE-2023-44487: The HTTP/2 protocol allows a denial of service (server resource consumption) because request cancellation can reset many streams quickly, as exploited in the wild in August through October 2023.",
+                "http_request": "GET /jquery/index.html HTTP/1.1",
+                "wstg": []
+            }
         ]
     },
     "additionals": {

--- a/tests/integration/test_mod_wapp/assertions/wapp_other_mock_index.wiki.jsp.html.json
+++ b/tests/integration/test_mod_wapp/assertions/wapp_other_mock_index.wiki.jsp.html.json
@@ -20,6 +20,15 @@
                     "WSTG-INFO-02"
                 ]
             }
+        ],
+        "Vulnerable software": [
+            {
+                "method": "GET",
+                "path": "/other_mock/index.wiki.jsp.html",
+                "info": "nginx CVE-2023-44487: The HTTP/2 protocol allows a denial of service (server resource consumption) because request cancellation can reset many streams quickly, as exploited in the wild in August through October 2023.",
+                "http_request": "GET /other_mock/index.wiki.jsp.html HTTP/1.1",
+                "wstg": []
+            }
         ]
     },
     "additionals": {

--- a/tests/integration/test_mod_wapp/assertions/wapp_react_index.html.json
+++ b/tests/integration/test_mod_wapp/assertions/wapp_react_index.html.json
@@ -11,6 +11,15 @@
                     "WSTG-INFO-02"
                 ]
             }
+        ],
+        "Vulnerable software": [
+            {
+                "method": "GET",
+                "path": "/react/index.html",
+                "info": "nginx CVE-2023-44487: The HTTP/2 protocol allows a denial of service (server resource consumption) because request cancellation can reset many streams quickly, as exploited in the wild in August through October 2023.",
+                "http_request": "GET /react/index.html HTTP/1.1",
+                "wstg": []
+            }
         ]
     },
     "additionals": {

--- a/tests/integration/test_mod_wapp/assertions/wapp_vuejs_index.html.json
+++ b/tests/integration/test_mod_wapp/assertions/wapp_vuejs_index.html.json
@@ -11,6 +11,15 @@
                     "WSTG-INFO-02"
                 ]
             }
+        ],
+        "Vulnerable software": [
+            {
+                "method": "GET",
+                "path": "/vuejs/index.html",
+                "info": "nginx CVE-2023-44487: The HTTP/2 protocol allows a denial of service (server resource consumption) because request cancellation can reset many streams quickly, as exploited in the wild in August through October 2023.",
+                "http_request": "GET /vuejs/index.html HTTP/1.1",
+                "wstg": []
+            }
         ]
     },
     "additionals": {

--- a/tests/integration/test_mod_wapp/behavior.json
+++ b/tests/integration/test_mod_wapp/behavior.json
@@ -21,6 +21,15 @@
                         "http_request": "",
                         "wstg": []
                     }
+                ],
+                "Vulnerable software": [
+                    {
+                        "method": "",
+                        "path": "",
+                        "info": "",
+                        "http_request": "",
+                        "wstg": []
+                    }
                 ]
             },
             "additionals": {

--- a/tests/integration/wapiti/Dockerfile.integration
+++ b/tests/integration/wapiti/Dockerfile.integration
@@ -34,6 +34,14 @@ RUN apt-get -y update &&\
 COPY --from=build /usr/local/lib/python3.11/dist-packages/ /usr/local/lib/python3.11/dist-packages/
 COPY --from=build /usr/local/bin/wapiti /usr/local/bin/wapiti-getcookie /usr/local/bin/
 
+# Create the Wapiti config directory
+RUN mkdir -p /root/.wapiti/config/cves
+
+# Download the NVD CVE files directly from GitHub
+RUN curl -k -L https://github.com/wapiti-scanner/nvd-web-cves/releases/download/nvd-web-cves-20240809/nginx.json.xz -o /root/.wapiti/config/cves/nginx.json.xz && \
+    curl -k -L https://github.com/wapiti-scanner/nvd-web-cves/releases/download/nvd-web-cves-20240809/cherokee.json.xz -o /root/.wapiti/config/cves/cherokee.json.xz && \
+    curl -k -L https://github.com/wapiti-scanner/nvd-web-cves/releases/download/nvd-web-cves-20240809/jquery.json.xz -o /root/.wapiti/config/cves/jquery.json.xz
+
 COPY ./tests/integration/wapiti/test.py /usr/local/bin/test.py
 COPY ./tests/integration/wapiti/templates_and_data.py /usr/local/bin/templates_and_data.py
 COPY ./tests/integration/wapiti/misc_functions.py /usr/local/bin/misc_functions.py

--- a/tests/integration/wapiti/templates_and_data.py
+++ b/tests/integration/wapiti/templates_and_data.py
@@ -573,6 +573,27 @@ TREE_CHECKER = {
                 'wstg': []
             }
         ],
+        'Vulnerable software': [
+            {
+                'curl_command': '',
+                'detail': {
+                    'response': {
+                        'body': '',
+                        'headers': [],
+                        'status_code': 0
+                    }
+                },
+                'http_request': '',
+                'info': '',
+                'level': 0,
+                'method': '',
+                'module': '',
+                'parameter': '',
+                'path': '',
+                'referer': '',
+                'wstg': []
+            }
+        ],
         'Weak credentials': [
             {
                 'curl_command': '',

--- a/wapitiCore/attack/cve/checker.py
+++ b/wapitiCore/attack/cve/checker.py
@@ -1,0 +1,116 @@
+import json
+import lzma
+from pathlib import Path
+from typing import Dict, Any, Iterable
+from packaging.version import Version, InvalidVersion
+import re
+
+from wapitiCore.language.vulnerability import CRITICAL_LEVEL, HIGH_LEVEL, MEDIUM_LEVEL, LOW_LEVEL
+
+SUPPORTED_SOFTWARES = [
+    "angularjs",
+    "apache",
+    "drupal",
+    "jetty",
+    "joomla",
+    "jquery",
+    "nextjs",
+    "nginx",
+    "nodejs",
+    "openssl",
+    "php",
+    "prestashop",
+    "spip",
+    "tomcat",
+    "underscorejs",
+    "wordpress",
+]
+
+CVE_DIRECTORY = "cves"
+
+
+def is_cve_supported_software(software_name: str) -> bool:
+    software_name = software_name.lower().replace(".", "").replace("-", "")
+    return software_name in SUPPORTED_SOFTWARES
+
+
+def compare_versions(ver_str: str, version: Version) -> bool:
+    """Helper function to compare a version string with a Version object."""
+    match = re.match(r"([<>]=?)([\d.]+)", ver_str)
+    if not match:
+        return False
+    op, ver = match.groups()
+    ver = Version(ver)
+    if op == '<':
+        return version < ver
+    elif op == '<=':
+        return version <= ver
+    elif op == '>':
+        return version > ver
+    elif op == '>=':
+        return version >= ver
+    return False
+
+
+def is_version_in_list(version: str, version_list: list) -> bool:
+    try:
+        version = Version(version)
+    except InvalidVersion:
+        return False
+
+    for item in version_list:
+        if isinstance(item, str):
+            try:
+                if version == Version(item):
+                    return True
+            except InvalidVersion:
+                continue
+        elif isinstance(item, list) and len(item) == 2:
+            start, end = item
+            start_ok = end_ok = True
+            if start is not None:
+                start_ok = compare_versions(start, version)
+            if end is not None:
+                end_ok = compare_versions(end, version)
+            if start_ok and end_ok:
+                return True
+    return False
+
+
+def cvss_score_to_wapiti_level(cvss_score: float):
+    """Returns the Wapiti alert level for a CVSS score. It is based on CVSS v3 Ratings."""
+    if cvss_score < 3.9:
+        return LOW_LEVEL
+    if cvss_score < 6.9:
+        return MEDIUM_LEVEL
+    if cvss_score < 8.9:
+        return HIGH_LEVEL
+    return CRITICAL_LEVEL
+
+
+class CVEChecker:
+    def __init__(self, data_dir: str):
+        self._data_dir = Path(data_dir)
+
+    def get_cves(self, software_name: str, version: str) -> Iterable[Dict[str, Any]]:
+        if not is_cve_supported_software(software_name):
+            return
+
+        software_name = software_name.replace(".", "").replace("-", "")
+        filepath = (self._data_dir / CVE_DIRECTORY / software_name).with_suffix(".json.xz")
+        if not filepath.is_file():
+            return
+
+        # Extract the contents of the .xz file
+        with lzma.open(str(filepath)) as fd:
+            try:
+                cve_list = json.load(fd)
+                for cve in cve_list:
+                    if is_version_in_list(version, cve.get("versions", [])):
+                        yield cve
+            except json.JSONDecodeError:
+                print("malformed JSON file")
+
+
+if __name__ == "__main__":
+    print(is_version_in_list("13.4.19", [[None, '<13.4.20'], '13.4.20']))

--- a/wapitiCore/attack/mod_wapp.py
+++ b/wapitiCore/attack/mod_wapp.py
@@ -21,16 +21,21 @@ import os
 import asyncio
 import shutil
 import string
-from typing import Dict, Tuple, Optional, List
+from typing import Dict, Tuple, Optional, List, AsyncIterator
 import re
 from urllib.parse import urlparse, quote_plus
 
+from aiocache import cached
 from httpx import RequestError
 
 from arsenic import get_session, browsers, services
 from arsenic.errors import JavascriptError, UnknownError, ArsenicError
 
-from wapitiCore.main.log import logging, log_blue
+from wapitiCore.attack.cve.checker import (
+    CVEChecker, cvss_score_to_wapiti_level, CVE_DIRECTORY, SUPPORTED_SOFTWARES, is_cve_supported_software
+)
+from wapitiCore.definitions.vulnerable_software_version import VulnerableSoftwareFinding
+from wapitiCore.main.log import logging, log_blue, log_severity
 from wapitiCore.main.wapiti import is_valid_url
 from wapitiCore.attack.attack import Attack
 from wapitiCore.controller.wapiti import InvalidOptionValue
@@ -153,6 +158,8 @@ class ModuleWapp(Attack):
         if not os.path.isdir(self.user_config_dir):
             os.makedirs(self.user_config_dir)
 
+        self._cve_checker = CVEChecker(self.user_config_dir)
+
     async def copy_files_to_conf(self, files_to_copy: List[str]):
         """
         This function copies wapp DB files specified as arguments to the config directory.
@@ -173,7 +180,16 @@ class ModuleWapp(Attack):
                 logging.error(f"Error copying {source_file}: {err}")
 
     async def update(self):
-        """Update the Wappalizer database from the web and load the patterns."""
+        await self.update_nvd()
+        await self.update_wappalyzer()
+
+    async def update_nvd(self):
+        """Update NVD archives from GitHub releases."""
+        for software_name in SUPPORTED_SOFTWARES:
+            await self.download_latest_release_asset(software_name, self.user_config_dir)
+
+    async def update_wappalyzer(self):
+        """Update the Wappalizer from the web and load the patterns."""
         self.gitlab_private_token = os.environ.get("GITLAB_PRIVATE_TOKEN", None)
 
         sources = ["src/categories.json", "src/technologies/", "src/groups.json"]
@@ -181,19 +197,23 @@ class ModuleWapp(Attack):
             # file path needs to be URL-encoded
             # https://docs.gitlab.com/ee/api/repository_files.html#get-raw-file-from-repository
             sources = [quote_plus(src) for src in sources]
+
         wapp_categories_url = f"{self.BASE_URL}{sources[0]}"
         wapp_technologies_base_url = f"{self.BASE_URL}{sources[1]}"
         wapp_groups_url = f"{self.BASE_URL}{sources[2]}"
+
         if self.WAPP_DIR:
             categories_file_path = os.path.join(self.WAPP_DIR, self.WAPP_CATEGORIES)
             groups_file_path = os.path.join(self.WAPP_DIR, self.WAPP_GROUPS)
             technologies_directory_path = os.path.join(self.WAPP_DIR, "technologies/")
             technologies_file_path = os.path.join(self.WAPP_DIR, self.WAPP_TECHNOLOGIES)
+
             try:
                 merge_json_files(technologies_directory_path, technologies_file_path)
             except (ValueError, OSError) as error:
                 logging.error(error)
                 raise ValueError(f"Update failed : Something went wrong with files in {self.WAPP_DIR}") from error
+
             try:
                 if is_json_file(categories_file_path) and is_json_file(groups_file_path) \
                         and is_json_file(technologies_file_path):
@@ -276,6 +296,7 @@ class ModuleWapp(Attack):
             log_blue(MSG_GROUPS, groups)
             if cpe:
                 log_blue(MSG_CPE, cpe)
+
             log_blue("")
             await self.add_info(
                 finding_class=SoftwareNameDisclosureFinding,
@@ -299,6 +320,37 @@ class ModuleWapp(Attack):
                         info=json.dumps(detected_applications[application_name]),
                         response=response
                     )
+
+                if is_cve_supported_software(application_name):
+                    if await self.download_latest_release_asset(application_name.lower(), self.user_config_dir):
+                        async for severity, message in self.get_vulnerabilities(application_name.lower(), versions):
+                            log_severity(severity, "---")
+                            log_severity(severity, message)
+                            log_severity(severity, "---")
+
+                            await self.add_payload(
+                                finding_class=VulnerableSoftwareFinding,
+                                level=severity,
+                                info=message,
+                                request=request_to_root,
+                                response=response
+                            )
+
+    async def get_vulnerabilities(self, software_name: str, versions: List[str]) -> AsyncIterator[Tuple[int, str]]:
+        detected_cves = set()
+        for version in versions:
+            for cve in self._cve_checker.get_cves(software_name.lower(), version):
+                if cve["id"] in detected_cves:
+                    continue
+
+                detected_cves.add(cve["id"])
+                # Get the score for the most recent CVSS standard and break
+                for cvss_format in ["cvss4", "cvss3.1", "cvss3", "cvss2"]:
+                    if cvss_format in cve:
+                        severity = cvss_score_to_wapiti_level(cve[cvss_format])
+                        message = f"{software_name} {cve['id']}: {cve['description']}"
+                        yield severity, message
+                        break
 
     async def _detect_applications(
             self,
@@ -335,13 +387,16 @@ class ModuleWapp(Attack):
         except RequestError:
             self.network_errors += 1
             raise
+
         if response.status != 200:
             logging.error(f"Error: Non-200 status code for {url}")
             return
+
         if not _is_valid_json(response):
             raise ValueError(f"Invalid or empty JSON response for {url}")
-        with open(file_path, 'w', encoding='utf-8') as file:
-            json.dump(response.json, file)
+
+        with open(file_path, 'wb') as file:
+            file.write(response.bytes)
 
     async def _load_wapp_database(self, categories_url: str, technologies_base_url: str, groups_url: str):
         categories_file_path = os.path.join(self.user_config_dir, self.WAPP_CATEGORIES)
@@ -353,7 +408,8 @@ class ModuleWapp(Attack):
         # Requesting all technologies one by one
         for technology_file_name in technology_files_names:
             technologies_file_url = technologies_base_url + technology_file_name
-            headers={}
+            headers = {}
+
             if self.gitlab_private_token:
                 technologies_file_url = technologies_file_url + "/raw"
                 headers = {"PRIVATE_TOKEN": self.gitlab_private_token}
@@ -365,25 +421,29 @@ class ModuleWapp(Attack):
             except RequestError:
                 self.network_errors += 1
                 raise
+
             if response.status != 200:
                 raise ValueError(f"{technologies_base_url} is not a valid URL for a wapp database")
+
             # Merging all technologies in one object
-            for technology_name in response.json:
-                technologies[technology_name] = response.json[technology_name]
-            try:
+            technologies.update(response.json)
+
+        # Saving technologies
+        with open(technologies_file_path, 'w', encoding='utf-8') as file:
+            json.dump(technologies, file)
+
+        try:
             # Saving categories & groups
-                await asyncio.gather(
-                    self._dump_url_content_to_file(categories_url, categories_file_path),
-                    self._dump_url_content_to_file(groups_url, groups_file_path))
-            except RequestError as req_error:
-                logging.error(f"Caught a RequestError: {req_error}")
-                raise
-            except ValueError as value_error:
-                logging.error(f"Caught a ValueError: {value_error}")
-                raise
-            # Saving technologies
-            with open(technologies_file_path, 'w', encoding='utf-8') as file:
-                json.dump(technologies, file)
+            await asyncio.gather(
+                self._dump_url_content_to_file(categories_url, categories_file_path),
+                self._dump_url_content_to_file(groups_url, groups_file_path)
+            )
+        except RequestError as req_error:
+            logging.error(f"Caught a RequestError: {req_error}")
+            raise
+        except ValueError as value_error:
+            logging.error(f"Caught a ValueError: {value_error}")
+            raise
 
     async def _verify_wapp_database(
             self,
@@ -398,10 +458,10 @@ class ModuleWapp(Attack):
                 json.load(categories_file)
                 json.load(technologies_file)
                 json.load(groups_file)
-        except IOError:
+        except (IOError, FileNotFoundError):
             logging.warning("Problem with local wapp database.")
             logging.info("Downloading from the web...")
-            await self.update()
+            await self.update_wappalyzer()
 
     async def _detect_applications_headless(self, url: str) -> dict:
         proxy_settings = None
@@ -477,3 +537,50 @@ class ModuleWapp(Attack):
                 pass
 
         return final_results
+
+    @cached()
+    async def get_nvd_release_data(self):
+        release_url = "https://api.github.com/repos/wapiti-scanner/nvd-web-cves/releases/latest"
+
+        # Create and send the request to get the latest release
+        release_request = Request(release_url)
+        release_response = await self.crawler.async_send(release_request)
+        return release_response.json
+
+    async def download_latest_release_asset(self, software_name: str, dest_folder: str) -> bool:
+        # Ensure the destination folder exists
+        os.makedirs(os.path.join(dest_folder, CVE_DIRECTORY), exist_ok=True)
+        file_name = software_name.lower().replace(".", "").replace("-", "") + ".json.xz"
+        file_path = os.path.join(dest_folder, CVE_DIRECTORY, file_name)
+        if os.path.isfile(file_path):
+            return True
+
+        log_blue(f"Downloading CVE data for {software_name}")
+
+        try:
+            # The response is cached as we don't want to repeat the same query for each received software name
+            latest_release = await self.get_nvd_release_data()
+        except RequestError as exception:
+            logging.error(f"Could not fetch wapiti-scanner/nvd-web-cves CVE index for {software_name}: {exception}")
+            return False
+
+        # Find the asset related to the software_name
+        asset = next((a for a in latest_release.get("assets", []) if file_name in a["name"]), None)
+        if asset is None:
+            logging.error(f"No CVE data found for {software_name} on wapiti-scanner/nvd-web-cves")
+            return False
+
+        # Download the asset
+        download_url = asset["browser_download_url"]
+        download_request = Request(download_url)
+        try:
+            download_response = await self.crawler.async_send(download_request, follow_redirects=True)
+        except RequestError as exception:
+            logging.error("Could not fetch CVE data for %s: %s", software_name, exception)
+            return False
+
+        # Save the downloaded content to the file
+        with open(file_path, "wb") as file:
+            file.write(download_response.bytes)
+
+        return True

--- a/wapitiCore/definitions/vulnerable_software_version.py
+++ b/wapitiCore/definitions/vulnerable_software_version.py
@@ -1,0 +1,57 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+
+# This file is part of the Wapiti project (https://wapiti-scanner.github.io)
+# Copyright (C) 2021-2023 Nicolas Surribas
+# Copyright (C) 2021-2024 Cyberwatch
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+from typing import List
+
+from wapitiCore.definitions.base import FindingBase
+
+
+class VulnerableSoftwareFinding(FindingBase):
+    @classmethod
+    def name(cls) -> str:
+        return "Vulnerable software"
+
+    @classmethod
+    def description(cls) -> str:
+        return (
+            "The detected software in its installed version is known to be vulnerable to one or more vulnerabilities."
+        )
+
+    @classmethod
+    def references(cls) -> list:
+        return []
+
+    @classmethod
+    def solution(cls) -> str:
+        return (
+            "Update the software to its latest version or applied security patches."
+        )
+
+    @classmethod
+    def short_name(cls) -> str:
+        return cls.name()
+
+    @classmethod
+    def type(cls) -> str:
+        return "vulnerability"
+
+    @classmethod
+    def wstg_code(cls) -> List[str]:
+        return []

--- a/wapitiCore/main/log.py
+++ b/wapitiCore/main/log.py
@@ -20,8 +20,11 @@
 import sys
 from functools import partial
 import logging as legacy_logger
+from typing import Any
 
 from loguru import logger as logging
+
+from wapitiCore.language.vulnerability import MEDIUM_LEVEL
 
 legacy_logger.getLogger("charset_normalizer").setLevel(legacy_logger.ERROR)
 logging.remove()
@@ -51,3 +54,10 @@ log_verbose = partial(logging.log, "VERBOSE")
 
 # Set default logging
 logging.add(sys.stdout, colorize=False, format="{message}", level="INFO")
+
+
+def log_severity(level: int, message: str, *args: Any, **kwargs: Any) -> None:
+    if level < MEDIUM_LEVEL:
+        log_orange(message, args, kwargs)
+    else:
+        log_red(message, args, kwargs)

--- a/wapitiCore/main/wapiti.py
+++ b/wapitiCore/main/wapiti.py
@@ -179,8 +179,11 @@ async def wapiti_main():
         elif args.wapp_dir:
             attack_options = {"level": args.level, "timeout": args.timeout, "wapp_dir": args.wapp_dir}
         else:
-            attack_options = {"level": args.level, "timeout": args.timeout,\
-                              "wapp_url": "https://raw.githubusercontent.com/wapiti-scanner/wappalyzer/main/"}
+            attack_options = {
+                "level": args.level,
+                "timeout": args.timeout,
+                "wapp_url": "https://raw.githubusercontent.com/wapiti-scanner/wappalyzer/main/"
+            }
         wap.set_attack_options(attack_options)
         try:
             await wap.update(args.modules)


### PR DESCRIPTION
- Download on the fly CVE data from wapiti-scanner/nvd-web-cves/ for a specific software when a version is detected. Data is JSON compressed with lzma (XZ)
- Use python `packaging` library for version comparison
- Adds a new finding called "Vulnerable software" which brings some CVE info (severity and description)
- The most recent CVSS format found is used for each CVE
- List of monitored softwares is hardcoded
- Separate wapp update logic from nvd update logic to ease testing
- Fix some issues present in mod_wapp, notably the categories.json and groups.json files were downloaded 27 times each due to bad indentation
- Fix some tests for mod_wapp, notably some assertions were lacking parenthesis to be effective
- Adds unit and integration tests for the new CVE finding