### PR TITLE
fix(passive): cut false positives in redirection & path-disclosure

### DIFF
--- a/tests/attack/passive/test_mod_inconsistent_redirection.py
+++ b/tests/attack/passive/test_mod_inconsistent_redirection.py
@@ -38,6 +38,49 @@ def test_inconsistent_redirection_cases(status, content_type, body, expected_cou
     assert len(vulns) == expected_count
 
 
+def test_standard_object_moved_body_is_not_reported():
+    """The framework 'Object moved to <a href="target">here</a>' body whose
+    only link is the redirection target itself must not be flagged."""
+    module = ModuleInconsistentRedirection()
+    url = "https://example.com/PressReleasePage.aspx?PRID=2280153"
+    location = "/PressReleasePage.aspx?PRID=2280153&reg=48&lang=2"
+    body = (
+        b'<html><head><title>Object moved</title></head><body>\n'
+        b'<h2>Object moved to <a href="/PressReleasePage.aspx?PRID=2280153&amp;reg=48&amp;lang=2">here</a>.</h2>\n'
+        b'</body></html>'
+    )
+    response = Response(
+        response=httpx.Response(
+            status_code=302,
+            headers={"Content-Type": "text/html; charset=utf-8", "Location": location},
+            content=body,
+        ),
+        url=url,
+    )
+    assert len(list(module.analyze(Request(url), response))) == 0
+
+
+def test_redirect_body_with_extra_link_is_reported():
+    """A redirect body linking somewhere *other* than the target is the real
+    leak and must be reported."""
+    module = ModuleInconsistentRedirection()
+    url = "https://example.com/go"
+    location = "/target"
+    body = (
+        b'<html><body><a href="/target">here</a>'
+        b'<a href="/secret/panel">panel</a></body></html>'
+    )
+    response = Response(
+        response=httpx.Response(
+            status_code=302,
+            headers={"Content-Type": "text/html", "Location": location},
+            content=body,
+        ),
+        url=url,
+    )
+    assert len(list(module.analyze(Request(url), response))) == 1
+
+
 def test_inconsistent_redirection_deduplication():
     """Ensure same response md5 does not produce duplicate findings."""
     module = ModuleInconsistentRedirection()

--- a/tests/attack/passive/test_mod_information_disclosure.py
+++ b/tests/attack/passive/test_mod_information_disclosure.py
@@ -91,6 +91,41 @@ def test_no_path_disclosure(module):
     assert len(vulns) == 0
 
 
+def test_base64_blob_is_not_reported_as_path(module):
+    """A long base64 token (e.g. ASP.NET __VIEWSTATE) that happens to contain a
+    '/var/'-like chunk must not be reported as a system path."""
+    blob = (
+        "/9bff8dyxROWIg1Q5FY3kO0652nWbIMB9GmY7D07y3W5YP70OQDBnleJ8Q9yyTqUtCtIPeT"
+        "4AfhEUw9mjxssNwcC5nUJVaNwPKwfTS9qR0iO0VZZxmjYJ/var/ZxKzLojXRU2ET2LqU3Wq"
+        "HvHt2kbkoTdtu6z8l6BaWDHeVjtApfTtBBgzev3GFSQ3t9VNucw2p0nGTH/cRD9vdzLC857"
+    )
+    content = f'<input type="hidden" name="__VIEWSTATE" value="{blob}" />'
+    request, response = create_mock_objects(content)
+    vulns = list(get_all_vulnerabilities(module, request, response))
+    assert len(vulns) == 0
+
+
+def test_short_base64_with_keyword_segment_is_not_reported(module):
+    """A short base64 chunk (< length cap) with a keyword segment is still
+    rejected thanks to the base64-looking components."""
+    content = (
+        '{"token":"/aB3xK9mQ2wZ7pL5nR8vT1cY4dF6gHkS/var/Zx9Kq2Mw7Pl5Nr8Vt1Cy4Df6jU/config"}'
+    )
+    request, response = create_mock_objects(content, content_type="application/json")
+    vulns = list(get_all_vulnerabilities(module, request, response))
+    assert len(vulns) == 0
+
+
+def test_hex_and_uuid_path_components_still_reported(module):
+    """A genuine path with a hex-hash or UUID directory (lower-case + digits,
+    no upper-case) must still be reported."""
+    content = "cache miss at /opt/app/f47ac10b-58cc-4372-a567-0e02b2c3d479/data.log"
+    request, response = create_mock_objects(content)
+    vulns = list(get_all_vulnerabilities(module, request, response))
+    assert len(vulns) == 1
+    assert "f47ac10b-58cc-4372-a567-0e02b2c3d479" in vulns[0].info
+
+
 def test_no_path_disclosure_unsupported_content_type(module):
     """Test that no vulnerability is reported for unsupported content types."""
     content = "An error occurred in /var/www/html/index.php"

--- a/wapitiCore/attack/modules/passive/mod_inconsistent_redirection.py
+++ b/wapitiCore/attack/modules/passive/mod_inconsistent_redirection.py
@@ -1,4 +1,4 @@
-from typing import Generator, Any
+from typing import Generator, Any, Optional
 
 from wapitiCore.definitions.inconsistent_redirection import InconsistentRedirectionFinding
 from wapitiCore.language.vulnerability import MEDIUM_LEVEL
@@ -7,6 +7,13 @@ from wapitiCore.main.log import log_orange
 from wapitiCore.model.vulnerability import VulnerabilityInstance
 from wapitiCore.net import Request, Response
 from wapitiCore.parsers.html_parser import Html
+
+
+def _points_to_redirection_target(link: str, target: Optional[str]) -> bool:
+    """True when a body link is just the redirection destination itself."""
+    if target is None:
+        return False
+    return link.rstrip("/") == target.rstrip("/")
 
 
 class ModuleInconsistentRedirection:
@@ -33,7 +40,20 @@ class ModuleInconsistentRedirection:
 
         # Use Html parser to check if the body contains at least one link or form
         page = Html(response.content, request.url)
-        if not page.links and not list(page.iter_forms()):
+        forms = list(page.iter_forms())
+
+        # The standard framework redirect body (ASP.NET/IIS "Object moved to
+        # <a href="target">here</a>") only links to the redirection target
+        # itself: that is expected boilerplate, not leaked content. Only the
+        # links pointing *elsewhere* betray the real bug this module targets
+        # (e.g. a PHP header() not followed by die() that still emits a page).
+        target = response.redirection_url
+        meaningful_links = [
+            link for link in page.links
+            if not _points_to_redirection_target(link, target)
+        ]
+
+        if not meaningful_links and not forms:
             return
 
         # Deduplicate with response MD5

--- a/wapitiCore/attack/modules/passive/mod_information_disclosure.py
+++ b/wapitiCore/attack/modules/passive/mod_information_disclosure.py
@@ -24,6 +24,43 @@ PATH_PATTERN = re.compile(
     flags=re.IGNORECASE,
 )
 
+# A real disclosed filesystem path is short; giant matches are base64 / tokens
+# (e.g. an ASP.NET __VIEWSTATE) that merely happen to contain a "/keyword/"
+# chunk. These bounds discard such noise without trying to base64-decode.
+MAX_PATH_LENGTH = 255
+# Path components are short and human-readable. base64/hash chunks between two
+# slashes are long, so a very long component is a strong noise signal.
+MAX_SEGMENT_LENGTH = 40
+# Below this length a component is too short to confidently call base64 noise.
+MIN_BASE64_SEGMENT_LENGTH = 24
+
+
+def _looks_like_base64_segment(segment: str) -> bool:
+    """A long component mixing upper-case, lower-case and digits looks like a
+    base64/token chunk rather than a directory or file name. A hex hash or a
+    UUID (lower-case + digits, no upper-case) is intentionally *not* flagged."""
+    if len(segment) < MIN_BASE64_SEGMENT_LENGTH:
+        return False
+    return (
+        any(c.isupper() for c in segment)
+        and any(c.islower() for c in segment)
+        and any(c.isdigit() for c in segment)
+    )
+
+
+def _is_realistic_path(candidate: str) -> bool:
+    """Heuristics to tell an actual system path from base64/token noise that
+    happens to match PATH_PATTERN. No decoding is attempted."""
+    if len(candidate) > MAX_PATH_LENGTH:
+        return False
+    # "=" is base64 padding and never appears in a normal filesystem path.
+    if "=" in candidate:
+        return False
+    return not any(
+        len(segment) > MAX_SEGMENT_LENGTH or _looks_like_base64_segment(segment)
+        for segment in re.split(r"[/\\]", candidate)
+    )
+
 
 class ModuleInformationDisclosure:
     """
@@ -50,6 +87,9 @@ class ModuleInformationDisclosure:
 
         for match in PATH_PATTERN.finditer(response.content):
             evidence = match.group()
+            if not _is_realistic_path(evidence):
+                continue
+
             if evidence.rstrip(".") in self._reported_paths:
                 continue
 


### PR DESCRIPTION
fix(passive): cut false positives in redirection & path-disclosure modules

inconsistent_redirection: the standard framework redirect body (ASP.NET/IIS "Object moved to <a href="target">here</a>") links only to the redirection target and is benign boilerplate. Only report when the body exposes links or forms pointing somewhere *other* than the Location target — the real bug this module targets (e.g. a PHP header() not followed by die()).

information_disclosure: a long base64 token (e.g. an ASP.NET __VIEWSTATE) can contain a "/var/"-like chunk and get reported as a system path. Add structural realism heuristics (no base64 decoding): reject candidates over 255 chars, containing "=", or with an over-long / base64-looking component (long and mixing upper-case, lower-case and digits). Hex-hash and UUID directories (lower-case + digits, no upper-case) are preserved, and both path separators are handled so Windows paths like System32 are not misjudged.