### PR TITLE
fix: misc small fixes (root URL crash, dead reference links, cookie domain, XXE skip crash)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -53,3 +53,6 @@ tests/integration/.dump_diff_file.txt
 tests/integration/.docker-compose.final.yml
 tests/integration/.test/
 tests/integration/wapiti/behavior.json
+
+### scratch notes (drafts, issue replies, local todo lists...) ###
+/notes/

--- a/tests/attack/test_mod_xxe.py
+++ b/tests/attack/test_mod_xxe.py
@@ -195,6 +195,65 @@ async def test_out_of_band_param():
 
 @pytest.mark.asyncio
 @respx.mock
+async def test_out_of_band_param_skipped_does_not_crash():
+    """A parameter excluded via --skip must not crash finish() with StopIteration
+    when the endpoint still reports an OOB hit for it (GH issue #483)."""
+    respx.route(host="127.0.0.1").pass_through()
+
+    persister = AsyncMock()
+    request = Request("http://127.0.0.1:65084/xxe/outofband/param.php?foo=bar&vuln=yolo")
+    request.path_id = 7
+    persister.get_path_by_id.return_value = request
+    crawler_configuration = CrawlerConfiguration(Request("http://127.0.0.1:65084/"))
+    async with AsyncCrawler.with_configuration(crawler_configuration) as crawler:
+        options = {
+            "timeout": 10,
+            "level": 1,
+            "external_endpoint": "http://wapiti3.ovh/",
+            "internal_endpoint": "http://wapiti3.ovh/",
+            "skipped_parameters": {"vuln"}
+        }
+
+        module = ModuleXxe(crawler, persister, options, crawler_configuration)
+
+        respx.get("http://wapiti3.ovh/get_xxe.php?session_id=" + module._session_id).mock(
+            return_value=httpx.Response(
+                200,
+                json={
+                    "7": {
+                        "76756c6e": [
+                            {
+                                "date": "2019-08-17T16:52:41+00:00",
+                                "url": "https://wapiti3.ovh/xxe_data/yolo/7/76756c6e/31337-0-192.168.2.1.txt",
+                                "ip": "192.168.2.1",
+                                "size": 999,
+                                "payload": "linux2"
+                            }
+                        ]
+                    }
+                }
+            )
+        )
+
+        module.do_post = False
+        await module.attack(request)
+        calls_before_finish = persister.add_payload.call_count
+
+        # Must not raise RuntimeError("coroutine raised StopIteration"): the OOB
+        # endpoint reports a hit for "vuln", but that parameter is skipped, so the
+        # mutator that rebuilds the evil request for the report yields nothing.
+        await module.finish()
+
+        # finish() itself must not have reported anything for the skipped parameter
+        assert persister.add_payload.call_count == calls_before_finish
+        assert all(
+            call.kwargs.get("parameter") != "vuln"
+            for call in persister.add_payload.call_args_list
+        )
+
+
+@pytest.mark.asyncio
+@respx.mock
 async def test_out_of_band_query_string():
     respx.route(host="127.0.0.1").pass_through()
 

--- a/tests/net/test_jsoncookie.py
+++ b/tests/net/test_jsoncookie.py
@@ -121,6 +121,52 @@ async def test_jsoncookie():
 
 
 @pytest.mark.asyncio
+async def test_jsoncookie_dotless_local_hostname():
+    """A cookie saved (e.g. via wapiti-getcookie) for a dotless local hostname such as
+    "localhost" must be found back when reading it during the actual scan, using the
+    same domain the crawler would pass (the raw hostname, with no leading dot)."""
+    empty_cookie_path = "./empty_cookie.txt"
+    files = {
+        f'{empty_cookie_path}': "{}",
+    }
+
+    json_cookie = JsonCookie()
+    with mock.patch("builtins.open", get_mock_open(files)):
+        json_cookie.load(empty_cookie_path)
+
+    cookie = Cookie(
+        version=0,
+        name="SESSIONID",
+        value="df298788980e4793220097b8896b1a98",
+        port=None,
+        port_specified=False,
+        domain="localhost",
+        domain_specified=True,
+        domain_initial_dot=False,
+        path="/",
+        path_specified=True,
+        secure=True,
+        expires=None,
+        discard=True,
+        comment=None,
+        comment_url=None,
+        rest={'HttpOnly': None},
+        rfc2109=False
+    )
+    cookie_jar = CookieJar()
+    cookie_jar.set_cookie(cookie)
+
+    assert json_cookie.addcookies(cookie_jar) is not False
+    # addcookies() must apply the same ".local" normalization used for reading,
+    # otherwise the cookie is stored under a key cookiejar() will never look up.
+    assert ".localhost.local" in json_cookie.cookiedict
+
+    result_jar = json_cookie.cookiejar("localhost")
+    assert len(result_jar) == 1
+    assert list(result_jar)[0].value == "df298788980e4793220097b8896b1a98"
+
+
+@pytest.mark.asyncio
 async def test_exception_jsoncookie():
     json_cookie = JsonCookie()
 

--- a/tests/reports/data/report.json
+++ b/tests/reports/data/report.json
@@ -169,7 +169,7 @@
       "sol": "Implement X-Frame-Options or Content Security Policy (CSP) frame-ancestors directive.",
       "ref": {
         "OWASP: Clickjacking": "https://owasp.org/www-project-web-security-testing-guide/latest/4-Web_Application_Security_Testing/11-Client-side_Testing/09-Testing_for_Clickjacking",
-        "KeyCDN: Preventing Clickjacking": "https://www.keycdn.com/support/prevent-clickjacking"
+        "OWASP: Clickjacking Defense Cheat Sheet": "https://cheatsheetseries.owasp.org/cheatsheets/Clickjacking_Defense_Cheat_Sheet.html"
       },
       "wstg": [
         "OSHP-X-Frame-Options"
@@ -180,7 +180,7 @@
       "sol": "Implement the HTTP Strict Transport Security header to enforce secure connections to the server.",
       "ref": {
         "OWASP: HTTP Strict Transport Security": "https://owasp.org/www-project-web-security-testing-guide/latest/4-Web_Application_Security_Testing/02-Configuration_and_Deployment_Management_Testing/07-Test_HTTP_Strict_Transport_Security",
-        "KeyCDN: Enabling HSTS": "https://www.keycdn.com/support/hsts"
+        "OWASP: HTTP Strict Transport Security Cheat Sheet": "https://cheatsheetseries.owasp.org/cheatsheets/HTTP_Strict_Transport_Security_Cheat_Sheet.html"
       },
       "wstg": [
         "WSTG-CONF-07",

--- a/tests/reports/data/report.json
+++ b/tests/reports/data/report.json
@@ -191,8 +191,8 @@
       "desc": "MIME type confusion can occur when a browser interprets files as a different type than intended, which could lead to security vulnerabilities like cross-site scripting (XSS).",
       "sol": "Implement X-Content-Type-Options to prevent MIME type sniffing.",
       "ref": {
-        "OWASP: MIME Sniffing": "https://owasp.org/www-community/attacks/MIME_sniffing",
-        "KeyCDN: Preventing MIME Type Sniffing": "https://www.keycdn.com/support/preventing-mime-type-sniffing"
+        "OWASP: MIME Sniffing": "https://cheatsheetseries.owasp.org/cheatsheets/HTTP_Headers_Cheat_Sheet.html#x-content-type-options",
+        "Mozilla: MIME Sniffing": "https://developer.mozilla.org/en-US/docs/Web/HTTP/Guides/MIME_types#mime_sniffing"
       },
       "wstg": [
         "OSHP-X-Content-Type-Options"

--- a/tests/reports/data/report.xml
+++ b/tests/reports/data/report.xml
@@ -372,8 +372,8 @@
                </wstg>
             </reference>
             <reference>
-               <title>KeyCDN: Preventing Clickjacking</title>
-               <url>https://www.keycdn.com/support/prevent-clickjacking</url>
+               <title>OWASP: Clickjacking Defense Cheat Sheet</title>
+               <url>https://cheatsheetseries.owasp.org/cheatsheets/Clickjacking_Defense_Cheat_Sheet.html</url>
                <wstg>
                   <code>OSHP-X-Frame-Options</code>
                </wstg>
@@ -394,8 +394,8 @@
                </wstg>
             </reference>
             <reference>
-               <title>KeyCDN: Enabling HSTS</title>
-               <url>https://www.keycdn.com/support/hsts</url>
+               <title>OWASP: HTTP Strict Transport Security Cheat Sheet</title>
+               <url>https://cheatsheetseries.owasp.org/cheatsheets/HTTP_Strict_Transport_Security_Cheat_Sheet.html</url>
                <wstg>
                   <code>WSTG-CONF-07</code>
                   <code>OSHP-HTTP-Strict-Transport-Security</code>

--- a/tests/reports/data/report.xml
+++ b/tests/reports/data/report.xml
@@ -410,14 +410,14 @@
          <references>
             <reference>
                <title>OWASP: MIME Sniffing</title>
-               <url>https://owasp.org/www-community/attacks/MIME_sniffing</url>
+               <url>https://cheatsheetseries.owasp.org/cheatsheets/HTTP_Headers_Cheat_Sheet.html#x-content-type-options</url>
                <wstg>
                   <code>OSHP-X-Content-Type-Options</code>
                </wstg>
             </reference>
             <reference>
-               <title>KeyCDN: Preventing MIME Type Sniffing</title>
-               <url>https://www.keycdn.com/support/preventing-mime-type-sniffing</url>
+               <title>Mozilla: MIME Sniffing</title>
+               <url>https://developer.mozilla.org/en-US/docs/Web/HTTP/Guides/MIME_types#mime_sniffing</url>
                <wstg>
                   <code>OSHP-X-Content-Type-Options</code>
                </wstg>

--- a/tests/reports/data/report_level1.json
+++ b/tests/reports/data/report_level1.json
@@ -169,7 +169,7 @@
       "sol": "Implement X-Frame-Options or Content Security Policy (CSP) frame-ancestors directive.",
       "ref": {
         "OWASP: Clickjacking": "https://owasp.org/www-project-web-security-testing-guide/latest/4-Web_Application_Security_Testing/11-Client-side_Testing/09-Testing_for_Clickjacking",
-        "KeyCDN: Preventing Clickjacking": "https://www.keycdn.com/support/prevent-clickjacking"
+        "OWASP: Clickjacking Defense Cheat Sheet": "https://cheatsheetseries.owasp.org/cheatsheets/Clickjacking_Defense_Cheat_Sheet.html"
       },
       "wstg": [
         "OSHP-X-Frame-Options"
@@ -180,7 +180,7 @@
       "sol": "Implement the HTTP Strict Transport Security header to enforce secure connections to the server.",
       "ref": {
         "OWASP: HTTP Strict Transport Security": "https://owasp.org/www-project-web-security-testing-guide/latest/4-Web_Application_Security_Testing/02-Configuration_and_Deployment_Management_Testing/07-Test_HTTP_Strict_Transport_Security",
-        "KeyCDN: Enabling HSTS": "https://www.keycdn.com/support/hsts"
+        "OWASP: HTTP Strict Transport Security Cheat Sheet": "https://cheatsheetseries.owasp.org/cheatsheets/HTTP_Strict_Transport_Security_Cheat_Sheet.html"
       },
       "wstg": [
         "WSTG-CONF-07",

--- a/tests/reports/data/report_level1.json
+++ b/tests/reports/data/report_level1.json
@@ -191,8 +191,8 @@
       "desc": "MIME type confusion can occur when a browser interprets files as a different type than intended, which could lead to security vulnerabilities like cross-site scripting (XSS).",
       "sol": "Implement X-Content-Type-Options to prevent MIME type sniffing.",
       "ref": {
-        "OWASP: MIME Sniffing": "https://owasp.org/www-community/attacks/MIME_sniffing",
-        "KeyCDN: Preventing MIME Type Sniffing": "https://www.keycdn.com/support/preventing-mime-type-sniffing"
+        "OWASP: MIME Sniffing": "https://cheatsheetseries.owasp.org/cheatsheets/HTTP_Headers_Cheat_Sheet.html#x-content-type-options",
+        "Mozilla: MIME Sniffing": "https://developer.mozilla.org/en-US/docs/Web/HTTP/Guides/MIME_types#mime_sniffing"
       },
       "wstg": [
         "OSHP-X-Content-Type-Options"

--- a/tests/reports/data/report_level1.xml
+++ b/tests/reports/data/report_level1.xml
@@ -372,8 +372,8 @@
                </wstg>
             </reference>
             <reference>
-               <title>KeyCDN: Preventing Clickjacking</title>
-               <url>https://www.keycdn.com/support/prevent-clickjacking</url>
+               <title>OWASP: Clickjacking Defense Cheat Sheet</title>
+               <url>https://cheatsheetseries.owasp.org/cheatsheets/Clickjacking_Defense_Cheat_Sheet.html</url>
                <wstg>
                   <code>OSHP-X-Frame-Options</code>
                </wstg>
@@ -394,8 +394,8 @@
                </wstg>
             </reference>
             <reference>
-               <title>KeyCDN: Enabling HSTS</title>
-               <url>https://www.keycdn.com/support/hsts</url>
+               <title>OWASP: HTTP Strict Transport Security Cheat Sheet</title>
+               <url>https://cheatsheetseries.owasp.org/cheatsheets/HTTP_Strict_Transport_Security_Cheat_Sheet.html</url>
                <wstg>
                   <code>WSTG-CONF-07</code>
                   <code>OSHP-HTTP-Strict-Transport-Security</code>

--- a/tests/reports/data/report_level1.xml
+++ b/tests/reports/data/report_level1.xml
@@ -410,14 +410,14 @@
          <references>
             <reference>
                <title>OWASP: MIME Sniffing</title>
-               <url>https://owasp.org/www-community/attacks/MIME_sniffing</url>
+               <url>https://cheatsheetseries.owasp.org/cheatsheets/HTTP_Headers_Cheat_Sheet.html#x-content-type-options</url>
                <wstg>
                   <code>OSHP-X-Content-Type-Options</code>
                </wstg>
             </reference>
             <reference>
-               <title>KeyCDN: Preventing MIME Type Sniffing</title>
-               <url>https://www.keycdn.com/support/preventing-mime-type-sniffing</url>
+               <title>Mozilla: MIME Sniffing</title>
+               <url>https://developer.mozilla.org/en-US/docs/Web/HTTP/Guides/MIME_types#mime_sniffing</url>
                <wstg>
                   <code>OSHP-X-Content-Type-Options</code>
                </wstg>

--- a/tests/reports/data/report_level2.json
+++ b/tests/reports/data/report_level2.json
@@ -169,7 +169,7 @@
       "sol": "Implement X-Frame-Options or Content Security Policy (CSP) frame-ancestors directive.",
       "ref": {
         "OWASP: Clickjacking": "https://owasp.org/www-project-web-security-testing-guide/latest/4-Web_Application_Security_Testing/11-Client-side_Testing/09-Testing_for_Clickjacking",
-        "KeyCDN: Preventing Clickjacking": "https://www.keycdn.com/support/prevent-clickjacking"
+        "OWASP: Clickjacking Defense Cheat Sheet": "https://cheatsheetseries.owasp.org/cheatsheets/Clickjacking_Defense_Cheat_Sheet.html"
       },
       "wstg": [
         "OSHP-X-Frame-Options"
@@ -180,7 +180,7 @@
       "sol": "Implement the HTTP Strict Transport Security header to enforce secure connections to the server.",
       "ref": {
         "OWASP: HTTP Strict Transport Security": "https://owasp.org/www-project-web-security-testing-guide/latest/4-Web_Application_Security_Testing/02-Configuration_and_Deployment_Management_Testing/07-Test_HTTP_Strict_Transport_Security",
-        "KeyCDN: Enabling HSTS": "https://www.keycdn.com/support/hsts"
+        "OWASP: HTTP Strict Transport Security Cheat Sheet": "https://cheatsheetseries.owasp.org/cheatsheets/HTTP_Strict_Transport_Security_Cheat_Sheet.html"
       },
       "wstg": [
         "WSTG-CONF-07",

--- a/tests/reports/data/report_level2.json
+++ b/tests/reports/data/report_level2.json
@@ -191,8 +191,8 @@
       "desc": "MIME type confusion can occur when a browser interprets files as a different type than intended, which could lead to security vulnerabilities like cross-site scripting (XSS).",
       "sol": "Implement X-Content-Type-Options to prevent MIME type sniffing.",
       "ref": {
-        "OWASP: MIME Sniffing": "https://owasp.org/www-community/attacks/MIME_sniffing",
-        "KeyCDN: Preventing MIME Type Sniffing": "https://www.keycdn.com/support/preventing-mime-type-sniffing"
+        "OWASP: MIME Sniffing": "https://cheatsheetseries.owasp.org/cheatsheets/HTTP_Headers_Cheat_Sheet.html#x-content-type-options",
+        "Mozilla: MIME Sniffing": "https://developer.mozilla.org/en-US/docs/Web/HTTP/Guides/MIME_types#mime_sniffing"
       },
       "wstg": [
         "OSHP-X-Content-Type-Options"

--- a/tests/reports/data/report_level2.xml
+++ b/tests/reports/data/report_level2.xml
@@ -383,8 +383,8 @@
                </wstg>
             </reference>
             <reference>
-               <title>KeyCDN: Preventing Clickjacking</title>
-               <url>https://www.keycdn.com/support/prevent-clickjacking</url>
+               <title>OWASP: Clickjacking Defense Cheat Sheet</title>
+               <url>https://cheatsheetseries.owasp.org/cheatsheets/Clickjacking_Defense_Cheat_Sheet.html</url>
                <wstg>
                   <code>OSHP-X-Frame-Options</code>
                </wstg>
@@ -405,8 +405,8 @@
                </wstg>
             </reference>
             <reference>
-               <title>KeyCDN: Enabling HSTS</title>
-               <url>https://www.keycdn.com/support/hsts</url>
+               <title>OWASP: HTTP Strict Transport Security Cheat Sheet</title>
+               <url>https://cheatsheetseries.owasp.org/cheatsheets/HTTP_Strict_Transport_Security_Cheat_Sheet.html</url>
                <wstg>
                   <code>WSTG-CONF-07</code>
                   <code>OSHP-HTTP-Strict-Transport-Security</code>

--- a/tests/reports/data/report_level2.xml
+++ b/tests/reports/data/report_level2.xml
@@ -421,14 +421,14 @@
          <references>
             <reference>
                <title>OWASP: MIME Sniffing</title>
-               <url>https://owasp.org/www-community/attacks/MIME_sniffing</url>
+               <url>https://cheatsheetseries.owasp.org/cheatsheets/HTTP_Headers_Cheat_Sheet.html#x-content-type-options</url>
                <wstg>
                   <code>OSHP-X-Content-Type-Options</code>
                </wstg>
             </reference>
             <reference>
-               <title>KeyCDN: Preventing MIME Type Sniffing</title>
-               <url>https://www.keycdn.com/support/preventing-mime-type-sniffing</url>
+               <title>Mozilla: MIME Sniffing</title>
+               <url>https://developer.mozilla.org/en-US/docs/Web/HTTP/Guides/MIME_types#mime_sniffing</url>
                <wstg>
                   <code>OSHP-X-Content-Type-Options</code>
                </wstg>

--- a/tests/web/test_request.py
+++ b/tests/web/test_request.py
@@ -218,6 +218,12 @@ def test_request_headers():
             None
         ),
         (
+            # Root URL with no trailing slash and no path must not crash (issue #774)
+            Request("http://perdu.com"),
+            '''GET / HTTP/1.1''',
+            None
+        ),
+        (
             Request("http://perdu.com/", method="POST", post_params=[["foo", "bar"]]),
             '''POST / HTTP/1.1
     Content-Type: application/x-www-form-urlencoded

--- a/wapitiCore/attack/mod_xxe.py
+++ b/wapitiCore/attack/mod_xxe.py
@@ -378,13 +378,21 @@ class ModuleXxe(Attack):
                             skip=self.options.get("skipped_parameters")
                         )
 
-                        mutated_request, __, __ = next(mutator.mutate(original_request, [used_payload]))
+                        mutation = next(mutator.mutate(original_request, [used_payload]), None)
+                        if mutation is None:
+                            # The parameter is in --skip: the mutator won't reproduce the
+                            # evil request that actually triggered the OOB callback.
+                            continue
+                        mutated_request, __, __ = mutation
                     else:
                         mutator = XXEUploadMutator(
                             parameters=[parameter_name],
                             skip=self.options.get("skipped_parameters")
                         )
-                        mutated_request, __, __ = next(mutator.mutate(original_request, [used_payload]))
+                        mutation = next(mutator.mutate(original_request, [used_payload]), None)
+                        if mutation is None:
+                            continue
+                        mutated_request, __, __ = mutation
 
                     if request_size:
                         add_vuln_method = self.add_high

--- a/wapitiCore/attack/mod_xxe.py
+++ b/wapitiCore/attack/mod_xxe.py
@@ -378,21 +378,21 @@ class ModuleXxe(Attack):
                             skip=self.options.get("skipped_parameters")
                         )
 
-                        mutation = next(mutator.mutate(original_request, [used_payload]), None)
-                        if mutation is None:
+                        try:
+                            mutated_request, __, __ = next(mutator.mutate(original_request, [used_payload]))
+                        except StopIteration:
                             # The parameter is in --skip: the mutator won't reproduce the
                             # evil request that actually triggered the OOB callback.
                             continue
-                        mutated_request, __, __ = mutation
                     else:
                         mutator = XXEUploadMutator(
                             parameters=[parameter_name],
                             skip=self.options.get("skipped_parameters")
                         )
-                        mutation = next(mutator.mutate(original_request, [used_payload]), None)
-                        if mutation is None:
+                        try:
+                            mutated_request, __, __ = next(mutator.mutate(original_request, [used_payload]))
+                        except StopIteration:
                             continue
-                        mutated_request, __, __ = mutation
 
                     if request_size:
                         add_vuln_method = self.add_high

--- a/wapitiCore/definitions/http_headers.py
+++ b/wapitiCore/definitions/http_headers.py
@@ -46,8 +46,8 @@ class ClickjackingFinding(FindingBase):
                 )
             },
             {
-                "title": "KeyCDN: Preventing Clickjacking",
-                "url": "https://www.keycdn.com/support/prevent-clickjacking"
+                "title": "OWASP: Clickjacking Defense Cheat Sheet",
+                "url": "https://cheatsheetseries.owasp.org/cheatsheets/Clickjacking_Defense_Cheat_Sheet.html"
             }
         ]
 
@@ -135,8 +135,8 @@ class HstsFinding(FindingBase):
                     )
             },
             {
-                "title": "KeyCDN: Enabling HSTS",
-                "url": "https://www.keycdn.com/support/hsts"
+                "title": "OWASP: HTTP Strict Transport Security Cheat Sheet",
+                "url": "https://cheatsheetseries.owasp.org/cheatsheets/HTTP_Strict_Transport_Security_Cheat_Sheet.html"
             }
         ]
 

--- a/wapitiCore/definitions/http_headers.py
+++ b/wapitiCore/definitions/http_headers.py
@@ -85,11 +85,14 @@ class MimeTypeConfusionFinding(FindingBase):
         return [
             {
                 "title": "OWASP: MIME Sniffing",
-                "url": "https://owasp.org/www-community/attacks/MIME_sniffing"
+                "url": (
+                    "https://cheatsheetseries.owasp.org/cheatsheets/HTTP_Headers_Cheat_Sheet.html"
+                    "#x-content-type-options"
+                )
             },
             {
-                "title": "KeyCDN: Preventing MIME Type Sniffing",
-                "url": "https://www.keycdn.com/support/preventing-mime-type-sniffing"
+                "title": "Mozilla: MIME Sniffing",
+                "url": "https://developer.mozilla.org/en-US/docs/Web/HTTP/Guides/MIME_types#mime_sniffing"
             }
         ]
 

--- a/wapitiCore/net/jsoncookie.py
+++ b/wapitiCore/net/jsoncookie.py
@@ -54,7 +54,13 @@ class JsonCookie:
                 # Match either an IPv4 address or an IPv6 address with a local suffix
                 domain_key = search_ip.group("ip")
             else:
-                domain_key = cookie.domain if cookie.domain[0] == '.' else '.' + cookie.domain
+                domain = cookie.domain
+                # For hostnames on local network we must add a 'local' tld (needed by cookielib),
+                # same normalization as the one applied for reading in cookiejar()/delete(), otherwise
+                # a cookie saved for a dotless host (e.g. "localhost") is never found back on read.
+                if '.' not in domain.lstrip('.'):
+                    domain += ".local"
+                domain_key = domain if domain[0] == '.' else '.' + domain
 
             if domain_key not in self.cookiedict.keys():
                 self.cookiedict[domain_key] = {}

--- a/wapitiCore/net/web.py
+++ b/wapitiCore/net/web.py
@@ -800,7 +800,10 @@ def is_valid_url(url: str):
 
 
 def http_repr(request: Request, left_margin: str = "    ") -> str:
-    rel_url = request.url.split('/', 3)[3]
+    # A bare root URL (e.g. "http://host") has no "/" after the netloc, so
+    # split('/', 3) yields only 3 parts: treat it the same as "http://host/".
+    url_parts = request.url.split('/', 3)
+    rel_url = url_parts[3] if len(url_parts) > 3 else ""
     http_string = f"{left_margin}{request.method} /{rel_url} HTTP/1.1\n"
 
     headers_to_display = request.sent_headers if request.sent_headers is not None else request.headers


### PR DESCRIPTION
## Summary

Batch of small, independent fixes found while triaging open issues.

- **`wapitiCore/net/web.py`**: fix `IndexError` in `http_repr()` for a bare root URL with no trailing slash and no path (`request.url.split('/', 3)` only yields 3 parts). Fixes #774.
- **`wapitiCore/definitions/http_headers.py`**: replace dead `keycdn.com` links (Clickjacking, HSTS, MIME sniffing) with actively maintained OWASP Cheat Sheet Series / MDN references. Fixes #697 — supersedes #770 (same MIME-sniffing fix, folded in here along with the other two dead KeyCDN links it didn't cover).
- **`wapitiCore/net/jsoncookie.py`**: fix domain-matching asymmetry between `addcookies()` (write, used by `wapiti-getcookie`) and `cookiejar()`/`delete()` (read, used by the main scan) for dotless local hostnames like `localhost` — a cookie saved for such a host was written under a different key than the one looked up at scan time, so it was silently never sent. Fixes #691.
- **`wapitiCore/attack/mod_xxe.py`**: fix `RuntimeError: coroutine raised StopIteration` in `finish()` when the parameter that triggered an out-of-band XXE callback is excluded via `--skip` — the mutator used to rebuild the evil request for the report then yields nothing, and the unguarded `next()` call crashed the whole scan. Fixes #483.

Each fix includes a regression test. All were verified with real, reproducible scenarios (Docker containers, in one case using the project's own self-hosted OOB endpoint) before and after the fix — see individual commit messages for details.

## Test plan

- [x] Added/updated unit tests for each fix, all passing
- [x] Verified each fix against a live reproduction of the reported bug (see commit messages)
- [x] `pylint` clean on all touched files