### PR TITLE
Use a modified arsenic packaged under another name to pass pypi restr…

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,7 +34,7 @@ dependencies = [
         "aiocache==0.12.2",
         "aiohttp==3.10.2",
         "aiosqlite==0.20.0",
-        "arsenic @ https://github.com/wapiti-scanner/arsenic/releases/download/28.1%2Bremove-distutils/arsenic-28.1+remove.distutils-py3-none-any.whl",
+        "wapiti-arsenic==28.2",
         "beautifulsoup4==4.12.3",
         "browser-cookie3==0.19.1",
         "dnspython==2.6.1",

--- a/wapitiCore/attack/mod_wapp.py
+++ b/wapitiCore/attack/mod_wapp.py
@@ -28,8 +28,8 @@ from urllib.parse import urlparse, quote_plus
 from aiocache import cached
 from httpx import RequestError
 
-from arsenic import get_session, browsers, services
-from arsenic.errors import JavascriptError, UnknownError, ArsenicError
+from wapiti_arsenic import get_session, browsers, services
+from wapiti_arsenic.errors import JavascriptError, UnknownError, ArsenicError
 
 from wapitiCore.attack.cve.checker import (
     CVEChecker, cvss_score_to_wapiti_level, CVE_DIRECTORY, SUPPORTED_SOFTWARES, is_cve_supported_software

--- a/wapitiCore/net/auth.py
+++ b/wapitiCore/net/auth.py
@@ -25,7 +25,7 @@ from urllib.parse import urlparse
 import importlib.util
 
 from httpx import RequestError
-from arsenic import get_session, browsers, services, errors, constants
+from wapiti_arsenic import get_session, browsers, services, errors, constants
 
 from wapitiCore.net import Request, Response
 from wapitiCore.parsers.html_parser import Html

--- a/wapitiCore/net/intercepting_explorer.py
+++ b/wapitiCore/net/intercepting_explorer.py
@@ -34,9 +34,9 @@ from mitmproxy.master import Master
 from mitmproxy.options import Options
 from mitmproxy.http import Request as MitmRequest
 import httpx
-from arsenic import get_session, browsers, services
-from arsenic.constants import SelectorType
-from arsenic.errors import ArsenicError, ElementNotInteractable, UnknownArsenicError, NoSuchElement
+from wapiti_arsenic import get_session, browsers, services
+from wapiti_arsenic.constants import SelectorType
+from wapiti_arsenic.errors import ArsenicError, ElementNotInteractable, UnknownArsenicError, NoSuchElement
 import structlog
 
 from wapitiCore.net import Request
@@ -68,7 +68,7 @@ def is_interpreted_type(mime_type: str) -> bool:
 
 def set_arsenic_log_level(level: int = WARNING):
     # Create logger
-    logger = getLogger('arsenic')
+    logger = getLogger('wapiti_arsenic')
 
     # We need factory, to return application-wide logger
     def logger_factory():


### PR DESCRIPTION
…ictions

```
ERROR    HTTPError: 400 Bad Request from https://upload.pypi.org/legacy/                                                                                                                                          
         The use of local versions in <Version('28.1+remove.distutils2')> is not allowed. See https://packaging.python.org/specifications/core-metadata for more information.
```

as I can't specify a arsenic package with a full URL to wheel, I have to refactor the project so it builds to another name (here wapiti_arsenic)