### PR TITLE
Fix false positives on ID command injections attacks

### DIFF
--- a/wapitiCore/attack/mod_exec.py
+++ b/wapitiCore/attack/mod_exec.py
@@ -168,7 +168,7 @@ class ModuleExec(Attack):
                 vuln_info = None
 
                 # No timeout raised, check for patterns in response
-                if any(rule in response.content for rule in payload_info.rules):
+                if any(rule.replace("[SPACE]", " ") in response.content for rule in payload_info.rules):
                     vuln_info = payload_info.description
                     # We reached maximum exploitation for this parameter, don't send more payloads
                     vulnerable_parameter = True

--- a/wapitiCore/data/attacks/execPayloads.ini
+++ b/wapitiCore/data/attacks/execPayloads.ini
@@ -1,6 +1,6 @@
 [DEFAULT]
 payload = None
-; rules will be used as a boolean AND if there are multiple
+; rules will be used as a boolean OR if there are multiple
 rules = None
 description = None
 status = vulnerability
@@ -8,17 +8,17 @@ type = pattern
 
 [no_escape]
 payload = id
-rules = uid=
-    gid=
-    groupes=
+rules = [SPACE]gid=
+    [SPACE]groupes=
+    [SPACE]groups=
 description = Command execution
 status = vulnerability
 
 [no_escape_owasp_benchmark]
 payload = id
-rules = uid&#x3d;
-    gid&#x3d;
-    groupes&#x3d;
+rules = [SPACE]gid&#x3d;
+    [SPACE]groupes&#x3d;
+    [SPACE]groups&#x3d;
 description = Command execution
 status = vulnerability
 


### PR DESCRIPTION
The rules for the ID command injection attacks were too permissive and would lead to several false positives.

Basically, when trying an injection with the `id` command, Wapiti would check if `id=` was available in the results. However, anything that contained `id=` would lead to a false positive, for instance `uuid=`.

Thus, I changed the rules for the id payload, in order to improve its results.

Also, I changed the comment at line 3, which said that rules were tested with a boolean AND when there were multiple case, but it was a boolean OR since a commit 9 months ago.

I tested the mod on the lab https://portswigger.net/web-security/os-command-injection/lab-simple and it still finds vulnerabilities.