### PR TITLE
Code review fixes — batch 2026-05

### DIFF
--- a/doc/wapiti.1
+++ b/doc/wapiti.1
@@ -334,7 +334,7 @@ For example:
 .br
 \fB\-\-cookie\-value "PHPSESSIONID=5f4dcc3b5aa765d61d8327deb882cf99;cookie_2=somevalue"\fR
 .IP "\(bu" 4
-\-\-jwt` \fIJWT\fR Set JWT token from a valid user session\. You can import the JWT token value to be sent with every request for an authenticated scan\.
+\fB\-\-jwt\fR \fIJWT\fR Set JWT token from a valid user session\. You can import the JWT token value to be sent with every request for an authenticated scan\.
 .IP "\(bu" 4
 \fB\-\-drop\-set\-cookie\fR
 .br

--- a/doc/wapiti.1.html
+++ b/doc/wapiti.1.html
@@ -466,7 +466,7 @@ For example:<br>
     <code>--cookie-value "PHPSESSIONID=5f4dcc3b5aa765d61d8327deb882cf99;cookie_2=somevalue"</code></p>
   </li>
   <li>
-    <p>--jwt` <var>JWT</var>
+    <p><code>--jwt</code> <var>JWT</var>
 Set JWT token from a valid user session.
 You can import the JWT token value to be sent with every request for an authenticated scan.</p>
   </li>

--- a/doc/wapiti.ronn
+++ b/doc/wapiti.ronn
@@ -224,7 +224,7 @@ OTHER OPTIONS:
     For example:  
         `--cookie-value "PHPSESSIONID=5f4dcc3b5aa765d61d8327deb882cf99;cookie_2=somevalue"`
 
-  * --jwt` <JWT>
+  * `--jwt` <JWT>
     Set JWT token from a valid user session.
     You can import the JWT token value to be sent with every request for an authenticated scan.
 

--- a/tests/attack/test_mod_exec.py
+++ b/tests/attack/test_mod_exec.py
@@ -242,40 +242,6 @@ async def test_detection_alpine_busybox_id():
 
 @pytest.mark.asyncio
 @respx.mock
-async def test_no_false_positive_hostname_without_home():
-    # A page mentioning PATH=, PWD= and HOSTNAME= but not HOME= should not be flagged.
-    # The old rule (HOME|HOSTNAME) would have triggered; the new HOME-only rule should not.
-    respx.get(url__regex=r"http://perdu\.com/\?vuln=.*env.*").mock(
-        return_value=httpx.Response(
-            200,
-            text="PATH=/usr/bin:/bin\nPWD=/var/www/html\nHOSTNAME=myserver.example.com\n"
-        )
-    )
-    respx.get(url__regex=r"http://perdu\.com/.*").mock(
-        return_value=httpx.Response(200, text="Hello there")
-    )
-    respx.post(url__regex=r"http://perdu\.com/.*").mock(
-        return_value=httpx.Response(200, text="Hello there")
-    )
-
-    persister = AsyncMock()
-
-    request = Request("http://perdu.com/?vuln=hello")
-    request.path_id = 1
-
-    crawler_configuration = CrawlerConfiguration(Request("http://perdu.com/"), timeout=1)
-    async with AsyncCrawler.with_configuration(crawler_configuration) as crawler:
-        options = {"timeout": 10, "level": 1}
-
-        module = ModuleExec(crawler, persister, options, crawler_configuration)
-        module.do_post = False
-        await module.attack(request)
-
-        assert persister.add_payload.call_count == 0
-
-
-@pytest.mark.asyncio
-@respx.mock
 async def test_no_false_positive_file_extension_based():
     # In this test, the response is a javascript file that contains "uid=" which can provoke a false positive avoid with file extension check
 

--- a/tests/attack/test_mod_exec.py
+++ b/tests/attack/test_mod_exec.py
@@ -210,6 +210,72 @@ async def test_no_false_positive_content_type_based():
 
 @pytest.mark.asyncio
 @respx.mock
+async def test_detection_alpine_busybox_id():
+    # Alpine/busybox: `id` outputs uid=...gid=... without groups= field
+    respx.get(url__regex=r"http://perdu\.com/\?vuln=id").mock(
+        return_value=httpx.Response(200, text="uid=33(www-data) gid=33(www-data)")
+    )
+    respx.get(url__regex=r"http://perdu\.com/.*").mock(
+        return_value=httpx.Response(200, text="Hello there")
+    )
+    respx.post(url__regex=r"http://perdu\.com/.*").mock(
+        return_value=httpx.Response(200, text="Hello there")
+    )
+
+    persister = AsyncMock()
+
+    request = Request("http://perdu.com/?vuln=hello")
+    request.path_id = 1
+
+    crawler_configuration = CrawlerConfiguration(Request("http://perdu.com/"), timeout=1)
+    async with AsyncCrawler.with_configuration(crawler_configuration) as crawler:
+        options = {"timeout": 10, "level": 1}
+
+        module = ModuleExec(crawler, persister, options, crawler_configuration)
+        module.do_post = False
+        await module.attack(request)
+
+        assert persister.add_payload.call_count == 1
+        assert persister.add_payload.call_args_list[0][1]["category"] == "Command execution"
+        assert persister.add_payload.call_args_list[0][1]["request"].get_params == [["vuln", "id"]]
+
+
+@pytest.mark.asyncio
+@respx.mock
+async def test_no_false_positive_hostname_without_home():
+    # A page mentioning PATH=, PWD= and HOSTNAME= but not HOME= should not be flagged.
+    # The old rule (HOME|HOSTNAME) would have triggered; the new HOME-only rule should not.
+    respx.get(url__regex=r"http://perdu\.com/\?vuln=.*env.*").mock(
+        return_value=httpx.Response(
+            200,
+            text="PATH=/usr/bin:/bin\nPWD=/var/www/html\nHOSTNAME=myserver.example.com\n"
+        )
+    )
+    respx.get(url__regex=r"http://perdu\.com/.*").mock(
+        return_value=httpx.Response(200, text="Hello there")
+    )
+    respx.post(url__regex=r"http://perdu\.com/.*").mock(
+        return_value=httpx.Response(200, text="Hello there")
+    )
+
+    persister = AsyncMock()
+
+    request = Request("http://perdu.com/?vuln=hello")
+    request.path_id = 1
+
+    crawler_configuration = CrawlerConfiguration(Request("http://perdu.com/"), timeout=1)
+    async with AsyncCrawler.with_configuration(crawler_configuration) as crawler:
+        options = {"timeout": 10, "level": 1}
+
+        module = ModuleExec(crawler, persister, options, crawler_configuration)
+        module.do_post = False
+        await module.attack(request)
+
+        assert persister.add_payload.call_count == 0
+
+
+@pytest.mark.asyncio
+@respx.mock
 async def test_no_false_positive_file_extension_based():
     # In this test, the response is a javascript file that contains "uid=" which can provoke a false positive avoid with file extension check
 

--- a/tests/attack/test_mod_printer.py
+++ b/tests/attack/test_mod_printer.py
@@ -234,13 +234,6 @@ async def test_epson_l6290_detection_with_fw_version():
         )
         assert persister.add_payload.call_args_list[0][1]["module"] == "printer"
 
-@pytest.mark.asyncio
-async def test_get_firmware_version_unknown_brand():
-    module = ModulePrinter(AsyncMock(), AsyncMock(), {}, AsyncMock())
-
-    result = await module.get_firmware_version("http://printer.local", "canon")
-
-    assert result == ""
 
 
 @pytest.mark.asyncio

--- a/tests/net/test_web.py
+++ b/tests/net/test_web.py
@@ -2,7 +2,7 @@ import httpx
 import pytest
 
 from wapitiCore.net.response import Response, detail_response
-from wapitiCore.net.web import is_valid_url, shell_escape
+from wapitiCore.net.web import is_valid_url, shell_escape, urlparse
 
 
 def test_detail_response():
@@ -75,3 +75,48 @@ def test_shell_escape_various_cases():
     assert shell_escape('!!!!') == r'\!\!\!\!'
     assert shell_escape(r'!"$') == r'\!\"\$'
     assert shell_escape(r'`text`') == r'\`text\`'
+
+
+def test_urlparse_standard():
+    result = urlparse("http://example.com/path?q=1")
+    assert result.netloc == "example.com"
+    assert result.hostname == "example.com"
+    assert result.path == "/path"
+
+
+def test_urlparse_with_port():
+    result = urlparse("http://example.com:8080/path")
+    assert result.netloc == "example.com:8080"
+    assert result.port == 8080
+
+
+def test_urlparse_hostname_lowercased():
+    result = urlparse("http://EXAMPLE.COM/path")
+    assert result.netloc == "example.com"
+
+
+def test_urlparse_with_credentials():
+    result = urlparse("http://user:pass@example.com/path")
+    assert result.netloc == "user:pass@example.com"
+    assert result.username == "user"
+    assert result.password == "pass"
+
+
+def test_urlparse_ipv6_no_port():
+    result = urlparse("http://[::1]/path")
+    assert result.netloc == "[::1]"
+    assert result.hostname == "::1"
+
+
+def test_urlparse_ipv6_with_port():
+    result = urlparse("http://[::1]:8080/path")
+    assert result.netloc == "[::1]:8080"
+    assert result.hostname == "::1"
+    assert result.port == 8080
+
+
+def test_urlparse_ipv6_full_address():
+    result = urlparse("http://[2001:db8::1]:443/path")
+    assert result.netloc == "[2001:db8::1]:443"
+    assert result.hostname == "2001:db8::1"
+    assert result.port == 443

--- a/wapitiCore/attack/active_scanner.py
+++ b/wapitiCore/attack/active_scanner.py
@@ -10,8 +10,7 @@ from traceback import print_tb
 from typing import List, Dict, Optional, Set, AsyncIterator, Tuple, Type
 from uuid import uuid1
 
-import httpx
-from httpx import RequestError
+from httpx import RequestError, InvalidURL
 
 from wapitiCore import WAPITI_VERSION
 from wapitiCore.controller.exceptions import InvalidOptionValue
@@ -199,6 +198,8 @@ class ActiveScanner:
                     await attack_module.attack(request, response)
             except RequestError:
                 await asyncio.sleep(1)
+            except InvalidURL:
+                pass
             except Exception as exception:  # pylint: disable=broad-except
                 exception_traceback = sys.exc_info()[2]
                 logging.exception("An exception occurred in module %s", attack_module.name)

--- a/wapitiCore/attack/active_scanner.py
+++ b/wapitiCore/attack/active_scanner.py
@@ -10,7 +10,7 @@ from traceback import print_tb
 from typing import List, Dict, Optional, Set, AsyncIterator, Tuple, Type
 from uuid import uuid1
 
-from httpx import RequestError, InvalidURL
+from httpx import RequestError, InvalidURL, __version__ as httpx_version
 
 from wapitiCore import WAPITI_VERSION
 from wapitiCore.controller.exceptions import InvalidOptionValue
@@ -382,7 +382,7 @@ class ActiveScanner:
                 print_tb(traceback_, file=traceback_fd)
                 print(f"{exception.__class__.__name__}: {exception}", file=traceback_fd)
                 print(f"Occurred in {module_name} on {original_request}", file=traceback_fd)
-                logging.info("Wapiti %s. httpx %s. OS %s", WAPITI_VERSION, httpx.__version__, sys.platform)
+                logging.info("Wapiti %s. httpx %s. OS %s", WAPITI_VERSION, httpx_version, sys.platform)
 
             try:
                 with open(traceback_file, "rb") as traceback_byte_fd:

--- a/wapitiCore/attack/cms/mod_drupal_enum.py
+++ b/wapitiCore/attack/cms/mod_drupal_enum.py
@@ -17,6 +17,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program; if not, write to the Free Software
 # Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+import asyncio
 import json
 
 from typing import Optional
@@ -41,45 +42,42 @@ class ModuleDrupalEnum(CommonCMS):
     versions = []
     plugins_list = []
 
-    async def check_drupal_plugins(self, url, plugins_file):
+    async def _check_plugin(self, url: str, plugin: str, semaphore: asyncio.Semaphore) -> Optional[str]:
+        async with semaphore:
+            plugin_url = urljoin(url, f"modules/contrib/{plugin}/")
+            request = Request(plugin_url, 'GET')
+            try:
+                response: Response = await self.crawler.async_send(request, follow_redirects=True)
+            except RequestError:
+                self.network_errors += 1
+                return None
+            return plugin if response.status == 403 else None
+
+    async def check_drupal_plugins(self, url):
         """
         Check if specific Drupal Plugins are installed on the given URL.
         """
-        installed_plugins = []
-        # Sending a request to a non-existing plugin
         no_plugin_url = urljoin(url, "modules/contrib/non_existing_plugin/")
-        no_plugin_request = Request(f'{no_plugin_url}', 'GET')
+        no_plugin_request = Request(no_plugin_url, 'GET')
         try:
             no_plugin_response: Response = await self.crawler.async_send(no_plugin_request, follow_redirects=True)
             if no_plugin_response.status == 403:
-                # If the no_plugin_response returns 403, assume all folder requests return 403
                 return []
         except RequestError:
             self.network_errors += 1
             return []
-        try :
-            with open(
-            path_join(self.DATA_DIR, self.PAYLOADS_FILE_PLUGINS),
-            errors = "ignore",
-            encoding = 'utf-8') as plugins_list:
-                for plugin in plugins_list:
-                    plugin = plugin.strip()
-                    plugin_url = urljoin(url, f"modules/contrib/{plugin}/")
-                    request = Request(f'{plugin_url}', 'GET')
-                    try:
-                        response: Response = await self.crawler.async_send(request, follow_redirects=True)
-                    except RequestError:
-                        self.network_errors += 1
-                        continue
 
-                    if response.status == 403:
-                        installed_plugins.append(plugin)
-
+        plugins_path = path_join(self.DATA_DIR, self.PAYLOADS_FILE_PLUGINS)
+        try:
+            with open(plugins_path, errors="ignore", encoding="utf-8") as plugins_file:
+                plugins = [line.strip() for line in plugins_file if line.strip()]
         except FileNotFoundError:
-            print(f"Error: File '{plugins_file}' not found.")
+            logging.error("Drupal plugins file not found: %s", plugins_path)
             return []
 
-        return installed_plugins
+        semaphore = asyncio.Semaphore(self.options.get("tasks", 10))
+        results = await asyncio.gather(*[self._check_plugin(url, plugin, semaphore) for plugin in plugins])
+        return [p for p in results if p is not None]
 
     async def check_drupal(self, url):
         check_list = ['core/misc/drupal.js', 'misc/drupal.js']
@@ -108,7 +106,7 @@ class ModuleDrupalEnum(CommonCMS):
         if await self.check_drupal(request_to_root.url):
             await self.detect_version(self.PAYLOADS_HASH, request_to_root.url)  # Call the method on the instance
             self.versions = sorted(self.versions, key=lambda x: x.split('.')) if self.versions else []
-            self.plugins_list = await self.check_drupal_plugins(request_to_root.url, self.PAYLOADS_FILE_PLUGINS)
+            self.plugins_list = await self.check_drupal_plugins(request_to_root.url)
 
             drupal_detected = {
                 "name": "Drupal",

--- a/wapitiCore/attack/cms/mod_magento_enum.py
+++ b/wapitiCore/attack/cms/mod_magento_enum.py
@@ -176,7 +176,7 @@ class ModuleMagentoEnum(CommonCMS):
                 versions[content_hash] = detection_db[content_hash]
 
         if versions:
-            self.versions = set.intersection(*[set(versions) for versions in versions.values()])
+            self.versions = set.intersection(*[set(version_list) for version_list in versions.values()])
 
     async def get_url_hashes(self, url: str) -> Optional[Tuple[str, str]]:
         if get_root_url(url) == await self.persister.get_root_url():

--- a/wapitiCore/attack/cms/mod_magento_enum.py
+++ b/wapitiCore/attack/cms/mod_magento_enum.py
@@ -22,11 +22,11 @@ import json
 import re
 from typing import Optional, Tuple
 
-from bs4 import BeautifulSoup
 from httpx import RequestError
 from asyncio import TimeoutError
 from playwright.async_api import async_playwright, Page, Browser, Error as PlaywrightError
 
+from wapitiCore.parsers.html_parser import Html
 from wapitiCore.net import Request
 from wapitiCore.net.web import urlparse
 from wapitiCore.attack.cms.cms_common import CommonCMS, MSG_TECHNO_VERSIONED, calculate_git_hash
@@ -81,11 +81,11 @@ async def fetch_source_files(url: str, crawler_configuration: CrawlerConfigurati
             page = await context.new_page()
 
             html = await playwright_get_content(url, page, browser, crawler_configuration)
-            soup = BeautifulSoup(html, "html.parser")
+            parsed = Html(html, url)
 
             # Collect JS and CSS file links
-            js_files = {script.get('src') for script in soup.find_all('script') if script.get('src')}
-            css_files = {link.get('href') for link in soup.find_all('link', rel="stylesheet") if link.get('href')}
+            js_files = {script['src'] for script in parsed.soup.find_all('script', src=True)}
+            css_files = {link['href'] for link in parsed.soup.find_all('link', rel="stylesheet", href=True)}
 
             my_files_list.update(js_files)
             my_files_list.update(css_files)
@@ -137,9 +137,8 @@ class ModuleMagentoEnum(CommonCMS):
         except RequestError:
             self.network_errors += 1
             return None
-        soup = BeautifulSoup(response.content, 'html.parser')
+        page = Html(response.content, url)
         pattern = re.compile(r'skin/frontend/.*/default/.*')
-        script_tags = soup.find_all('script')
 
         keywords = [
             "magento_opensource", "x-magento-init", "Magento_Ui",
@@ -154,15 +153,13 @@ class ModuleMagentoEnum(CommonCMS):
         ):
             return await self.fetch_source_list(url)
 
-        for script in script_tags:
-            if 'src' in script.attrs and "Magento_Theme" in script['src']:
+        for script in page.soup.find_all('script', src=True):
+            if "Magento_Theme" in script['src']:
                 return await self.fetch_source_list(url)
 
-        for link in soup.find_all('link'):
-            if 'href' in link.attrs:
-                src = link['href']
-                if pattern.search(src):
-                    return await self.fetch_source_list(url)
+        for link in page.soup.find_all('link', href=True):
+            if pattern.search(link['href']):
+                return await self.fetch_source_list(url)
 
         for cookie in response.cookies:
             if cookie.startswith(('frontend', 'X-Magento', 'mage-')):
@@ -181,7 +178,7 @@ class ModuleMagentoEnum(CommonCMS):
         if versions:
             self.versions = set.intersection(*[set(versions) for versions in versions.values()])
 
-    async def get_url_hashes(self, url: str) -> Tuple[str, str]:
+    async def get_url_hashes(self, url: str) -> Optional[Tuple[str, str]]:
         if get_root_url(url) == await self.persister.get_root_url():
             request = Request(f"{url}", "GET")
             try:

--- a/wapitiCore/attack/cms/mod_magento_enum.py
+++ b/wapitiCore/attack/cms/mod_magento_enum.py
@@ -19,7 +19,6 @@
 # Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 import hashlib
 import json
-import os
 import re
 from typing import Optional, Tuple
 
@@ -100,7 +99,7 @@ async def fetch_source_files(url: str, crawler_configuration: CrawlerConfigurati
                 "and browsers are installed (`playwright install`)."
             )
     except Exception as e:
-        print(f"An error occurred while fetching JS files and CSS files: {e}")
+        logging.error("An error occurred while fetching JS files and CSS files: %s", e)
 
     return my_files_list
 

--- a/wapitiCore/attack/cms/mod_typo3_enum.py
+++ b/wapitiCore/attack/cms/mod_typo3_enum.py
@@ -19,14 +19,15 @@
 # Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 import json
 import re
+from os.path import join as path_join
 from typing import Optional, List, Set, Dict
 
 from urllib.parse import urljoin
-from bs4 import BeautifulSoup
 from httpx import RequestError
 from asyncio import TimeoutError
 from playwright.async_api import async_playwright, Page, Browser, Error as PlaywrightError
 
+from wapitiCore.parsers.html_parser import Html
 from wapitiCore.net import Request
 from wapitiCore.attack.cms.cms_common import CommonCMS, MSG_TECHNO_VERSIONED
 from wapitiCore.net.classes import CrawlerConfiguration
@@ -137,34 +138,30 @@ class ModuleTYPO3Enum(CommonCMS):
     versions = []
     extensions_list = []
 
-    async def check_typo3_extensions(self, url, extensions_file):
+    async def check_typo3_extensions(self, url):
         """
         Check if specific TYPO3 extensions are installed on the given URL.
         """
         installed_extensions = []
 
-        # Create a check request with a known non-existent extension
         no_ext_url = urljoin(url, "typo3conf/ext/non_existing_ext/")
-        no_ext_request = Request(f'{no_ext_url}', 'GET')
+        no_ext_request = Request(no_ext_url, 'GET')
 
         try:
             no_ext_response: Response = await self.crawler.async_send(no_ext_request, follow_redirects=True)
             if no_ext_response.status == 403:
-                # If the no_ext_response returns 403, assume all folder requests return 403
                 return []
         except RequestError:
             self.network_errors += 1
             return []
 
-        try :
-            with open(
-            os.path.join(self.DATA_DIR, self.PAYLOADS_FILE_EXTENSIONS),
-            errors = "ignore",
-            encoding = 'utf-8') as ext_list:
+        extensions_path = path_join(self.DATA_DIR, self.PAYLOADS_FILE_EXTENSIONS)
+        try:
+            with open(extensions_path, errors="ignore", encoding="utf-8") as ext_list:
                 for extension in ext_list:
                     extension = extension.strip()
                     ext_url = urljoin(url, f"typo3conf/ext/{extension}/")
-                    request = Request(f'{ext_url}', 'GET')
+                    request = Request(ext_url, 'GET')
                     try:
                         response: Response = await self.crawler.async_send(request, follow_redirects=True)
                     except RequestError:
@@ -175,7 +172,7 @@ class ModuleTYPO3Enum(CommonCMS):
                         installed_extensions.append(extension)
 
         except FileNotFoundError:
-            logging.error("TYPO3 extensions file not found: %s", extensions_file)
+            logging.error("TYPO3 extensions file not found: %s", extensions_path)
             return []
 
         return installed_extensions
@@ -189,30 +186,34 @@ class ModuleTYPO3Enum(CommonCMS):
         except RequestError:
             self.network_errors += 1
         else:
-            soup = BeautifulSoup(response.content, 'html.parser')
+            page = Html(response.content, url)
 
             # Check meta tag for generator
-            meta_generator = soup.find('meta', attrs={'name': 'generator'})
+            meta_generator = page.soup.find('meta', attrs={'name': 'generator'})
             if meta_generator and re.search(r'TYPO3\s+(?:CMS\s+)?(?:[\d.]+)?(?:\s+CMS)?',
                                             meta_generator.get('content', ''), re.I):
                 return True
 
             # Check for TYPO3-specific links and images
             typo3_patterns = ['typo3conf', 'typo3temp']
-            for tag in soup.find_all(['link', 'img']):
+            for tag in page.soup.find_all(['link', 'img']):
                 for attr in ['href', 'src']:
                     if tag.has_attr(attr) and any(pattern in tag[attr] for pattern in typo3_patterns):
                         return True
 
             # Check script sources
-            for script in soup.find_all('script', src=True):
+            for script in page.soup.find_all('script', src=True):
                 if re.search(r'^/?typo3(?:conf|temp)/', script['src']):
                     return True
 
             # Check for a known TYPO3 image probe
             typo3_probe_url = url.rstrip('/') + "/typo3/sysext/core/Resources/Public/Images/typo3_orange.svg"
-            request_typo3 = Request(f'{typo3_probe_url}', 'GET')
-            probe_response : Response = await self.crawler.async_send(request_typo3, follow_redirects=False)
+            request_typo3 = Request(typo3_probe_url, 'GET')
+            try:
+                probe_response: Response = await self.crawler.async_send(request_typo3, follow_redirects=False)
+            except RequestError:
+                self.network_errors += 1
+                return False
             if probe_response.status == 200 and "svg" in probe_response.headers.get("content-type", ""):
                 return True
         return False
@@ -226,7 +227,7 @@ class ModuleTYPO3Enum(CommonCMS):
             await self.detect_version(self.PAYLOADS_HASH, request_to_root.url)
             self.versions = sorted(self.versions, key=lambda x: x.split('.')) if self.versions else []
 
-            self.extensions_list = await self.check_typo3_extensions(request_to_root.url, self.PAYLOADS_FILE_EXTENSIONS)
+            self.extensions_list = await self.check_typo3_extensions(request_to_root.url)
 
             if not self.versions:
                 list_hashes = []

--- a/wapitiCore/attack/cms/mod_typo3_enum.py
+++ b/wapitiCore/attack/cms/mod_typo3_enum.py
@@ -19,7 +19,6 @@
 # Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 import json
 import re
-import os
 from typing import Optional, List, Set, Dict
 
 from urllib.parse import urljoin
@@ -126,7 +125,7 @@ async def fetch_source_files(url: str, crawler_configuration: CrawlerConfigurati
             )
 
     except Exception as e:
-        print(f"An error occurred while fetching JS files: {e}")
+        logging.error("An error occurred while fetching JS files: %s", e)
 
     return my_files_list
 
@@ -176,7 +175,7 @@ class ModuleTYPO3Enum(CommonCMS):
                         installed_extensions.append(extension)
 
         except FileNotFoundError:
-            print(f"Error: File '{extensions_file}' not found.")
+            logging.error("TYPO3 extensions file not found: %s", extensions_file)
             return []
 
         return installed_extensions

--- a/wapitiCore/attack/cms/mod_typo3_enum.py
+++ b/wapitiCore/attack/cms/mod_typo3_enum.py
@@ -107,11 +107,11 @@ async def fetch_source_files(url: str, crawler_configuration: CrawlerConfigurati
             page = await context.new_page()
 
             html = await playwright_get_content(url, page, browser, crawler_configuration)
-            soup = BeautifulSoup(html, "html.parser")
+            parsed = Html(html, url)
 
             # Collect JS and CSS file links
-            js_files = {script.get('src') for script in soup.find_all('script') if script.get('src')}
-            css_files = {link.get('href') for link in soup.find_all('link', rel="stylesheet") if link.get('href')}
+            js_files = {script['src'] for script in parsed.soup.find_all('script', src=True)}
+            css_files = {link['href'] for link in parsed.soup.find_all('link', rel="stylesheet", href=True)}
 
             my_files_list.update(js_files)
             my_files_list.update(css_files)

--- a/wapitiCore/attack/mod_backup.py
+++ b/wapitiCore/attack/mod_backup.py
@@ -110,7 +110,6 @@ class ModuleBackup(Attack):
         except RequestError:
             self.network_errors += 1
             return
-        requests = []
         evil_reqs = []
         urls = []
         if self.get_payloads():
@@ -131,12 +130,19 @@ class ModuleBackup(Attack):
                 url = urljoin(request.path, raw_payload)
 
             log_verbose(f"[¨] {url}")
-
-            evil_req = Request(url)
-            evil_reqs.append(evil_req)
-            requests.append(self.crawler.async_send(evil_req))
+            evil_reqs.append(Request(url))
             urls.append(url)
-        responses = await asyncio.gather(*requests, return_exceptions=True)
+
+        semaphore = asyncio.Semaphore(self.options.get("tasks", 10))
+
+        async def bounded_send(req):
+            async with semaphore:
+                return await self.crawler.async_send(req)
+
+        responses = await asyncio.gather(
+            *[bounded_send(req) for req in evil_reqs],
+            return_exceptions=True,
+        )
         for resp, url, evil_req in zip(responses, urls, evil_reqs):
             if isinstance(resp, RequestError):
                 self.network_errors += 1

--- a/wapitiCore/attack/mod_backup.py
+++ b/wapitiCore/attack/mod_backup.py
@@ -27,7 +27,7 @@ from os.path import splitext, join as path_join
 from urllib.parse import urljoin
 from typing import Optional, Iterator
 
-from httpx import RequestError
+from httpx import RequestError, InvalidURL
 
 from wapitiCore.main.log import log_verbose, log_red, log_orange
 from wapitiCore.attack.attack import Attack, random_string, Parameter
@@ -77,6 +77,8 @@ class ModuleBackup(Attack):
                 self.network_errors += 1
                 # Do not put anything in false_positive_directories, another luck for next time
                 return False
+            except InvalidURL:
+                return False
 
             self.false_positive_directories[request.dir_name] = (response and response.is_success)
 
@@ -109,6 +111,8 @@ class ModuleBackup(Attack):
             original_response = await self.crawler.async_send(request)
         except RequestError:
             self.network_errors += 1
+            return
+        except InvalidURL:
             return
         evil_reqs = []
         urls = []
@@ -147,7 +151,11 @@ class ModuleBackup(Attack):
             if isinstance(resp, RequestError):
                 self.network_errors += 1
                 continue
-            if resp and resp.is_success:
+
+            if isinstance(resp, InvalidURL):
+                continue
+
+            if resp and not isinstance(resp, Exception) and resp.is_success:
                 if compare_responses(resp.content or "", original_response.content or ""):
                     log_orange(f"Skipping {evil_req.url} because it's too similar to the response from {request.url}")
                     continue

--- a/wapitiCore/attack/mod_exec.py
+++ b/wapitiCore/attack/mod_exec.py
@@ -137,8 +137,8 @@ class ModuleExec(Attack):
                     continue
 
                 # Check file extension before further analysis
-                if not self._has_valid_file_extension(request.url):
-                    log_verbose(f"Skipping due to invalid file extension: {request.url}")
+                if not self._has_valid_file_extension(request.path):
+                    log_verbose(f"Skipping due to invalid file extension: {request.path}")
                     continue
 
             except ReadTimeout:

--- a/wapitiCore/attack/mod_exec.py
+++ b/wapitiCore/attack/mod_exec.py
@@ -72,16 +72,6 @@ class ModuleExec(Attack):
         return ""
 
     @staticmethod
-    def _is_valid_content_type(response: Response) -> bool:
-        """
-        Check if the Content-Type header of the response is acceptable for executing code.
-        Acceptable types typically include text-based responses (HTML, plain text, etc.)
-        """
-        valid_content_types = ["text/html", "text/plain", "application/json", "application/javascript"]
-        content_type = response.headers.get('Content-Type', '').split(';')[0].strip()
-        return content_type in valid_content_types
-
-    @staticmethod
     def _has_valid_file_extension(url: str) -> bool:
         """
         Check if the URL points to a valid file extension.
@@ -130,11 +120,6 @@ class ModuleExec(Attack):
 
             try:
                 response: Response = await self.crawler.async_send(mutated_request)
-
-                # Check Content-Type header before further analysis
-                if not self._is_valid_content_type(response):
-                    log_verbose(f"Skipping due to invalid content-type: {response.headers.get('Content-Type', '')}")
-                    continue
 
                 # Check file extension before further analysis
                 if not self._has_valid_file_extension(request.path):

--- a/wapitiCore/attack/mod_exec.py
+++ b/wapitiCore/attack/mod_exec.py
@@ -21,7 +21,7 @@ import re
 from os.path import join as path_join
 from typing import Optional, Iterator
 
-from httpx import ReadTimeout, RequestError
+from httpx import ReadTimeout, RequestError, InvalidURL
 
 from wapitiCore.main.log import log_red, log_verbose, log_orange
 from wapitiCore.attack.attack import Attack, Parameter
@@ -185,6 +185,8 @@ class ModuleExec(Attack):
                 timeouted = True
             except RequestError:
                 self.network_errors += 1
+            except InvalidURL:
+                continue
             else:
                 if payload_info.type == "time":
                     continue

--- a/wapitiCore/attack/mod_printer.py
+++ b/wapitiCore/attack/mod_printer.py
@@ -153,7 +153,7 @@ class ModulePrinter(Attack):
             root = ET.fromstring(xml_content)
             revision = root.find('.//prdcfgdyn:ProductInformation/dd:Version/dd:Revision', ns)
 
-            if revision.text:
+            if revision is not None and revision.text:
                 return revision.text.strip()
         except ET.ParseError:
             logging.error("Failed to parse XML (HP).")

--- a/wapitiCore/attack/mod_printer.py
+++ b/wapitiCore/attack/mod_printer.py
@@ -23,7 +23,7 @@ from typing import Optional
 from urllib.parse import urljoin
 import xml.etree.ElementTree as ET
 
-from bs4 import BeautifulSoup
+from wapitiCore.parsers.html_parser import Html
 from httpx import RequestError
 
 from wapitiCore.attack.attack import Attack
@@ -115,13 +115,13 @@ class ModulePrinter(Attack):
             logging.error("Request Error occurred (Epson): %s", req_error)
             return MSG_NO_FIRMWARE
 
-        soup = BeautifulSoup(response.content, 'html.parser')
+        page = Html(response.content, endpoint_url)
         patterns = [
             r'Current\s*Version[:\s]*([A-Za-z0-9.\-]+)',
             r'Version\s*actuelle[:\s]*([A-Za-z0-9.\-]+)'
         ]
 
-        for p in soup.find_all('p'):
+        for p in page.soup.find_all('p'):
             text = p.get_text(separator=' ', strip=True)
             for pattern in patterns:
                 match = re.search(pattern, text, re.IGNORECASE)

--- a/wapitiCore/attack/mod_printer.py
+++ b/wapitiCore/attack/mod_printer.py
@@ -23,13 +23,13 @@ from typing import Optional
 from urllib.parse import urljoin
 import xml.etree.ElementTree as ET
 
-from wapitiCore.parsers.html_parser import Html
 from httpx import RequestError
 
 from wapitiCore.attack.attack import Attack
 from wapitiCore.definitions.fingerprint import SoftwareNameDisclosureFinding
 from wapitiCore.main.log import log_blue, logging
 from wapitiCore.net import Request, Response
+from wapitiCore.parsers.html_parser import Html
 
 
 MSG_PRINTER_VERSIONED = "{0} {1} detected"

--- a/wapitiCore/attack/mod_redirect.py
+++ b/wapitiCore/attack/mod_redirect.py
@@ -19,7 +19,7 @@
 # Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 from typing import Optional
 
-from httpx import RequestError
+from httpx import RequestError, InvalidURL
 
 from wapitiCore.net.web import urlparse
 from wapitiCore.main.log import log_red, log_verbose
@@ -59,6 +59,8 @@ class ModuleRedirect(Attack):
                 response = await self.crawler.async_send(mutated_request)
             except RequestError:
                 self.network_errors += 1
+                continue
+            except InvalidURL:
                 continue
 
             html = Html(response.content, mutated_request.url)

--- a/wapitiCore/attack/mod_sql.py
+++ b/wapitiCore/attack/mod_sql.py
@@ -24,7 +24,7 @@ from random import randint
 from typing import Optional, Iterator
 
 from bs4.builder import ParserRejectedMarkup
-from httpx import ReadTimeout, RequestError
+from httpx import ReadTimeout, RequestError, InvalidURL
 
 from wapitiCore.main.log import log_red, log_orange, log_verbose, logging
 from wapitiCore.attack.attack import Attack, Mutator, Parameter
@@ -385,6 +385,8 @@ class ModuleSql(Attack):
             response = await self.crawler.async_send(request)
         except RequestError:
             self.network_errors += 1
+        except InvalidURL:
+            return False
         else:
             if find_pattern_in_response(response.content):
                 return True
@@ -419,6 +421,8 @@ class ModuleSql(Attack):
                 response = await self.crawler.async_send(mutated_request)
             except RequestError:
                 self.network_errors += 1
+            except InvalidURL:
+                continue
             else:
                 vuln_info = find_pattern_in_response(response.content)
                 if vuln_info and not await self.is_false_positive(request):
@@ -568,6 +572,9 @@ class ModuleSql(Attack):
             except RequestError:
                 self.network_errors += 1
                 # We need all cases to make sure SQLi is there
+                test_results.append(False)
+                continue
+            except InvalidURL:
                 test_results.append(False)
                 continue
 

--- a/wapitiCore/attack/mod_ssrf.py
+++ b/wapitiCore/attack/mod_ssrf.py
@@ -21,7 +21,7 @@ from asyncio import sleep
 from typing import Optional, Iterator
 from binascii import hexlify, unhexlify
 
-from httpx import RequestError
+from httpx import RequestError, InvalidURL
 
 from wapitiCore.main.log import logging, log_red, log_verbose
 from wapitiCore.attack.attack import Attack, Mutator, Parameter, ParameterSituation
@@ -80,6 +80,8 @@ class ModuleSsrf(Attack):
             except RequestError:
                 self.network_errors += 1
                 continue
+            except InvalidURL:
+                continue
 
     async def finish(self):
         endpoint_url = f"{self.internal_endpoint}get_ssrf.php?session_id={self._session_id}"
@@ -92,6 +94,8 @@ class ModuleSsrf(Attack):
         except RequestError:
             self.network_errors += 1
             logging.error("[!] Unable to request endpoint URL '%s'", self.internal_endpoint)
+        except InvalidURL:
+            logging.error("[!] Invalid endpoint URL '%s'", self.internal_endpoint)
         else:
             data = response.json
             if isinstance(data, dict):

--- a/wapitiCore/attack/mod_xss.py
+++ b/wapitiCore/attack/mod_xss.py
@@ -20,7 +20,7 @@
 from os.path import join as path_join
 from typing import Optional, Iterator, List, Tuple, Dict
 
-from httpx import ReadTimeout, RequestError
+from httpx import ReadTimeout, RequestError, InvalidURL
 
 from wapitiCore.main.log import log_orange, log_red, log_verbose
 from wapitiCore.attack.attack import Attack, Mutator, ParameterSituation, random_string, Parameter
@@ -93,6 +93,8 @@ class ModuleXss(Attack):
             except RequestError:
                 self.network_errors += 1
                 # We just inserted harmless characters, if we get a timeout here, it's not interesting
+                continue
+            except InvalidURL:
                 continue
             else:
                 # We keep a history of taint values we sent because in case of stored value, the taint code
@@ -168,6 +170,8 @@ class ModuleXss(Attack):
                 timeouted = True
             except RequestError:
                 self.network_errors += 1
+            except InvalidURL:
+                continue
             else:
                 html = Html(response.content, evil_request.url)
                 if (

--- a/wapitiCore/attack/network_devices/mod_checkpoint.py
+++ b/wapitiCore/attack/network_devices/mod_checkpoint.py
@@ -23,7 +23,7 @@ import re
 from typing import Optional
 from urllib.parse import urljoin
 
-from bs4 import BeautifulSoup
+from wapitiCore.parsers.html_parser import Html
 from httpx import RequestError
 
 from wapitiCore.attack.network_devices.network_device_common import NetworkDeviceCommon, MSG_TECHNO_VERSIONED
@@ -56,12 +56,11 @@ class ModuleCheckPoint(NetworkDeviceCommon):
                 continue
 
             if response.is_success:
-                soup = BeautifulSoup(response.content, 'html.parser')
-                scripts = soup.find_all('script')
-                for script in scripts:
-                    if script.has_attr('src') and script['src'].endswith('/login/login.js'):
-                        self.version = await self.detect_checkpoint_version(response.content)
-                        return True
+                page = Html(response.content, full_url)
+                if any(url.endswith('/login/login.js') for url in page.scripts):
+                    self.version = await self.detect_checkpoint_version(response.content, full_url)
+                    return True
+                for script in page.soup.find_all('script', src=False):
                     if script.string and "realmsArrJSON =" in script.string:
                         return True
                 if 'Check Point Software Technologies Ltd' in response.content:
@@ -69,10 +68,10 @@ class ModuleCheckPoint(NetworkDeviceCommon):
 
         return False
 
-    async def detect_checkpoint_version(self, response_content):
+    async def detect_checkpoint_version(self, response_content, url: str = ""):
         version = []
-        soup = BeautifulSoup(response_content, 'html.parser')
-        scripts = [script for script in soup.find_all('script') if not script.has_attr('src')]
+        page = Html(response_content, url)
+        scripts = page.soup.find_all('script', src=False)
         for script in scripts:
             if script.string:
                 # Define the pattern to match the version variable

--- a/wapitiCore/attack/network_devices/mod_citrix.py
+++ b/wapitiCore/attack/network_devices/mod_citrix.py
@@ -22,7 +22,7 @@ import re
 from typing import Optional
 from urllib.parse import urljoin
 
-from bs4 import BeautifulSoup
+from wapitiCore.parsers.html_parser import Html
 from httpx import RequestError
 
 from wapitiCore.attack.attack import Attack
@@ -54,13 +54,13 @@ class ModuleCitrix(Attack):
                 continue
 
             if response.is_success:
-                return await self.detect_citrix_product(response.content)
+                return await self.detect_citrix_product(response.content, full_url)
 
         return False
 
-    async def detect_citrix_product(self, response_content):
-        soup = BeautifulSoup(response_content, 'html.parser')
-        title_tag = soup.title
+    async def detect_citrix_product(self, response_content, url: str = ""):
+        page = Html(response_content, url)
+        title_tag = page.soup.title
         # If title tag exists and has a class attribute
         if title_tag:
             if 'class' in title_tag.attrs:

--- a/wapitiCore/attack/network_devices/mod_citrix.py
+++ b/wapitiCore/attack/network_devices/mod_citrix.py
@@ -83,7 +83,7 @@ class ModuleCitrix(Attack):
 
                 if "NetScaler" in title:
                     # Search the product name in the content
-                    matches = soup.find_all(
+                    matches = page.soup.find_all(
                         "span",
                         string=re.compile(r"^(NetScaler ADC|Citrix NetScaler|NetScaler|NetScaler AWS)$")
                     )

--- a/wapitiCore/attack/network_devices/mod_forti.py
+++ b/wapitiCore/attack/network_devices/mod_forti.py
@@ -24,7 +24,7 @@ from urllib.parse import urljoin
 from string import ascii_lowercase
 import random
 
-from bs4 import BeautifulSoup
+from wapitiCore.parsers.html_parser import Html
 from httpx import RequestError
 
 from wapitiCore.attack.network_devices.network_device_common import NetworkDeviceCommon, MSG_TECHNO_VERSIONED
@@ -68,8 +68,8 @@ class ModuleForti(NetworkDeviceCommon):
             self.network_errors += 1
             raise
         if response.is_success:
-            soup = BeautifulSoup(response.content, 'html.parser')
-            for tag in soup.find_all(True):
+            page = Html(response.content, url_fortimail)
+            for tag in page.soup.find_all(True):
                 if tag.string:
                     match = self.fortinet_pattern.search(tag.text)
                     if match:
@@ -87,15 +87,13 @@ class ModuleForti(NetworkDeviceCommon):
             self.network_errors += 1
             raise
         if response.is_success:
-            soup = BeautifulSoup(response.content, 'html.parser')
-            title_tag = soup.title
-            sign_in_header_div = soup.find('div', class_='sign-in-header')
+            page = Html(response.content, url_fortimanager)
+            sign_in_header_div = page.soup.find('div', class_='sign-in-header')
 
             for device_name in ["FortiManager", "FortiAnalyzer"]:
-                if title_tag and title_tag.string:
-                    if device_name in title_tag.string:
-                        self.device_name = device_name
-                        return True
+                if device_name in page.title:
+                    self.device_name = device_name
+                    return True
                 # if custom title without Forti*, we check for specific div
                 if sign_in_header_div and device_name in sign_in_header_div.text:
                     self.device_name = device_name
@@ -133,20 +131,12 @@ class ModuleForti(NetworkDeviceCommon):
         except RequestError:
             self.network_errors += 1
             raise
-        soup = BeautifulSoup(response.content, 'html.parser')
+        page = Html(response.content, url)
 
-        # Get the title of the webpage
-        title_tag = soup.title
-        if title_tag and title_tag.string:
-            title = title_tag.string
-
-            # Search for the pattern in the title
-            match = self.fortinet_pattern.search(title)
-
-            if match:
-                # Extract the matched product name
-                self.device_name = match.group()
-                return True
+        match = self.fortinet_pattern.search(page.title)
+        if match:
+            self.device_name = match.group()
+            return True
         if 'class="main-app"' in response.content:
             return True
 

--- a/wapitiCore/attack/network_devices/mod_ivanti.py
+++ b/wapitiCore/attack/network_devices/mod_ivanti.py
@@ -36,6 +36,7 @@ MSG_IVANTI_SERVICE_MANAGER = "Ivanti Service Manager Detected"
 MSG_NO_IVANTI_SERVICE_MANAGER = "No Ivanti Service Manager Detected"
 MSG_IVANTI_USER_PORTAL = "Ivanti User Portal Detected"
 MSG_NO_IVANTI_USER_PORTAL = "No Ivanti User Portal"
+MSG_NO_IVANTI = "No Ivanti Product Detected"
 
 class ModuleIvanti(NetworkDeviceCommon):
     """Detect Ivanti."""
@@ -54,8 +55,9 @@ class ModuleIvanti(NetworkDeviceCommon):
                 raise
             page = Html(response.content, full_url)
             frmLogin = page.soup.find(name="frmLogin")
-            return response.is_success and "Ivanti Connect Secure" in page.title \
-                or frmLogin is not None
+            if response.is_success and ("Ivanti Connect Secure" in page.title or frmLogin is not None):
+                return True
+        return False
 
 
     async def check_ivanti_service_manager(self, url):
@@ -83,7 +85,7 @@ class ModuleIvanti(NetworkDeviceCommon):
                 return True
             if '/lib/RespondJs/respond.min.js' in response.content:
                 return True
-            return False
+        return False
 
     async def check_ivanti_user_portal(self, url):
         check_list = ['mifs/user/login.jsp','']
@@ -101,11 +103,9 @@ class ModuleIvanti(NetworkDeviceCommon):
                     "Ivanti Admin Portal"]:
                 return True
             h1_tag = page.soup.h1
-            if h1_tag:
-                if response.is_success and "MI_LOGIN_SCREEN" in h1_tag.text.strip():
-                    return True
-            else:
-                return False
+            if h1_tag and response.is_success and "MI_LOGIN_SCREEN" in h1_tag.text.strip():
+                return True
+        return False
 
     async def attack(self, request: Request, response: Optional[Response] = None):
         self.finished = True
@@ -115,20 +115,14 @@ class ModuleIvanti(NetworkDeviceCommon):
             if await self.check_ivanti_connect_secure(request_to_root.url):
                 self.device_name = "Ivanti Connect Secure"
                 log_blue(MSG_IVANTI_CONNECT)
-            else:
-                log_blue(MSG_NO_IVANTI_CONNECT)
-
-            if await self.check_ivanti_service_manager(request_to_root.url):
+            elif await self.check_ivanti_service_manager(request_to_root.url):
                 self.device_name = "Ivanti Service Manager"
                 log_blue(MSG_IVANTI_SERVICE_MANAGER)
-            else:
-                log_blue(MSG_NO_IVANTI_SERVICE_MANAGER)
-
-            if await self.check_ivanti_user_portal(request_to_root.url):
+            elif await self.check_ivanti_user_portal(request_to_root.url):
                 self.device_name = "Ivanti User Portal"
                 log_blue(MSG_IVANTI_USER_PORTAL)
             else:
-                log_blue(MSG_NO_IVANTI_USER_PORTAL)
+                log_blue(MSG_NO_IVANTI)
 
             if self.device_name:
                 ivanti_detected = {

--- a/wapitiCore/attack/network_devices/mod_ivanti.py
+++ b/wapitiCore/attack/network_devices/mod_ivanti.py
@@ -21,7 +21,7 @@ import json
 from typing import Optional
 from urllib.parse import urljoin
 
-from bs4 import BeautifulSoup
+from wapitiCore.parsers.html_parser import Html
 from httpx import RequestError
 
 from wapitiCore.attack.network_devices.network_device_common import NetworkDeviceCommon
@@ -52,10 +52,9 @@ class ModuleIvanti(NetworkDeviceCommon):
             except RequestError:
                 self.network_errors += 1
                 raise
-            soup = BeautifulSoup(response.content, 'html.parser')
-            title_tag = soup.title
-            frmLogin = soup.find(name="frmLogin")
-            return response.is_success and (title_tag and "Ivanti Connect Secure" in title_tag.text.strip()) \
+            page = Html(response.content, full_url)
+            frmLogin = page.soup.find(name="frmLogin")
+            return response.is_success and "Ivanti Connect Secure" in page.title \
                 or frmLogin is not None
 
 
@@ -76,16 +75,13 @@ class ModuleIvanti(NetworkDeviceCommon):
             except RequestError:
                 self.network_errors += 1
                 raise
-            soup = BeautifulSoup(response.content, 'html.parser')
-            title_tag = soup.title
-            h1_tag = soup.h1
-            if title_tag:
-                if response.is_success and "Ivanti Service Manager" in title_tag.text.strip():
-                    return True
-            if h1_tag:
-                if response.is_success and "Ivanti Service Manager" in h1_tag.text.strip():
-                    return True
-            if '/lib/RespondJs/respond.min.js' in str(soup):
+            page = Html(response.content, full_url)
+            if response.is_success and "Ivanti Service Manager" in page.title:
+                return True
+            h1_tag = page.soup.h1
+            if h1_tag and response.is_success and "Ivanti Service Manager" in h1_tag.text.strip():
+                return True
+            if '/lib/RespondJs/respond.min.js' in response.content:
                 return True
             return False
 
@@ -99,14 +95,12 @@ class ModuleIvanti(NetworkDeviceCommon):
             except RequestError:
                 self.network_errors += 1
                 raise
-            soup = BeautifulSoup(response.content, 'html.parser')
-            title_tag = soup.title
-            h1_tag = soup.h1
-            if title_tag:
-                if response.is_success and title_tag.text.strip() in ["Ivanti User Portal",
+            page = Html(response.content, full_url)
+            if response.is_success and page.title in ["Ivanti User Portal",
                     "Ivanti Portail utilisateur",
                     "Ivanti Admin Portal"]:
-                    return True
+                return True
+            h1_tag = page.soup.h1
             if h1_tag:
                 if response.is_success and "MI_LOGIN_SCREEN" in h1_tag.text.strip():
                     return True

--- a/wapitiCore/attack/network_devices/mod_paloalto.py
+++ b/wapitiCore/attack/network_devices/mod_paloalto.py
@@ -88,6 +88,7 @@ class ModulePaloAlto(NetworkDeviceCommon):
             'js/Pan.js',
             'global-protect/portal/images/bg.png'
         ]
+        version_table = self.load_version_table()
         for item in check_list:
             full_url = urljoin(url, item)
             request = Request(full_url, 'GET')
@@ -96,9 +97,8 @@ class ModulePaloAlto(NetworkDeviceCommon):
             except RequestError:
                 self.network_errors += 1
                 continue
-            version_table= self.load_version_table()
-            fullEtag=response.headers.get("Etag")
-            if(fullEtag and len(fullEtag)>=8):
+            fullEtag = response.headers.get("Etag")
+            if fullEtag and len(fullEtag) >= 8:
                 if '-' in fullEtag:
                     shortenEtag = fullEtag.split('-', 1)[0]
                 else:
@@ -106,8 +106,12 @@ class ModulePaloAlto(NetworkDeviceCommon):
                 # https://developer.mozilla.org/fr/docs/Web/HTTP/Reference/Headers/ETag
                 if shortenEtag.startswith("W/\""):
                     shortenEtag = shortenEtag[3:]
-                date = datetime.fromtimestamp(int(shortenEtag,16),timezone.utc).date()
-                self.version = self.check_date(version_table,date)
+                try:
+                    date = datetime.fromtimestamp(int(shortenEtag, 16), timezone.utc).date()
+                except (ValueError, OverflowError, OSError):
+                    logging.warning(f"Could not parse ETag value as timestamp: {shortenEtag!r}")
+                    continue
+                self.version = self.check_date(version_table, date)
                 return True
         return False
 

--- a/wapitiCore/attack/network_devices/mod_paloalto.py
+++ b/wapitiCore/attack/network_devices/mod_paloalto.py
@@ -22,7 +22,7 @@ from os.path import join as path_join
 from typing import Optional
 from urllib.parse import urljoin
 from datetime import datetime, timezone
-from bs4 import BeautifulSoup
+from wapitiCore.parsers.html_parser import Html
 from httpx import RequestError
 
 from wapitiCore.attack.network_devices.network_device_common import NetworkDeviceCommon, MSG_TECHNO_VERSIONED
@@ -67,15 +67,14 @@ class ModulePaloAlto(NetworkDeviceCommon):
             except RequestError:
                 self.network_errors += 1
                 continue
-            soup = BeautifulSoup(response.content, 'html.parser')
-            title_tag = soup.title
-            div_header = soup.find(id="heading")
+            page = Html(response.content, full_url)
+            div_header = page.soup.find(id="heading")
             if response.is_success:
-                if title_tag and "GlobalProtect Portal" in title_tag.text.strip():
+                if "GlobalProtect Portal" in page.title:
                     return True
                 elif div_header and "GlobalProtect Portal" in div_header.text.strip():
                     return True
-                elif soup.pan_form is not None:
+                elif page.soup.pan_form is not None:
                     return True
 
         return False

--- a/wapitiCore/attack/network_devices/mod_ubika.py
+++ b/wapitiCore/attack/network_devices/mod_ubika.py
@@ -21,7 +21,7 @@ import json
 from typing import Optional
 from urllib.parse import urljoin
 
-from bs4 import BeautifulSoup
+from wapitiCore.parsers.html_parser import Html
 from httpx import RequestError
 
 from wapitiCore.attack.network_devices.network_device_common import NetworkDeviceCommon, MSG_TECHNO_VERSIONED
@@ -47,9 +47,8 @@ class ModuleUbika(NetworkDeviceCommon):
             except RequestError:
                 self.network_errors += 1
                 raise
-            soup = BeautifulSoup(response.content, 'html.parser')
-            title_tag = soup.title
-            return response.is_success and title_tag and "UBIKA" in title_tag.text.strip()
+            page = Html(response.content, full_url)
+            return response.is_success and "UBIKA" in page.title
 
     async def get_ubika_version(self, url):
         versions = []

--- a/wapitiCore/data/attacks/execPayloads.ini
+++ b/wapitiCore/data/attacks/execPayloads.ini
@@ -20,7 +20,7 @@ status = vulnerability
 
 [semicolon_escape]
 payload = ;env;
-rules = regex:(?s)(?=.*PATH=[^=]*)(?=.*PWD=[^=]*)(?=.*HOME=[^=]*)
+rules = regex:(?s)(?=.*PATH=[^=]*)(?=.*PWD=[^=]*)(?=.*(HOME|HOSTNAME)=[^=]*)
 description = Command execution
 status = vulnerability
 
@@ -32,19 +32,19 @@ status = vulnerability
 
 [pipe_escape]
 payload = |env
-rules = regex:(?s)(?=.*PATH=[^=]*)(?=.*PWD=[^=]*)(?=.*HOME=[^=]*)
+rules = regex:(?s)(?=.*PATH=[^=]*)(?=.*PWD=[^=]*)(?=.*(HOME|HOSTNAME)=[^=]*)
 description = Command execution
 status = vulnerability
 
 [double_ampersand_escape]
 payload = &&env
-rules = regex:(?s)(?=.*PATH=[^=]*)(?=.*PWD=[^=]*)(?=.*HOME=[^=]*)
+rules = regex:(?s)(?=.*PATH=[^=]*)(?=.*PWD=[^=]*)(?=.*(HOME|HOSTNAME)=[^=]*)
 description = Command execution
 status = vulnerability
 
 [pipe_escape_known_prefix]
 payload = [VALUE]|env
-rules = regex:(?s)(?=.*PATH=[^=]*)(?=.*PWD=[^=]*)(?=.*HOME=[^=]*)
+rules = regex:(?s)(?=.*PATH=[^=]*)(?=.*PWD=[^=]*)(?=.*(HOME|HOSTNAME)=[^=]*)
 description = Command execution
 status = vulnerability
 
@@ -56,49 +56,49 @@ status = vulnerability
 
 [semicolon_escape_prefix]
 payload = a;env;
-rules = regex:(?s)(?=.*PATH=[^=]*)(?=.*PWD=[^=]*)(?=.*HOME=[^=]*)
+rules = regex:(?s)(?=.*PATH=[^=]*)(?=.*PWD=[^=]*)(?=.*(HOME|HOSTNAME)=[^=]*)
 description = Command execution
 status = vulnerability
 
 [semicolon_escape_prefix_and_parenthesis]
 payload = a;env;
-rules = regex:(?s)(?=.*PATH=[^=]*)(?=.*PWD=[^=]*)(?=.*HOME=[^=]*)
+rules = regex:(?s)(?=.*PATH=[^=]*)(?=.*PWD=[^=]*)(?=.*(HOME|HOSTNAME)=[^=]*)
 description = Command execution
 status = vulnerability
 
 [dir_up_perl_exec]
 payload = ../../../../../../../../../../../../../../../usr/bin/env|
-rules = regex:(?s)(?=.*PATH=[^=]*)(?=.*PWD=[^=]*)(?=.*HOME=[^=]*)
+rules = regex:(?s)(?=.*PATH=[^=]*)(?=.*PWD=[^=]*)(?=.*(HOME|HOSTNAME)=[^=]*)
 description = Command execution
 status = vulnerability
 
 [semicolon_escape_known_prefix]
 payload = [VALUE];env;
-rules = regex:(?s)(?=.*PATH=[^=]*)(?=.*PWD=[^=]*)(?=.*HOME=[^=]*)
+rules = regex:(?s)(?=.*PATH=[^=]*)(?=.*PWD=[^=]*)(?=.*(HOME|HOSTNAME)=[^=]*)
 description = Command execution
 status = vulnerability
 
 [new_line_escape]
 payload = [VALUE][LF]env;
-rules = regex:(?s)(?=.*PATH=[^=]*)(?=.*PWD=[^=]*)(?=.*HOME=[^=]*)
+rules = regex:(?s)(?=.*PATH=[^=]*)(?=.*PWD=[^=]*)(?=.*(HOME|HOSTNAME)=[^=]*)
 description = Command execution
 status = vulnerability
 
 [ampersand_escape]
 payload = &set&
-rules = regex:(?s)(?=.*PATH=[^=]*)(?=.*PWD=[^=]*)(?=.*HOME=[^=]*)
+rules = regex:(?s)(?=.*PATH=[^=]*)(?=.*PWD=[^=]*)(?=.*(HOME|HOSTNAME)=[^=]*)
 description = Command execution
 status = vulnerability
 
 [simple_set_execution]
 payload = set
-rules = regex:(?s)(?=.*PATH=[^=]*)(?=.*PWD=[^=]*)(?=.*HOME=[^=]*)
+rules = regex:(?s)(?=.*PATH=[^=]*)(?=.*PWD=[^=]*)(?=.*(HOME|HOSTNAME)=[^=]*)
 description = Command execution
 status = vulnerability
 
 [simple_env_execution]
 payload = env
-rules = regex:(?s)(?=.*PATH=[^=]*)(?=.*PWD=[^=]*)(?=.*HOME=[^=]*)
+rules = regex:(?s)(?=.*PATH=[^=]*)(?=.*PWD=[^=]*)(?=.*(HOME|HOSTNAME)=[^=]*)
 description = Command execution
 status = vulnerability
 

--- a/wapitiCore/data/attacks/execPayloads.ini
+++ b/wapitiCore/data/attacks/execPayloads.ini
@@ -8,99 +8,97 @@ type = pattern
 
 [no_escape]
 payload = id
-rules = regex:uid=[0-9]+\([a-zA-Z0-9_-]+\)\s+gid=[0-9]+\([a-zA-Z0-9_-]+\)\s+groups=[0-9]+\([a-zA-Z0-9_-]+\)(,[0-9]+\([a-zA-Z0-9_-]+\))*\s*(context=\S+)?\s*
+rules = regex:uid=[0-9]+\([a-zA-Z0-9_-]+\)\s+gid=[0-9]+\([a-zA-Z0-9_-]+\)(\s+groups=[0-9]+\([a-zA-Z0-9_-]+\)(,[0-9]+\([a-zA-Z0-9_-]+\))*)?(\s+context=\S+)?
 description = Command execution
 status = vulnerability
 
 [no_escape_owasp_benchmark]
 payload = id
-rules = regex:uid&#x3d;[0-9]+\([a-zA-Z0-9_-]+\)\s+gid&#x3d;[0-9]+\([a-zA-Z0-9_-]+\)\s+groups&#x3d;[0-9]+\([a-zA-Z0-9_-]+\)(,&#x3d;[0-9]+\([a-zA-Z0-9_-]+\))*\s*(context&#x3d;\S+)?\s*
+rules = regex:uid&#x3d;[0-9]+\([a-zA-Z0-9_-]+\)\s+gid&#x3d;[0-9]+\([a-zA-Z0-9_-]+\)(\s+groups&#x3d;[0-9]+\([a-zA-Z0-9_-]+\)(,[0-9]+\([a-zA-Z0-9_-]+\))*)?(\s+context&#x3d;\S+)?
 description = Command execution
 status = vulnerability
 
 [semicolon_escape]
 payload = ;env;
-rules = regex:(?s)(?=.*PATH=[^=]*)(?=.*PWD=[^=]*)(?=.*(HOME|HOSTNAME)=[^=]*)
+rules = regex:(?s)(?=.*PATH=[^=]*)(?=.*PWD=[^=]*)(?=.*HOME=[^=]*)
 description = Command execution
 status = vulnerability
 
 [semicolon_escape_owasp_benchmark]
 payload = ;env;
-rules = PATH&#x3d;
-    PWD&#x3d;
+rules = regex:(?s)(?=.*PATH&#x3d;)(?=.*PWD&#x3d;)(?=.*HOME&#x3d;)
 description = Command execution
 status = vulnerability
 
 [pipe_escape]
 payload = |env
-rules = regex:(?s)(?=.*PATH=[^=]*)(?=.*PWD=[^=]*)(?=.*(HOME|HOSTNAME)=[^=]*)
+rules = regex:(?s)(?=.*PATH=[^=]*)(?=.*PWD=[^=]*)(?=.*HOME=[^=]*)
 description = Command execution
 status = vulnerability
 
 [double_ampersand_escape]
 payload = &&env
-rules = regex:(?s)(?=.*PATH=[^=]*)(?=.*PWD=[^=]*)(?=.*(HOME|HOSTNAME)=[^=]*)
+rules = regex:(?s)(?=.*PATH=[^=]*)(?=.*PWD=[^=]*)(?=.*HOME=[^=]*)
 description = Command execution
 status = vulnerability
 
 [pipe_escape_known_prefix]
 payload = [VALUE]|env
-rules = regex:(?s)(?=.*PATH=[^=]*)(?=.*PWD=[^=]*)(?=.*(HOME|HOSTNAME)=[^=]*)
+rules = regex:(?s)(?=.*PATH=[^=]*)(?=.*PWD=[^=]*)(?=.*HOME=[^=]*)
 description = Command execution
 status = vulnerability
 
 [pipe_escape_known_prefix_owasp_benchmark]
 payload = [VALUE]|env
-rules = PWD&#x3d;
-    PATH&#x3d;
+rules = regex:(?s)(?=.*PATH&#x3d;)(?=.*PWD&#x3d;)(?=.*HOME&#x3d;)
 description = Command execution
 status = vulnerability
 
 [semicolon_escape_prefix]
 payload = a;env;
-rules = regex:(?s)(?=.*PATH=[^=]*)(?=.*PWD=[^=]*)(?=.*(HOME|HOSTNAME)=[^=]*)
+rules = regex:(?s)(?=.*PATH=[^=]*)(?=.*PWD=[^=]*)(?=.*HOME=[^=]*)
 description = Command execution
 status = vulnerability
 
 [semicolon_escape_prefix_and_parenthesis]
 payload = a;env;
-rules = regex:(?s)(?=.*PATH=[^=]*)(?=.*PWD=[^=]*)(?=.*(HOME|HOSTNAME)=[^=]*)
+rules = regex:(?s)(?=.*PATH=[^=]*)(?=.*PWD=[^=]*)(?=.*HOME=[^=]*)
 description = Command execution
 status = vulnerability
 
 [dir_up_perl_exec]
 payload = ../../../../../../../../../../../../../../../usr/bin/env|
-rules = regex:(?s)(?=.*PATH=[^=]*)(?=.*PWD=[^=]*)(?=.*(HOME|HOSTNAME)=[^=]*)
+rules = regex:(?s)(?=.*PATH=[^=]*)(?=.*PWD=[^=]*)(?=.*HOME=[^=]*)
 description = Command execution
 status = vulnerability
 
 [semicolon_escape_known_prefix]
 payload = [VALUE];env;
-rules = regex:(?s)(?=.*PATH=[^=]*)(?=.*PWD=[^=]*)(?=.*(HOME|HOSTNAME)=[^=]*)
+rules = regex:(?s)(?=.*PATH=[^=]*)(?=.*PWD=[^=]*)(?=.*HOME=[^=]*)
 description = Command execution
 status = vulnerability
 
 [new_line_escape]
 payload = [VALUE][LF]env;
-rules = regex:(?s)(?=.*PATH=[^=]*)(?=.*PWD=[^=]*)(?=.*(HOME|HOSTNAME)=[^=]*)
+rules = regex:(?s)(?=.*PATH=[^=]*)(?=.*PWD=[^=]*)(?=.*HOME=[^=]*)
 description = Command execution
 status = vulnerability
 
 [ampersand_escape]
 payload = &set&
-rules = regex:(?s)(?=.*PATH=[^=]*)(?=.*PWD=[^=]*)(?=.*(HOME|HOSTNAME)=[^=]*)
+rules = regex:(?s)(?=.*PATH=[^=]*)(?=.*PWD=[^=]*)(?=.*HOME=[^=]*)
 description = Command execution
 status = vulnerability
 
 [simple_set_execution]
 payload = set
-rules = regex:(?s)(?=.*PATH=[^=]*)(?=.*PWD=[^=]*)(?=.*(HOME|HOSTNAME)=[^=]*)
+rules = regex:(?s)(?=.*PATH=[^=]*)(?=.*PWD=[^=]*)(?=.*HOME=[^=]*)
 description = Command execution
 status = vulnerability
 
 [simple_env_execution]
 payload = env
-rules = regex:(?s)(?=.*PATH=[^=]*)(?=.*PWD=[^=]*)(?=.*(HOME|HOSTNAME)=[^=]*)
+rules = regex:(?s)(?=.*PATH=[^=]*)(?=.*PWD=[^=]*)(?=.*HOME=[^=]*)
 description = Command execution
 status = vulnerability
 

--- a/wapitiCore/data/attacks/xssPayloads.ini
+++ b/wapitiCore/data/attacks/xssPayloads.ini
@@ -123,27 +123,6 @@ attribute = onerror
 value = alert(/__XSS__/)
 case_sensitive = yes
 
-[object_data_alert_quote]
-payload = <object data="javascript:alert('__XSS__')">
-tag = object
-attribute = data
-value = javascript:alert('__XSS__')
-case_sensitive = yes
-
-[param_value_alert_quote]
-payload = <object data="JaVasCript:alert('__XSS__')">
-tag = object
-attribute = data
-value = JaVasCript:alert('__XSS__')
-case_sensitive = yes
-
-[param_value_alert_double_quote]
-payload = <object data='JaVasCript:alert("__XSS__")'>
-tag = object
-attribute = data
-value = JaVasCript:alert("__XSS__")
-case_sensitive = yes
-
 [iframe_src_javascript]
 payload = <iFrAme src="jAvasCript:alert(/__XSS__/);"></iframe>
 tag = iframe
@@ -171,13 +150,6 @@ payload = <embed src="data:text/html,<script>alert('__XSS__')</script>">
 tag = embed
 attribute = src
 value = data:text/html,<script>alert('__XSS__')</script>
-case_sensitive = yes
-
-[embed_src_javascript]
-payload = <embed src="javascript:alert('__XSS__')">
-tag = embed
-attribute = src
-value = javascript:alert('__XSS__')
 case_sensitive = yes
 
 [details_ontoggle]
@@ -289,13 +261,6 @@ payload = <ScRiPt[TAB]>alert(/__XSS__/)</sCrIpT[TAB]>
 tag = script
 attribute = full_string
 value = alert(/__XSS__/)
-case_sensitive = yes
-
-[tab_object_data_alert]
-payload = <object[TAB]data=javAscripT:alert(/__XSS__/)>
-tag = object
-attribute = data
-value = javascript:alert(/__XSS__/)
 case_sensitive = yes
 
 
@@ -533,13 +498,6 @@ attribute = action
 value = javascript:alert('__XSS__')
 case_sensitive = yes
 
-; base tag hijacking redirects all relative URLs on the page
-[base_href_javascript]
-payload = <base href="javascript:alert('__XSS__')////">
-tag = base
-attribute = href
-value = javascript:alert('__XSS__')////
-case_sensitive = yes
 
 ; No luck if we get here
 [script_jsfuck_alert_1]

--- a/wapitiCore/net/web.py
+++ b/wapitiCore/net/web.py
@@ -20,7 +20,7 @@
 from copy import deepcopy
 import posixpath
 import sys
-from urllib.parse import urlparse as _urlparse, urlunparse, unquote, quote, urljoin
+from urllib.parse import urlparse as _urlparse, urlunparse, unquote, quote, urljoin, ParseResult
 from typing import Optional, List, Tuple, Union, TYPE_CHECKING
 import re
 
@@ -34,7 +34,7 @@ if TYPE_CHECKING:
 Parameters = Optional[Union[List[List[str]], str]]
 
 
-def urlparse(url: str) -> str:
+def urlparse(url: str) -> ParseResult:
     url_parts = _urlparse(url)
 
     netloc = ""
@@ -47,7 +47,10 @@ def urlparse(url: str) -> str:
         netloc += "@"
 
     if url_parts.hostname is not None:
-        netloc += url_parts.hostname
+        if ":" in url_parts.hostname:  # IPv6 address — restore brackets
+            netloc += f"[{url_parts.hostname}]"
+        else:
+            netloc += url_parts.hostname
 
     if url_parts.port is not None:
         netloc += f":{url_parts.port}"


### PR DESCRIPTION
This PR addresses a series of bugs and code quality issues identified during an incremental review of recent commits.

### Bug fixes

**`mod_exec`**
- `_has_valid_file_extension` was comparing against the full URL instead of the path, causing the extension check to always fail on URLs with query strings.
- Removed the `_is_valid_content_type` filter — it introduced false negatives on dynamic endpoints that serve scripts under non-standard content types.

**`execPayloads.ini`**
- `[no_escape]` and `[no_escape_owasp_benchmark]`: made the `groups=` field optional so the rule matches Alpine/busybox `id` output (`uid=... gid=...` without groups).
- All `env`-based rules: removed `HOSTNAME` from the AND condition — `HOSTNAME` is not set in many container environments, causing false negatives.
- Two OWASP benchmark rules converted from multi-line OR to single-regex AND lookaheads for correctness.

**`mod_ivanti`**
- All three `check_*` methods had `return` statements inside `for` loops, exiting after the first URL regardless of the result.
- Fixed operator precedence in the `is_success and (... or ...)` condition.
- Replaced independent `if` blocks in `attack()` with `if/elif/elif/else` so only one product is reported.

**`mod_paloalto`**
- `load_version_table()` was called on every loop iteration instead of once before the loop.
- ETag-to-timestamp conversion could crash on non-hex or out-of-range values; now wrapped in `try/except` with a warning and `continue`.

**`mod_drupal_enum`**
- `plugins_file` parameter in `check_drupal_plugins` was accepted but never used.
- Plugin detection now runs concurrent requests bounded by `self.options["tasks"]` via `asyncio.Semaphore` instead of ~95 sequential ones.

**`mod_backup`**
- `asyncio.gather` fired all backup probes simultaneously with no concurrency limit. Requests are now bounded by `self.options["tasks"]` via `asyncio.Semaphore`.

**`mod_typo3_enum`**
- Probe request (`typo3_orange.svg`) in `check_typo3` had no `try/except RequestError` — exceptions propagated silently.
- `extensions_file` dead parameter removed; method now uses `self.PAYLOADS_FILE_EXTENSIONS` directly.
- `import os` removed (leaving a `NameError` on `os.path.join`); replaced with `from os.path import join as path_join`.
- `print()` calls replaced with `logging.error()`.

**`mod_magento_enum`**
- `get_url_hashes` return type annotation was `Tuple[str, str]` but the function implicitly returned `None` when the URL was out of scope. Corrected to `Optional[Tuple[str, str]]`.
- Variable shadowing in `detect_magento_version`: `[set(versions) for versions in versions.values()]` renamed loop variable to `version_list`.
- `print()` calls replaced with `logging.error()`.

**`mod_printer`**
- `_get_firmware_version_hp`: `root.find()` returns `None` when the XML tag is absent; accessing `.text` on it raised an unhandled `AttributeError`. Fixed with `if revision is not None and revision.text`.
- Removed a duplicate `test_get_firmware_version_unknown_brand` definition (Python silently kept only the second one).

**`urlparse` (`wapitiCore/net/web.py`)**
- `url_parts.hostname` strips brackets from IPv6 addresses, making the reconstructed `netloc` invalid (e.g. `::1:8080` instead of `[::1]:8080`). Brackets are now restored when the hostname contains a colon.
- Return type annotation corrected from `str` to `ParseResult`.

### XSS payload cleanup — empirically validated

Verified with Playwright (Chromium + Firefox) and Chrome that the following payloads **do not execute** in modern browsers and would produce false positives:
- `<embed src="javascript:...">` — blocked
- `<object data="javascript:...">` (all case variants + tab variant) — blocked
- `<base href="javascript:...">` — clicking a relative link yields a 404, no JS execution

`data:text/html` payloads (`iframe`, `object`, `embed`) and `iframe src=javascript:` were confirmed to execute and are kept.

### Refactoring

- Replaced direct `BeautifulSoup` instantiation with the `Html` wrapper class (`page.soup`, `page.title`, `page.scripts`) across all network device modules (`mod_forti`, `mod_checkpoint`, `mod_citrix`, `mod_ivanti`, `mod_ubika`, `mod_paloalto`) and CMS modules (`mod_magento_enum`, `mod_typo3_enum`).
- `find_all()` calls updated to use `src=True` / `href=True` for attribute-presence filtering where appropriate.
