### PR TITLE
Improve devcontainer for local development workflow

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,13 +1,20 @@
 FROM python:3.13-slim
 
+# UID/GID de l'utilisateur local (passés au build) pour matcher les permissions du montage
+ARG USER_UID=1000
+ARG USER_GID=1000
+
 ENV DEBIAN_FRONTEND=noninteractive \
     LANG=en_US.UTF-8 \
     PYTHONDONTWRITEBYTECODE=1 \
-    PYTHONUNBUFFERED=1
+    PYTHONUNBUFFERED=1 \
+    PLAYWRIGHT_BROWSERS_PATH=/opt/ms-playwright
 
-# Install required system dependencies
-RUN apt-get update && apt-get install -y \
+# Install required system dependencies (dev tools)
+RUN apt-get update && apt-get install -y --no-install-recommends \
     git \
+    openssh-client \
+    gnupg \
     build-essential \
     ca-certificates \
     curl \
@@ -17,35 +24,24 @@ RUN apt-get update && apt-get install -y \
     php8.4-cli \
     php8.4-xml \
     sslscan \
+    xz-utils \
+    bzip2 \
     && apt-get clean -yq \
     && apt-get autoremove -yq \
     && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
-# Install system dependencies for Playwright
-# (will be completed by playwright install --with-deps in postCreateCommand)
-RUN apt-get update && apt-get install -y \
-    libnss3 \
-    libnspr4 \
-    libatk1.0-0 \
-    libatk-bridge2.0-0 \
-    libcups2 \
-    libdrm2 \
-    libdbus-1-3 \
-    libxkbcommon0 \
-    libxcomposite1 \
-    libxdamage1 \
-    libxfixes3 \
-    libxrandr2 \
-    libgbm1 \
-    libasound2 \
-    libpango-1.0-0 \
-    libcairo2 \
+# Update pip and install Playwright (same base as Dockerfile.headless)
+RUN pip install --no-cache-dir --upgrade pip setuptools wheel \
+    && pip install --no-cache-dir playwright
+
+# Playwright system deps + Firefox (same as Dockerfile.headless, tout dans l’image)
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends --no-install-suggests xz-utils curl bzip2 \
+    && playwright install-deps firefox \
+    && playwright install firefox \
     && apt-get clean -yq \
     && apt-get autoremove -yq \
     && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
-
-# Update pip
-RUN pip install --no-cache-dir --upgrade pip setuptools wheel
 
 # Set working directory
 WORKDIR /workspace
@@ -54,8 +50,19 @@ WORKDIR /workspace
 COPY pyproject.toml ./
 COPY Makefile ./
 
-# Python dependencies will be installed via postCreateCommand
-# to allow mounting the workspace with local modifications
+# Utilisateur avec UID/GID de l'hôte (évite soucis de permissions sur les fichiers montés)
+RUN export uid=${USER_UID:-1000} gid=${USER_GID:-1000} \
+    && (groupadd --gid $gid wapiti 2>/dev/null || true) \
+    && useradd --uid $uid --gid $gid -m -s /bin/bash wapiti \
+    && apt-get update && apt-get install -y --no-install-recommends sudo \
+    && echo "wapiti ALL=(ALL) NOPASSWD:ALL" >> /etc/sudoers \
+    && apt-get clean -yq && rm -rf /var/lib/apt/lists/*
 
+USER wapiti
+WORKDIR /workspace
 
+# Scripts pip (wapiti, wapiti-getcookie, …) installés en ~/.local/bin par postCreate
+ENV PATH="/home/wapiti/.local/bin:$PATH"
+
+# Dépendances Python installées au postCreate (workspace monté)
 

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -2,7 +2,11 @@
 	"name": "Wapiti Development",
 	"build": {
 		"dockerfile": "Dockerfile",
-		"context": ".."
+		"context": "..",
+		"args": {
+			"USER_UID": "${localEnv:UID}",
+			"USER_GID": "${localEnv:GID}"
+		}
 	},
 	"features": {},
 	"customizations": {
@@ -15,7 +19,7 @@
 				"charliermarsh.ruff"
 			],
 			"settings": {
-				"python.defaultInterpreterPath": "/usr/local/bin/python",
+				"python.defaultInterpreterPath": "/workspace/.venv/bin/python",
 				"python.linting.enabled": true,
 				"python.linting.pylintEnabled": true,
 				"python.formatting.provider": "black",
@@ -27,11 +31,18 @@
 		}
 	},
 	"forwardPorts": [],
-	"postCreateCommand": "pip install -e '.[dev]' && playwright install --with-deps",
-	"remoteUser": "root",
+	"postCreateCommand": "bash -c '[ -d .venv ] || python3 -m venv .venv; .venv/bin/pip install -q --upgrade pip; .venv/bin/pip install -e \".[dev]\" --upgrade'",
+	"remoteUser": "wapiti",
 	"workspaceFolder": "/workspace",
+	"containerEnv": {
+		"PATH": "/workspace/.venv/bin:/usr/local/bin:/usr/bin:/bin:/home/wapiti/.local/bin"
+	},
 	"mounts": [
-		"source=${localWorkspaceFolder},target=/workspace,type=bind"
+		"source=${localWorkspaceFolder},target=/workspace,type=bind",
+		"source=${localEnv:HOME}/.gitconfig,target=/home/wapiti/.gitconfig,type=bind,readonly",
+		"source=${localEnv:HOME}/.ssh,target=/home/wapiti/.ssh,type=bind,readonly",
+		"source=${localEnv:HOME}/.gnupg,target=/home/wapiti/.gnupg,type=bind,readonly",
+		"type=volume,source=wapiti-pip-cache,target=/home/wapiti/.cache/pip"
 	]
 }
 

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 ### Python ###
+.venv/
 # Byte-compiled / optimized / DLL files
 __pycache__/
 *.py[cod]


### PR DESCRIPTION
This PR improves Improve the devcontainer for local development workflow

- Match container user UID/GID to host (with the user `wapiti`) to avoid permission issues on mounted files
- Mount host .gitconfig, .ssh, and .gnupg for using git command without extra configuration.
- Use a persistent pip cache volume (wapiti-pip-cache) and a venv in the workspace (in `.venv` dir) so dependencies are not re-downloaded on each start