### PR TITLE
Support Python 3 14

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -40,7 +40,7 @@ jobs:
     runs-on: ubuntu-24.04
     strategy:
       matrix:
-        python-version: ["3.12.11", "3.13.5"]
+        python-version: ["3.12", "3.13", "3.14"]
     steps:
     - uses: actions/checkout@v4
     - name: Set up Python ${{ matrix.python-version }}

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -8,6 +8,7 @@ variables:
   PYTHON_11_IMAGE: "docker.io/library/python:3.11-slim-bullseye"
   PYTHON_12_IMAGE: "docker.io/library/python:3.12-slim-bullseye"
   PYTHON_13_IMAGE: "docker.io/library/python:3.13-slim-bullseye"
+  PYTHON_14_IMAGE: "docker.io/library/python:3.14-slim-bullseye"
   ACCESS_TOKEN_NAME: "gitlab-ci-token"
 
 check_coding_style:
@@ -38,7 +39,7 @@ test-python:
         $CI_PIPELINE_SOURCE == "merge_request_event"
   parallel:
     matrix:
-      - PYTHON_IMAGE: [$PYTHON_10_IMAGE, $PYTHON_11_IMAGE, $PYTHON_12_IMAGE, $PYTHON_13_IMAGE]
+      - PYTHON_IMAGE: [$PYTHON_10_IMAGE, $PYTHON_11_IMAGE, $PYTHON_12_IMAGE, $PYTHON_13_IMAGE, $PYTHON_14_IMAGE]
   image: $PYTHON_IMAGE
   before_script:
     - python -c "import sys; print(sys.version)"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ name = "wapiti3"
 version = "3.2.10"
 description = "A web application vulnerability scanner"
 readme  = "README.rst"
-requires-python = ">=3.12,<3.14"
+requires-python = ">=3.12,<3.15"
 authors = [
         {name="Nicolas Surribas", email="nicolas.surribas@gmail.com"},
 ]

--- a/wapitiCore/controller/wapiti.py
+++ b/wapitiCore/controller/wapiti.py
@@ -363,7 +363,7 @@ class Wapiti:
                     if not os.path.exists(p.firefox.executable_path):
                         log_red(
                             "Firefox is not installed. "
-                            "Please run `playwright install firefox`"
+                            "Please run `wapiti-install-headless-browser`"
                         )
                         self._headless_mode = "no"
                     else:
@@ -371,7 +371,7 @@ class Wapiti:
                 except PlaywrightError:
                     log_red(
                         "Could not find browser installation. "
-                        "Please run `playwright install --with-deps firefox`"
+                        "Please run `wapiti-install-headless-browser`"
                     )
                     self._headless_mode = "no"
 


### PR DESCRIPTION
Had to modify the tests as the html parsers from Python evolved.

Most changes seem to concern all python 3.x versions but the "noembed" change hasn't been applied to the python 3.12 branch yet.

While we aren't testing python 3.11 anymore, it should fix https://github.com/wapiti-scanner/wapiti/issues/698

Wapiti tested on 3.14 with and without headless browser