### PR TITLE
Fix Tomcat image used in tests

### DIFF
--- a/tests/integration/.env
+++ b/tests/integration/.env
@@ -15,10 +15,10 @@ HTTPD_HASH='@sha256:760413d133979e7cc5ced07d8c323e7b68bb48b4e114f8898c2f2d6af82e
 # The following hash corresponds to the image nginx:stable-alpine
 # it can be found here: https://hub.docker.com/layers/library/nginx/stable-alpine/images/sha256-0f737f8ba72d336d5e5e5c6f4ae163ef15c047b58ec5d88fdcb277be61d1aebb?context=explore
 NGINX_HASH='@sha256:0f737f8ba72d336d5e5e5c6f4ae163ef15c047b58ec5d88fdcb277be61d1aebb'
-# The following hash corresponds to the image tomcat:8.0.36-jre8
-# it can be found here: https://hub.docker.com/layers/library/tomcat/8.0.36-jre8/images/sha256-945050cf462d19a61b840fa5dbdaf75512621c25ffd9031c09147463fce2db84?context=explore
-TOMCAT_HASH='@sha256:945050cf462d19a61b840fa5dbdaf75512621c25ffd9031c09147463fce2db84'
-TOMCAT_TAG=':8.0.36-jre8'
+# The following hash corresponds to the image tomcat:8.0.51-jre8
+# it can be found here: https://hub.docker.com/layers/library/tomcat/8.0.51-jre8/images/sha256-8fa15f85f39220adbd402ff73de97175f7c7f3ea95bef16e502970c76fe546a5?context=explore
+TOMCAT_HASH='@sha256:8fa15f85f39220adbd402ff73de97175f7c7f3ea95bef16e502970c76fe546a5'
+TOMCAT_TAG=':8.0.51-jre8'
 
 # The following hashes corresponds respectively to the images, drupal:9-apache, drupal:10-apache
 # drupal@sha256:18692a0792c882957024f4086cadbc966778c5593850dfa89edb7780ba8b794d

--- a/tests/integration/test_mod_log4shell/tomcat/Dockerfile.tomcat
+++ b/tests/integration/test_mod_log4shell/tomcat/Dockerfile.tomcat
@@ -1,27 +1,25 @@
-ARG TOMCAT_HASH_TAG=':8.0.36-jre8'
+ARG TOMCAT_HASH_TAG=':8.0.51-jre8'
 FROM tomcat${TOMCAT_HASH_TAG}
 
-# Need to add nc for healthcheck, 
-# This is Debian Jessie so we need to access to the archive packages
-# and clean the outdated repos  
-RUN printf "deb http://archive.debian.org/debian jessie main non-free contrib\n\
-    deb-src http://archive.debian.org/debian/ jessie main non-free contrib\n\n\
-    deb http://archive.debian.org/debian-security/ jessie/updates main non-free contrib\n\
-    deb-src http://archive.debian.org/debian-security/ etch/updates main non-free contrib\n"\
-    > /etc/apt/sources.list &&\
-    rm /etc/apt/sources.list.d/* &&\
-    apt install debian-archive-keyring -y &&\
-    apt-get clean &&\
-    apt update &&\
-    yes | apt install netcat --force-yes &&\
-    apt-get clean -yq &&\
-    apt-get autoremove -yq &&\
-    rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* &&\
-    truncate -s 0 /var/log/*log
+# Need to add nc for healthcheck.
+# Base image is Debian Stretch (EOL), use archive.debian.org and allow unauthenticated
+# packages (archive signing keys have expired).
+RUN printf "deb http://archive.debian.org/debian stretch main\n\
+    deb http://archive.debian.org/debian-security stretch/updates main\n" \
+    > /etc/apt/sources.list && \
+    rm -f /etc/apt/sources.list.d/* && \
+    apt-get update && \
+    apt-get install -y --allow-unauthenticated netcat-openbsd && \
+    apt-get clean -yq && \
+    apt-get autoremove -yq && \
+    rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* && \
+    truncate -s 0 /var/log/*log 2>/dev/null || true
 
-# Some config tuning for Apache 
-RUN rm -rf /usr/local/tomcat/webapps/* &&\
+# Tomcat config: empty webapps, listen on port 80 for healthcheck
+RUN rm -rf /usr/local/tomcat/webapps/* && \
     sed -i 's/port="8080"/port="80"/' /usr/local/tomcat/conf/server.xml
-ADD log4shell-1.0-SNAPSHOT.war /usr/local/tomcat/webapps/ROOT.war 
-EXPOSE 8080
+
+ADD log4shell-1.0-SNAPSHOT.war /usr/local/tomcat/webapps/ROOT.war
+
+EXPOSE 80
 CMD ["catalina.sh", "run"]


### PR DESCRIPTION
The previous image is no longer available on docker hub. Maybe too old and docker pruned it. The tag is still available but not the layers.