### PR TITLE
Improve Log4Shell DNS verification performance

### DIFF
--- a/tests/attack/test_mod_log4shell.py
+++ b/tests/attack/test_mod_log4shell.py
@@ -7,7 +7,7 @@ from httpx import Response as HttpxResponse
 
 import pytest
 import respx
-from dns.resolver import Resolver
+from dns.asyncresolver import Resolver
 
 from tests import get_mock_open
 from wapitiCore.attack.mod_log4shell import ModuleLog4Shell
@@ -109,10 +109,10 @@ async def test_verify_dns():
 
         module = ModuleLog4Shell(crawler, persister, options, crawler_configuration)
 
-        with mock.patch.object(Resolver, "resolve", return_value=(MockAnswer(True),)):
+        with mock.patch.object(Resolver, "resolve", new=AsyncMock(return_value=(MockAnswer(True),))):
             assert await module._verify_dns("foobar") is True
 
-        with mock.patch.object(Resolver, "resolve", return_value=(MockAnswer(False),)):
+        with mock.patch.object(Resolver, "resolve", new=AsyncMock(return_value=(MockAnswer(False),))):
             assert await module._verify_dns("foobar") is False
 
 


### PR DESCRIPTION
This MR improves the performance of the DNS verification used to confirm a Log4Shell exploitation. The module relies on a DNS lookup to determine whether the payload was actually triggered.

To increase performance, we make these DNS lookups asynchronous. The module switches from dns.resolver to dns.asyncresolver so DNS responses can be awaited and batches the requests to run them asynchronously.

To avoid putting too much pressure on the DNS, a semaphore is introduced to cap the number of concurrent request. In addition, the resolver is instantiated once and reused instead of being recreated for every verification.

Tests were updated to reflect the use of an async DNS resolver.

With these changes, runtime went from 11m 20s down to 2m 25s on https://quotes.toscrape.com/