### PR TITLE
Force aiosqlite lower than 0.22.0

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -34,7 +34,7 @@ jobs:
           install: true
       - name: Build
         run: |
-          docker build .
+          docker build -f Dockerfile .
 
   build:
     runs-on: ubuntu-24.04

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,7 @@ classifiers = [
         "Topic :: Software Development :: Testing"
 ]
 dependencies = [
-    "aiosqlite>=0.19,<1.0",
+    "aiosqlite>=0.19,<0.22.0",
     "playwright>=1.42,<2.0",
     "beautifulsoup4>=4.12,<5.0",
     "browser-cookie3>=0.19,<0.21",


### PR DESCRIPTION
New version of aiosqlite made the python 3.14 pytest step freeze, see https://github.com/omnilib/aiosqlite/issues/369