### PR TITLE
fix wp_enum and cms/wp_enum versions consistency

### DIFF
--- a/tests/attack/test_mod_cms.py
+++ b/tests/attack/test_mod_cms.py
@@ -909,13 +909,13 @@ async def test_wp_false_positive_403():
             '{"name": "bbpress", "versions": ["2.6.6"], "categories": ["WordPress plugins"], "groups": ["Add-ons"]}'
         )
         assert persister.add_payload.call_args_list[2][1]["info"] == (
-            '{"name": "unyson", "versions": [""], "categories": ["WordPress plugins"], "groups": ["Add-ons"]}'
+            '{"name": "unyson", "versions": [], "categories": ["WordPress plugins"], "groups": ["Add-ons"]}'
         )
         assert persister.add_payload.call_args_list[3][1]["info"] == (
             '{"name": "twentynineteen", "versions": ["1.9"], "categories": ["WordPress themes"], "groups": ["Add-ons"]}'
         )
         assert persister.add_payload.call_args_list[4][1]["info"] == (
-            '{"name": "customify", "versions": [""], "categories": ["WordPress themes"], "groups": ["Add-ons"]}'
+            '{"name": "customify", "versions": [], "categories": ["WordPress themes"], "groups": ["Add-ons"]}'
         )
 
 
@@ -1021,13 +1021,13 @@ async def test_wp_false_positive_success():
             '{"name": "bbpress", "versions": ["2.6.6"], "categories": ["WordPress plugins"], "groups": ["Add-ons"]}'
         )
         assert persister.add_payload.call_args_list[2][1]["info"] == (
-            '{"name": "wp-reset", "versions": [""], "categories": ["WordPress plugins"], "groups": ["Add-ons"]}'
+            '{"name": "wp-reset", "versions": [], "categories": ["WordPress plugins"], "groups": ["Add-ons"]}'
         )
         assert persister.add_payload.call_args_list[3][1]["info"] == (
             '{"name": "twentynineteen", "versions": ["1.9"], "categories": ["WordPress themes"], "groups": ["Add-ons"]}'
         )
         assert persister.add_payload.call_args_list[4][1]["info"] == (
-            '{"name": "seedlet", "versions": [""], "categories": ["WordPress themes"], "groups": ["Add-ons"]}'
+            '{"name": "seedlet", "versions": [], "categories": ["WordPress themes"], "groups": ["Add-ons"]}'
         )
 
 
@@ -1111,10 +1111,10 @@ async def test_wp_plugin():
             '{"name": "bbpress", "versions": ["2.6.6"], "categories": ["WordPress plugins"], "groups": ["Add-ons"]}'
         )
         assert persister.add_payload.call_args_list[2][1]["info"] == (
-            '{"name": "wp-reset", "versions": [""], "categories": ["WordPress plugins"], "groups": ["Add-ons"]}'
+            '{"name": "wp-reset", "versions": [], "categories": ["WordPress plugins"], "groups": ["Add-ons"]}'
         )
         assert persister.add_payload.call_args_list[3][1]["info"] == (
-            '{"name": "unyson", "versions": [""], "categories": ["WordPress plugins"], "groups": ["Add-ons"]}'
+            '{"name": "unyson", "versions": [], "categories": ["WordPress plugins"], "groups": ["Add-ons"]}'
         )
 
 
@@ -1189,8 +1189,8 @@ async def test_wp_theme():
             '{"name": "twentynineteen", "versions": ["1.9"], "categories": ["WordPress themes"], "groups": ["Add-ons"]}'
         )
         assert persister.add_payload.call_args_list[2][1]["info"] == (
-            '{"name": "seedlet", "versions": [""], "categories": ["WordPress themes"], "groups": ["Add-ons"]}'
+            '{"name": "seedlet", "versions": [], "categories": ["WordPress themes"], "groups": ["Add-ons"]}'
         )
         assert persister.add_payload.call_args_list[3][1]["info"] == (
-            '{"name": "customify", "versions": [""], "categories": ["WordPress themes"], "groups": ["Add-ons"]}'
+            '{"name": "customify", "versions": [], "categories": ["WordPress themes"], "groups": ["Add-ons"]}'
         )

--- a/tests/attack/test_mod_wp_enum.py
+++ b/tests/attack/test_mod_wp_enum.py
@@ -120,10 +120,10 @@ async def test_plugin():
             '{"name": "bbpress", "versions": ["2.6.6"], "categories": ["WordPress plugins"], "groups": ["Add-ons"]}'
         )
         assert persister.add_payload.call_args_list[2][1]["info"] == (
-            '{"name": "wp-reset", "versions": [""], "categories": ["WordPress plugins"], "groups": ["Add-ons"]}'
+            '{"name": "wp-reset", "versions": [], "categories": ["WordPress plugins"], "groups": ["Add-ons"]}'
         )
         assert persister.add_payload.call_args_list[3][1]["info"] == (
-            '{"name": "unyson", "versions": [""], "categories": ["WordPress plugins"], "groups": ["Add-ons"]}'
+            '{"name": "unyson", "versions": [], "categories": ["WordPress plugins"], "groups": ["Add-ons"]}'
         )
 
 
@@ -198,10 +198,10 @@ async def test_theme():
             '{"name": "twentynineteen", "versions": ["1.9"], "categories": ["WordPress themes"], "groups": ["Add-ons"]}'
         )
         assert persister.add_payload.call_args_list[2][1]["info"] == (
-            '{"name": "seedlet", "versions": [""], "categories": ["WordPress themes"], "groups": ["Add-ons"]}'
+            '{"name": "seedlet", "versions": [], "categories": ["WordPress themes"], "groups": ["Add-ons"]}'
         )
         assert persister.add_payload.call_args_list[3][1]["info"] == (
-            '{"name": "customify", "versions": [""], "categories": ["WordPress themes"], "groups": ["Add-ons"]}'
+            '{"name": "customify", "versions": [], "categories": ["WordPress themes"], "groups": ["Add-ons"]}'
         )
 
 

--- a/tests/integration/test_mod_wp_enum/assertions/wordpress.json
+++ b/tests/integration/test_mod_wp_enum/assertions/wordpress.json
@@ -7,7 +7,7 @@
             {
                 "method": "GET",
                 "path": "//wp-content/plugins/akismet/readme.txt",
-                "info": "{\"name\": \"akismet\", \"versions\": [\"\"], \"categories\": [\"WordPress plugins\"], \"groups\": [\"Add-ons\"]}",
+                "info": "{\"name\": \"akismet\", \"versions\": [], \"categories\": [\"WordPress plugins\"], \"groups\": [\"Add-ons\"]}",
                 "level": 0,
                 "parameter": null,
                 "module": "wp_enum",

--- a/wapitiCore/attack/cms/mod_wp_enum.py
+++ b/wapitiCore/attack/cms/mod_wp_enum.py
@@ -108,27 +108,29 @@ class ModuleWpEnum(CommonCMS):
             except RequestError:
                 self.network_errors += 1
             else:
+                plugin_detected = {
+                    "name": plugin,
+                    "versions": [],
+                    "categories": ["WordPress plugins"],
+                    "groups": ['Add-ons']
+                }
+
                 if response.is_success:
                     version = re.search(r'tag:\s*([\d.]+)', response.content)
 
                     # This check was added to detect invalid format of "Readme.txt" which can cause a crash
                     if version:
                         version = version.group(1)
+                        plugin_detected["versions"] = [version]
                     else:
-                        version = ""
+                        logging.warning(f"Readme.txt for {plugin} has an invalid format.")
 
                     if version or \
                         self.false_positive["plugins"] < 200 or self.false_positive["plugins"] > 299:
-                        plugin_detected = {
-                            "name": plugin,
-                            "versions": [version],
-                            "categories": ["WordPress plugins"],
-                            "groups": ['Add-ons']
-                        }
                         log_blue(
                             MSG_TECHNO_VERSIONED,
                             plugin,
-                            [version]
+                            [version] if version else []
                         )
                         await self.add_info(
                             finding_class=SoftwareNameDisclosureFinding,
@@ -137,16 +139,10 @@ class ModuleWpEnum(CommonCMS):
                             response=response
                         )
                 elif response.status == 403 and self.false_positive["plugins"] != 403:
-                    plugin_detected = {
-                        "name": plugin,
-                        "versions": [""],
-                        "categories": ["WordPress plugins"],
-                        "groups": ['Add-ons']
-                    }
                     log_blue(
                         MSG_TECHNO_VERSIONED,
                         plugin,
-                        [""]
+                        []
                     )
                     await self.add_info(
                         finding_class=SoftwareNameDisclosureFinding,
@@ -163,27 +159,28 @@ class ModuleWpEnum(CommonCMS):
             except RequestError:
                 self.network_errors += 1
             else:
+                theme_detected = {
+                    "name": theme,
+                    "versions": [],
+                    "categories": ["WordPress themes"],
+                    "groups": ['Add-ons']
+                }
+
                 if response.is_success:
                     version = re.search(r'tag:\s*([\d.]+)', response.content)
                     # This check was added to detect invalid format of "Readme.txt" which can cause a crash
                     if version:
                         version = version.group(1)
+                        theme_detected["versions"] = [version]
                     else:
-                        version = ""
-
-                    theme_detected = {
-                        "name": theme,
-                        "versions": [version],
-                        "categories": ["WordPress themes"],
-                        "groups": ['Add-ons']
-                    }
+                        logging.warning(f"Readme.txt for {theme} has an invalid format.")
 
                     if version or \
                         self.false_positive["themes"] < 200 or self.false_positive["themes"] > 299:
                         log_blue(
                             MSG_TECHNO_VERSIONED,
                             theme,
-                            [version]
+                            [version] if version else []
                         )
                         await self.add_info(
                             finding_class=SoftwareNameDisclosureFinding,
@@ -192,16 +189,10 @@ class ModuleWpEnum(CommonCMS):
                             response=response
                         )
                 elif response.status == 403 and self.false_positive["themes"] != 403:
-                    theme_detected = {
-                        "name": theme,
-                        "versions": [""],
-                        "categories": ["WordPress themes"],
-                        "groups": ['Add-ons']
-                    }
                     log_blue(
                         MSG_TECHNO_VERSIONED,
                         theme,
-                        [""]
+                        []
                     )
                     await self.add_info(
                         finding_class=SoftwareNameDisclosureFinding,

--- a/wapitiCore/attack/mod_wp_enum.py
+++ b/wapitiCore/attack/mod_wp_enum.py
@@ -152,27 +152,29 @@ class ModuleWpEnum(Attack):
             except RequestError:
                 self.network_errors += 1
             else:
+                plugin_detected = {
+                    "name": plugin,
+                    "versions": [],
+                    "categories": ["WordPress plugins"],
+                    "groups": ['Add-ons']
+                }
+
                 if response.is_success:
                     version = re.search(r'tag:\s*([\d.]+)', response.content)
 
                     # This check was added to detect an invalid format of "Readme.txt" which can cause a crash
                     if version:
                         version = version.group(1)
+                        plugin_detected["versions"] = [version]
                     else:
-                        version = ""
+                        logging.warning("Readme.txt for %s has an invalid format.", plugin)
 
                     if version or \
                         self.false_positive["plugins"] < 200 or self.false_positive["plugins"] > 299:
-                        plugin_detected = {
-                            "name": plugin,
-                            "versions": [version],
-                            "categories": ["WordPress plugins"],
-                            "groups": ['Add-ons']
-                        }
                         log_blue(
                             MSG_TECHNO_VERSIONED,
                             plugin,
-                            [version]
+                            [version] if version else []
                         )
                         await self.add_info(
                             finding_class=SoftwareNameDisclosureFinding,
@@ -181,16 +183,10 @@ class ModuleWpEnum(Attack):
                             response=response
                         )
                 elif response.status == 403 and self.false_positive["plugins"] != 403:
-                    plugin_detected = {
-                        "name": plugin,
-                        "versions": [""],
-                        "categories": ["WordPress plugins"],
-                        "groups": ['Add-ons']
-                    }
                     log_blue(
                         MSG_TECHNO_VERSIONED,
                         plugin,
-                        [""]
+                        []
                     )
                     await self.add_info(
                         finding_class=SoftwareNameDisclosureFinding,
@@ -207,27 +203,28 @@ class ModuleWpEnum(Attack):
             except RequestError:
                 self.network_errors += 1
             else:
+                theme_detected = {
+                    "name": theme,
+                    "versions": [],
+                    "categories": ["WordPress themes"],
+                    "groups": ['Add-ons']
+                }
+
                 if response.is_success:
                     version = re.search(r'tag:\s*([\d.]+)', response.content)
                     # This check was added to detect invalid format of "Readme.txt" which can cause a crash
                     if version:
                         version = version.group(1)
+                        theme_detected["versions"] = [version]
                     else:
-                        version = ""
-
-                    theme_detected = {
-                        "name": theme,
-                        "versions": [version],
-                        "categories": ["WordPress themes"],
-                        "groups": ['Add-ons']
-                    }
+                        logging.warning("Readme.txt for %s has an invalid format.", theme)
 
                     if version or \
                         self.false_positive["themes"] < 200 or self.false_positive["themes"] > 299:
                         log_blue(
                             MSG_TECHNO_VERSIONED,
                             theme,
-                            [version]
+                            [version] if version else []
                         )
                         await self.add_info(
                             finding_class=SoftwareNameDisclosureFinding,
@@ -236,16 +233,10 @@ class ModuleWpEnum(Attack):
                             response=response
                         )
                 elif response.status == 403 and self.false_positive["themes"] != 403:
-                    theme_detected = {
-                        "name": theme,
-                        "versions": [""],
-                        "categories": ["WordPress themes"],
-                        "groups": ['Add-ons']
-                    }
                     log_blue(
                         MSG_TECHNO_VERSIONED,
                         theme,
-                        [""]
+                        []
                     )
                     await self.add_info(
                         finding_class=SoftwareNameDisclosureFinding,


### PR DESCRIPTION
Correction des incohérences dans le format de sortie du champ versions pour les modules wp_enum (deprecated) et cms/wp_enum.

Au lieu de renvoyer [""] les modules renvoient maintenant [] si aucune version n'est identifiée.

