### PR TITLE
crawler: fix empty enctype case

### DIFF
--- a/doc/cookies_and_scripts_auth.md
+++ b/doc/cookies_and_scripts_auth.md
@@ -74,7 +74,7 @@ async def run(crawler_configuration: CrawlerConfiguration, auth_url: str,headles
                 enctype="application/json"
         )
         # Send it
-        response = await crawler.async_post(request)
+        response = await crawler.async_send(request)
         data = response.json
         if not data:
             print("authentication failed")

--- a/wapitiCore/net/crawler.py
+++ b/wapitiCore/net/crawler.py
@@ -273,7 +273,7 @@ class AsyncCrawler:
         if form.enctype and not form.is_multipart:
             form_headers = {"Content-Type": form.enctype}
 
-        if isinstance(headers, dict) and headers:
+        if isinstance(headers, (dict, httpx.Headers)) and headers:
             form_headers.update(headers)
 
         if form.referer:

--- a/wapitiCore/net/crawler.py
+++ b/wapitiCore/net/crawler.py
@@ -267,7 +267,7 @@ class AsyncCrawler:
         @rtype: Response
         """
         form_headers = {}
-        if not form.is_multipart:
+        if form.enctype and not form.is_multipart:
             form_headers = {"Content-Type": form.enctype}
 
         if isinstance(headers, (dict, httpx.Headers)) and headers:
@@ -339,7 +339,7 @@ class AsyncCrawler:
         """
         form_headers = {}
 
-        if not form.is_multipart:
+        if form.enctype and not form.is_multipart:
             form_headers = {"Content-Type": form.enctype}
 
         if isinstance(headers, dict) and headers:


### PR DESCRIPTION
Saw since https://github.com/wapiti-scanner/wapiti/commit/85097cb80acb671d6063ea1c5ca3fb4d5522c967#diff-d7e9c3756fcd51d905c37cb6d0f0ce60e24934ff30e015bde1b6a354d7e11edcR339 that requests may be sent with the "content-type" header specifying an empty value.

The MR fix that and also removes async_send that is directly handled by async_request now.