### PR TITLE
Improve passive CSP module: unknown directives, frame-ancestors & form-action

### DIFF
--- a/tests/attack/passive/test_mod_csp.py
+++ b/tests/attack/passive/test_mod_csp.py
@@ -8,11 +8,16 @@ from wapitiCore.attack.modules.passive.mod_csp import (
     MSG_NO_CSP,
     MSG_CSP_MISSING,
     MSG_CSP_UNSAFE,
+    MSG_CSP_UNKNOWN,
 )
 from wapitiCore.definitions.csp import CspFinding
 from wapitiCore.language.vulnerability import MEDIUM_LEVEL, LOW_LEVEL
 from wapitiCore.net import Response, Request
-from wapitiCore.net.csp_utils import csp_header_to_dict, check_policy_values
+from wapitiCore.net.csp_utils import (
+    csp_header_to_dict,
+    check_policy_values,
+    find_unknown_directives,
+)
 
 # pylint: disable=redefined-outer-name
 
@@ -53,6 +58,41 @@ def test_bad_csp_examples():
 def test_missing_csp_directive():
     csp_dict = csp_header_to_dict("script-src 'self'")
     assert check_policy_values("default-src", csp_dict) == -1
+
+
+def test_no_fallback_directives_dont_use_default_src():
+    # base-uri, frame-ancestors and form-action have no fallback to default-src:
+    # they must be considered missing even when default-src is present.
+    csp_dict = csp_header_to_dict("default-src 'self'")
+    assert check_policy_values("base-uri", csp_dict) == -1
+    assert check_policy_values("frame-ancestors", csp_dict) == -1
+    assert check_policy_values("form-action", csp_dict) == -1
+    # A fetch directive like object-src still falls back to default-src
+    assert check_policy_values("object-src", csp_dict) == 0
+
+
+def test_valueless_directives_are_kept():
+    csp_dict = csp_header_to_dict("default-src 'none'; upgrade-insecure-requests")
+    assert csp_dict["upgrade-insecure-requests"] == []
+
+
+def test_directive_names_are_case_insensitive():
+    csp_dict = csp_header_to_dict("Default-Src 'none'; Script-SRC 'self'")
+    assert csp_dict.keys() == {"default-src", "script-src"}
+
+
+def test_orphan_value_is_not_treated_as_directive():
+    # A value left orphan by a misplaced semicolon must not become a directive
+    csp_dict = csp_header_to_dict("script-src 'self'; 'unsafe-eval'")
+    assert csp_dict.keys() == {"script-src"}
+
+
+def test_find_unknown_directives():
+    csp_dict = csp_header_to_dict("default-src 'none'; foobar-src 'self'; script-scr 'self'")
+    assert set(find_unknown_directives(csp_dict)) == {"foobar-src", "script-scr"}
+
+    csp_dict = csp_header_to_dict("default-src 'none'; frame-ancestors 'self'; upgrade-insecure-requests")
+    assert find_unknown_directives(csp_dict) == []
 
 
 @pytest.fixture
@@ -117,14 +157,20 @@ def get_all_vulnerabilities(module, request, response):
             [MSG_NO_CSP.format("http://example.com")],
             [LOW_LEVEL],
         ),
-        # CSP declared but object-src is missing
+        # CSP declared with default-src only: object-src falls back to it (unsafe), while base-uri,
+        # frame-ancestors and form-action have no fallback and are therefore missing.
         (
             {
                 "Content-Type": "text/html",
                 "Content-Security-Policy": "default-src 'self'",
             },
-            [MSG_CSP_UNSAFE.format("object-src", "http://example.com")],
-            [MEDIUM_LEVEL],
+            [
+                MSG_CSP_UNSAFE.format("object-src", "http://example.com"),
+                MSG_CSP_MISSING.format("base-uri", "http://example.com"),
+                MSG_CSP_MISSING.format("frame-ancestors", "http://example.com"),
+                MSG_CSP_MISSING.format("form-action", "http://example.com"),
+            ],
+            [MEDIUM_LEVEL, MEDIUM_LEVEL, MEDIUM_LEVEL, LOW_LEVEL],
         ),
         # CSP declared but script-src contains unsafe-inline. Also as default-src is missing, there are no fallback
         (
@@ -137,14 +183,31 @@ def get_all_vulnerabilities(module, request, response):
                 MSG_CSP_UNSAFE.format("script-src", "http://example.com"),
                 MSG_CSP_MISSING.format("object-src", "http://example.com"),
                 MSG_CSP_MISSING.format("base-uri", "http://example.com"),
+                MSG_CSP_MISSING.format("frame-ancestors", "http://example.com"),
+                MSG_CSP_MISSING.format("form-action", "http://example.com"),
             ],
-            [LOW_LEVEL, MEDIUM_LEVEL, MEDIUM_LEVEL, MEDIUM_LEVEL],
+            [LOW_LEVEL, MEDIUM_LEVEL, MEDIUM_LEVEL, MEDIUM_LEVEL, MEDIUM_LEVEL, LOW_LEVEL],
+        ),
+        # CSP declares an unknown/misspelled directive
+        (
+            {
+                "Content-Type": "text/html",
+                "Content-Security-Policy": (
+                    "default-src 'none'; base-uri 'self'; frame-ancestors 'none'; "
+                    "form-action 'self'; foobar-src 'self'"
+                ),
+            },
+            [MSG_CSP_UNKNOWN.format("foobar-src", "http://example.com")],
+            [LOW_LEVEL],
         ),
         # CSP is well-made
         (
             {
                 "Content-Type": "text/html",
-                "Content-Security-Policy": "default-src 'self'; script-src 'self'; object-src 'none'; base-uri 'self'",
+                "Content-Security-Policy": (
+                    "default-src 'self'; script-src 'self'; object-src 'none'; "
+                    "base-uri 'self'; frame-ancestors 'none'; form-action 'self'"
+                ),
             },
             [],
             [],

--- a/tests/integration/test_mod_csp/assertions/csp_csp_insecured.php.json
+++ b/tests/integration/test_mod_csp/assertions/csp_csp_insecured.php.json
@@ -4,7 +4,7 @@
             {
                 "method": "GET",
                 "path": "/csp_insecured.php",
-                "info": "CSP \"base-uri\" value is not safe for URL: http://csp/csp_insecured.php",
+                "info": "CSP directive \"foobar-src\" is unknown or misspelled for URL: http://csp/csp_insecured.php",
                 "parameter": null,
                 "module": "csp",
                 "http_request": "GET /csp_insecured.php HTTP/1.1\nhost: csp\nconnection: keep-alive\nuser-agent: Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:128.0) Gecko/20100101 Firefox/128.0\naccept-language: en-US\naccept-encoding: gzip, deflate, br\naccept: text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,*/*;q=0.8",
@@ -28,6 +28,18 @@
             {
                 "method": "GET",
                 "path": "/csp_insecured.php",
+                "info": "CSP \"script-src\" value is not safe for URL: http://csp/csp_insecured.php",
+                "parameter": null,
+                "module": "csp",
+                "http_request": "GET /csp_insecured.php HTTP/1.1\nhost: csp\nconnection: keep-alive\nuser-agent: Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:128.0) Gecko/20100101 Firefox/128.0\naccept-language: en-US\naccept-encoding: gzip, deflate, br\naccept: text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,*/*;q=0.8",
+                "wstg": [
+                    "OSHP-Content-Security-Policy",
+                    "WSTG-CONF-12"
+                ]
+            },
+            {
+                "method": "GET",
+                "path": "/csp_insecured.php",
                 "info": "CSP \"object-src\" value is not safe for URL: http://csp/csp_insecured.php",
                 "parameter": null,
                 "module": "csp",
@@ -40,7 +52,31 @@
             {
                 "method": "GET",
                 "path": "/csp_insecured.php",
-                "info": "CSP \"script-src\" value is not safe for URL: http://csp/csp_insecured.php",
+                "info": "CSP attribute \"base-uri\" is missing for URL: http://csp/csp_insecured.php",
+                "parameter": null,
+                "module": "csp",
+                "http_request": "GET /csp_insecured.php HTTP/1.1\nhost: csp\nconnection: keep-alive\nuser-agent: Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:128.0) Gecko/20100101 Firefox/128.0\naccept-language: en-US\naccept-encoding: gzip, deflate, br\naccept: text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,*/*;q=0.8",
+                "wstg": [
+                    "OSHP-Content-Security-Policy",
+                    "WSTG-CONF-12"
+                ]
+            },
+            {
+                "method": "GET",
+                "path": "/csp_insecured.php",
+                "info": "CSP attribute \"frame-ancestors\" is missing for URL: http://csp/csp_insecured.php",
+                "parameter": null,
+                "module": "csp",
+                "http_request": "GET /csp_insecured.php HTTP/1.1\nhost: csp\nconnection: keep-alive\nuser-agent: Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:128.0) Gecko/20100101 Firefox/128.0\naccept-language: en-US\naccept-encoding: gzip, deflate, br\naccept: text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,*/*;q=0.8",
+                "wstg": [
+                    "OSHP-Content-Security-Policy",
+                    "WSTG-CONF-12"
+                ]
+            },
+            {
+                "method": "GET",
+                "path": "/csp_insecured.php",
+                "info": "CSP attribute \"form-action\" is missing for URL: http://csp/csp_insecured.php",
                 "parameter": null,
                 "module": "csp",
                 "http_request": "GET /csp_insecured.php HTTP/1.1\nhost: csp\nconnection: keep-alive\nuser-agent: Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:128.0) Gecko/20100101 Firefox/128.0\naccept-language: en-US\naccept-encoding: gzip, deflate, br\naccept: text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,*/*;q=0.8",

--- a/tests/integration/test_mod_csp/assertions/csp_csp_insecured.php.json
+++ b/tests/integration/test_mod_csp/assertions/csp_csp_insecured.php.json
@@ -4,31 +4,7 @@
             {
                 "method": "GET",
                 "path": "/csp_insecured.php",
-                "info": "CSP directive \"foobar-src\" is unknown or misspelled for URL: http://csp/csp_insecured.php",
-                "parameter": null,
-                "module": "csp",
-                "http_request": "GET /csp_insecured.php HTTP/1.1\nhost: csp\nconnection: keep-alive\nuser-agent: Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:128.0) Gecko/20100101 Firefox/128.0\naccept-language: en-US\naccept-encoding: gzip, deflate, br\naccept: text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,*/*;q=0.8",
-                "wstg": [
-                    "OSHP-Content-Security-Policy",
-                    "WSTG-CONF-12"
-                ]
-            },
-            {
-                "method": "GET",
-                "path": "/csp_insecured.php",
                 "info": "CSP \"default-src\" value is not safe for URL: http://csp/csp_insecured.php",
-                "parameter": null,
-                "module": "csp",
-                "http_request": "GET /csp_insecured.php HTTP/1.1\nhost: csp\nconnection: keep-alive\nuser-agent: Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:128.0) Gecko/20100101 Firefox/128.0\naccept-language: en-US\naccept-encoding: gzip, deflate, br\naccept: text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,*/*;q=0.8",
-                "wstg": [
-                    "OSHP-Content-Security-Policy",
-                    "WSTG-CONF-12"
-                ]
-            },
-            {
-                "method": "GET",
-                "path": "/csp_insecured.php",
-                "info": "CSP \"script-src\" value is not safe for URL: http://csp/csp_insecured.php",
                 "parameter": null,
                 "module": "csp",
                 "http_request": "GET /csp_insecured.php HTTP/1.1\nhost: csp\nconnection: keep-alive\nuser-agent: Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:128.0) Gecko/20100101 Firefox/128.0\naccept-language: en-US\naccept-encoding: gzip, deflate, br\naccept: text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,*/*;q=0.8",
@@ -52,7 +28,31 @@
             {
                 "method": "GET",
                 "path": "/csp_insecured.php",
+                "info": "CSP \"script-src\" value is not safe for URL: http://csp/csp_insecured.php",
+                "parameter": null,
+                "module": "csp",
+                "http_request": "GET /csp_insecured.php HTTP/1.1\nhost: csp\nconnection: keep-alive\nuser-agent: Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:128.0) Gecko/20100101 Firefox/128.0\naccept-language: en-US\naccept-encoding: gzip, deflate, br\naccept: text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,*/*;q=0.8",
+                "wstg": [
+                    "OSHP-Content-Security-Policy",
+                    "WSTG-CONF-12"
+                ]
+            },
+            {
+                "method": "GET",
+                "path": "/csp_insecured.php",
                 "info": "CSP attribute \"base-uri\" is missing for URL: http://csp/csp_insecured.php",
+                "parameter": null,
+                "module": "csp",
+                "http_request": "GET /csp_insecured.php HTTP/1.1\nhost: csp\nconnection: keep-alive\nuser-agent: Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:128.0) Gecko/20100101 Firefox/128.0\naccept-language: en-US\naccept-encoding: gzip, deflate, br\naccept: text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,*/*;q=0.8",
+                "wstg": [
+                    "OSHP-Content-Security-Policy",
+                    "WSTG-CONF-12"
+                ]
+            },
+            {
+                "method": "GET",
+                "path": "/csp_insecured.php",
+                "info": "CSP attribute \"form-action\" is missing for URL: http://csp/csp_insecured.php",
                 "parameter": null,
                 "module": "csp",
                 "http_request": "GET /csp_insecured.php HTTP/1.1\nhost: csp\nconnection: keep-alive\nuser-agent: Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:128.0) Gecko/20100101 Firefox/128.0\naccept-language: en-US\naccept-encoding: gzip, deflate, br\naccept: text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,*/*;q=0.8",
@@ -76,7 +76,7 @@
             {
                 "method": "GET",
                 "path": "/csp_insecured.php",
-                "info": "CSP attribute \"form-action\" is missing for URL: http://csp/csp_insecured.php",
+                "info": "CSP directive \"foobar-src\" is unknown or misspelled for URL: http://csp/csp_insecured.php",
                 "parameter": null,
                 "module": "csp",
                 "http_request": "GET /csp_insecured.php HTTP/1.1\nhost: csp\nconnection: keep-alive\nuser-agent: Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:128.0) Gecko/20100101 Firefox/128.0\naccept-language: en-US\naccept-encoding: gzip, deflate, br\naccept: text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,*/*;q=0.8",
@@ -90,6 +90,204 @@
     "infos": {
         "target": "http://csp/csp_insecured.php",
         "crawled_pages": [
+            {
+                "request": {
+                    "url": "http://csp/csp_insecured.php",
+                    "method": "GET",
+                    "headers": [
+                        [
+                            "accept",
+                            "text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,*/*;q=0.8"
+                        ],
+                        [
+                            "accept-encoding",
+                            "gzip, deflate, br"
+                        ],
+                        [
+                            "accept-language",
+                            "en-US"
+                        ],
+                        [
+                            "connection",
+                            "keep-alive"
+                        ],
+                        [
+                            "host",
+                            "csp"
+                        ],
+                        [
+                            "user-agent",
+                            "Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:128.0) Gecko/20100101 Firefox/128.0"
+                        ]
+                    ]
+                },
+                "response": {
+                    "status_code": 200,
+                    "body": "<!DOCTYPE html>\n<html>\n    <head>\n        <title>CSP Example</title>\n\n    </head>\n    <body>\n        <p>Page with an CSP highly bypassable.</p>\n    </body>\n</html>\n\n",
+                    "headers": [
+                        [
+                            "connection",
+                            "Keep-Alive"
+                        ],
+                        [
+                            "content-encoding",
+                            "gzip"
+                        ],
+                        [
+                            "content-length",
+                            "132"
+                        ],
+                        [
+                            "content-security-policy",
+                            "default-src *; script-src 'unsafe-inline'; 'unsafe-eval'; style-src 'unsafe-inline'; img-src *; connect-src *; foobar-src 'foobar'"
+                        ],
+                        [
+                            "content-type",
+                            "text/html; charset=UTF-8"
+                        ],
+                        [
+                            "server",
+                            "Apache/2.4.56 (Debian)"
+                        ],
+                        [
+                            "vary",
+                            "Accept-Encoding"
+                        ]
+                    ]
+                }
+            },
+            {
+                "request": {
+                    "url": "http://csp/csp_insecured.php",
+                    "method": "GET",
+                    "headers": [
+                        [
+                            "accept",
+                            "text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,*/*;q=0.8"
+                        ],
+                        [
+                            "accept-encoding",
+                            "gzip, deflate, br"
+                        ],
+                        [
+                            "accept-language",
+                            "en-US"
+                        ],
+                        [
+                            "connection",
+                            "keep-alive"
+                        ],
+                        [
+                            "host",
+                            "csp"
+                        ],
+                        [
+                            "user-agent",
+                            "Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:128.0) Gecko/20100101 Firefox/128.0"
+                        ]
+                    ]
+                },
+                "response": {
+                    "status_code": 200,
+                    "body": "<!DOCTYPE html>\n<html>\n    <head>\n        <title>CSP Example</title>\n\n    </head>\n    <body>\n        <p>Page with an CSP highly bypassable.</p>\n    </body>\n</html>\n\n",
+                    "headers": [
+                        [
+                            "connection",
+                            "Keep-Alive"
+                        ],
+                        [
+                            "content-encoding",
+                            "gzip"
+                        ],
+                        [
+                            "content-length",
+                            "132"
+                        ],
+                        [
+                            "content-security-policy",
+                            "default-src *; script-src 'unsafe-inline'; 'unsafe-eval'; style-src 'unsafe-inline'; img-src *; connect-src *; foobar-src 'foobar'"
+                        ],
+                        [
+                            "content-type",
+                            "text/html; charset=UTF-8"
+                        ],
+                        [
+                            "server",
+                            "Apache/2.4.56 (Debian)"
+                        ],
+                        [
+                            "vary",
+                            "Accept-Encoding"
+                        ]
+                    ]
+                }
+            },
+            {
+                "request": {
+                    "url": "http://csp/csp_insecured.php",
+                    "method": "GET",
+                    "headers": [
+                        [
+                            "accept",
+                            "text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,*/*;q=0.8"
+                        ],
+                        [
+                            "accept-encoding",
+                            "gzip, deflate, br"
+                        ],
+                        [
+                            "accept-language",
+                            "en-US"
+                        ],
+                        [
+                            "connection",
+                            "keep-alive"
+                        ],
+                        [
+                            "host",
+                            "csp"
+                        ],
+                        [
+                            "user-agent",
+                            "Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:128.0) Gecko/20100101 Firefox/128.0"
+                        ]
+                    ]
+                },
+                "response": {
+                    "status_code": 200,
+                    "body": "<!DOCTYPE html>\n<html>\n    <head>\n        <title>CSP Example</title>\n\n    </head>\n    <body>\n        <p>Page with an CSP highly bypassable.</p>\n    </body>\n</html>\n\n",
+                    "headers": [
+                        [
+                            "connection",
+                            "Keep-Alive"
+                        ],
+                        [
+                            "content-encoding",
+                            "gzip"
+                        ],
+                        [
+                            "content-length",
+                            "132"
+                        ],
+                        [
+                            "content-security-policy",
+                            "default-src *; script-src 'unsafe-inline'; 'unsafe-eval'; style-src 'unsafe-inline'; img-src *; connect-src *; foobar-src 'foobar'"
+                        ],
+                        [
+                            "content-type",
+                            "text/html; charset=UTF-8"
+                        ],
+                        [
+                            "server",
+                            "Apache/2.4.56 (Debian)"
+                        ],
+                        [
+                            "vary",
+                            "Accept-Encoding"
+                        ]
+                    ]
+                }
+            },
             {
                 "request": {
                     "url": "http://csp/csp_insecured.php",

--- a/tests/integration/test_mod_csp/assertions/csp_csp_secured.php.json
+++ b/tests/integration/test_mod_csp/assertions/csp_csp_secured.php.json
@@ -54,7 +54,7 @@
                         ],
                         [
                             "content-security-policy",
-                            "default-src 'none'  ; frame-ancestors 'self' ; base-uri 'self' ; block-all-mixed-content ;require-trusted-types-for 'script'"
+                            "default-src 'none'  ; frame-ancestors 'self' ; base-uri 'self' ; form-action 'self' ; block-all-mixed-content ;require-trusted-types-for 'script'"
                         ],
                         [
                             "content-type",

--- a/tests/integration/test_mod_csp/php/src/csp_secured.php
+++ b/tests/integration/test_mod_csp/php/src/csp_secured.php
@@ -1,6 +1,6 @@
 <?php
 header_remove();
-header("Content-Security-Policy: default-src 'none'  ; frame-ancestors 'self' ; base-uri 'self' ; block-all-mixed-content ;require-trusted-types-for 'script'")
+header("Content-Security-Policy: default-src 'none'  ; frame-ancestors 'self' ; base-uri 'self' ; form-action 'self' ; block-all-mixed-content ;require-trusted-types-for 'script'")
 ?>
 <!DOCTYPE html>
 <html>

--- a/wapitiCore/attack/modules/passive/mod_csp.py
+++ b/wapitiCore/attack/modules/passive/mod_csp.py
@@ -20,7 +20,12 @@ from typing import Generator, Any, Tuple
 
 from wapitiCore.model.vulnerability import VulnerabilityInstance
 from wapitiCore.net import Request, Response
-from wapitiCore.net.csp_utils import csp_header_to_dict, CSP_CHECK_LISTS, check_policy_values
+from wapitiCore.net.csp_utils import (
+    csp_header_to_dict,
+    CSP_CHECK_LISTS,
+    check_policy_values,
+    find_unknown_directives,
+)
 from wapitiCore.definitions.csp import CspFinding
 from wapitiCore.main.log import log_red
 from wapitiCore.language.vulnerability import LOW_LEVEL, MEDIUM_LEVEL
@@ -28,6 +33,7 @@ from wapitiCore.language.vulnerability import LOW_LEVEL, MEDIUM_LEVEL
 MSG_NO_CSP = "CSP is not set for URL: {0}"
 MSG_CSP_MISSING = "CSP attribute \"{0}\" is missing for URL: {1}"
 MSG_CSP_UNSAFE = "CSP \"{0}\" value is not safe for URL: {1}"
+MSG_CSP_UNKNOWN = "CSP directive \"{0}\" is unknown or misspelled for URL: {1}"
 
 
 class ModuleCsp:
@@ -65,6 +71,20 @@ class ModuleCsp:
                 )
         else:
             csp_dict = csp_header_to_dict(csp_header_value)
+
+            for directive in find_unknown_directives(csp_dict):
+                identifier = (request.netloc, directive, "Unknown")
+                if identifier not in self._reported_csp_issues:
+                    self._reported_csp_issues.add(identifier)
+                    info = MSG_CSP_UNKNOWN.format(directive, request.url)
+                    log_red(info)
+                    yield VulnerabilityInstance(
+                        finding_class=CspFinding,
+                        request=request,
+                        response=response,
+                        info=info,
+                        severity=LOW_LEVEL,
+                    )
 
             for policy_name in CSP_CHECK_LISTS:
                 result = check_policy_values(policy_name, csp_dict)

--- a/wapitiCore/net/csp_utils.py
+++ b/wapitiCore/net/csp_utils.py
@@ -22,12 +22,44 @@ from wapitiCore.net.response import Response
 
 POLICY_REGEX = re.compile(r"\s*((?:'[^']*')|(?:[^'\s]+))\s*")
 
+# A directive name is a sequence of ASCII letters, digits and dashes.
+# Anything else (e.g. a value left orphan by a misplaced semicolon) is not a directive.
+DIRECTIVE_NAME_REGEX = re.compile(r"^[a-z0-9-]+$")
+
 CSP_CHECK_LISTS = {
     # As default-src is the fallback directive we may want to avoid those duplicates in the future
     "default-src": ["unsafe-inline", "data:", "http:", "https:", "*", "unsafe-eval"],
     "script-src": ["unsafe-inline", "data:", "http:", "https:", "*", "unsafe-eval"],
     "object-src": ["none"],
-    "base-uri": ["none", "self"]
+    "base-uri": ["none", "self"],
+    "frame-ancestors": ["none", "self"],
+    "form-action": ["none", "self"],
+}
+
+# Directives that do NOT fall back to default-src when they are omitted.
+# default-src only acts as a fallback for the fetch directives; document and
+# navigation directives (base-uri, frame-ancestors, form-action, ...) have no fallback.
+CSP_NO_FALLBACK_DIRECTIVES = {"base-uri", "frame-ancestors", "form-action"}
+
+# Every directive name defined by the CSP specification (Level 3), plus a few
+# widely-encountered deprecated ones. Used to flag unknown or misspelled directives.
+CSP_DIRECTIVES = {
+    # Fetch directives
+    "child-src", "connect-src", "default-src", "font-src", "frame-src",
+    "img-src", "manifest-src", "media-src", "object-src", "prefetch-src",
+    "script-src", "script-src-elem", "script-src-attr",
+    "style-src", "style-src-elem", "style-src-attr", "worker-src",
+    # Document directives
+    "base-uri", "sandbox",
+    # Navigation directives
+    "form-action", "frame-ancestors", "navigate-to",
+    # Reporting directives
+    "report-uri", "report-to",
+    # Directives without a source list
+    "block-all-mixed-content", "upgrade-insecure-requests",
+    "require-trusted-types-for", "trusted-types", "require-sri-for",
+    # Deprecated but still encountered in the wild
+    "referrer", "reflected-xss", "disown-opener", "plugin-types",
 }
 
 CSP_HEADERS = {"content-security-policy", "x-content-security-policy", "x-webkit-csp"}
@@ -82,12 +114,23 @@ def csp_header_to_dict(header):
     csp_dict = {}
 
     for policy_string in header.split(";"):
-        try:
-            policy_name, policy_values = policy_string.strip().split(" ", 1)
-        except ValueError:
-            # Either it is malformed or we reach the end
+        policy_string = policy_string.strip()
+        if not policy_string:
+            # We reached the end or an empty segment
             continue
-        csp_dict[policy_name] = [value.strip("'") for value in POLICY_REGEX.findall(policy_values)]
+
+        parts = policy_string.split(" ", 1)
+        # Directive names are case-insensitive
+        policy_name = parts[0].lower()
+        if not DIRECTIVE_NAME_REGEX.match(policy_name):
+            # Malformed segment (e.g. a value orphaned by a misplaced semicolon)
+            continue
+
+        if len(parts) == 2:
+            csp_dict[policy_name] = [value.strip("'") for value in POLICY_REGEX.findall(parts[1])]
+        else:
+            # Directive without a value (e.g. upgrade-insecure-requests)
+            csp_dict[policy_name] = []
 
     return csp_dict
 
@@ -100,12 +143,15 @@ def check_policy_values(policy_name, csp_dict):
     1  : the element is set and his value is secure
     """
 
-    if policy_name not in csp_dict and "default-src" not in csp_dict:
-        return -1
-
-    # The HTTP CSP "default-src" directive serves as a fallback for the other CSP fetch directives.
+    # The HTTP CSP "default-src" directive serves as a fallback for the other CSP fetch directives only.
     # https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/default-src
-    policy_values = csp_dict.get(policy_name) or csp_dict["default-src"]
+    # Document/navigation directives (base-uri, frame-ancestors, form-action) have no fallback.
+    if policy_name in csp_dict:
+        policy_values = csp_dict[policy_name]
+    elif policy_name not in CSP_NO_FALLBACK_DIRECTIVES and "default-src" in csp_dict:
+        policy_values = csp_dict["default-src"]
+    else:
+        return -1
 
     # If the tested element is default-src or script-src, we must ensure that none of this unsafe values are present
     if policy_name in ["default-src", "script-src"]:
@@ -118,6 +164,13 @@ def check_policy_values(policy_name, csp_dict):
         return 0
 
     return 1
+
+
+def find_unknown_directives(csp_dict):
+    """Return the list of directive names present in the CSP that are not part of the
+    specification. Those are usually typos or misspelled directives, which are silently
+    ignored by browsers and thus provide no protection at all."""
+    return [name for name in csp_dict if name not in CSP_DIRECTIVES]
 
 
 def has_strong_csp(response: Response, page: Html) -> bool:


### PR DESCRIPTION
Improves the passive CSP module, as suggested in #404 (inspired by Google's CSP Evaluator).

## Changes

- **Detect unknown / misspelled directives.** A typo such as `foobar-src` or `script-scr` is now reported. Browsers silently ignore unknown directives, so a misspelled one provides no protection while looking like it does. New helper `find_unknown_directives()` validates directive names against the CSP Level 3 list (`CSP_DIRECTIVES`).
- **Actually evaluate `frame-ancestors` and add `form-action`.** `frame-ancestors` was referenced in the module to raise the severity, but it was never present in `CSP_CHECK_LISTS`, so that branch was dead code and the directive was never checked. It is now evaluated (`'none'`/`'self'`), along with the newly added `form-action`.
- **No fallback to `default-src` for document/navigation directives.** Per the CSP spec, `base-uri`, `frame-ancestors` and `form-action` do **not** fall back to `default-src`. The previous code let `base-uri` fall back, producing false negatives (a `default-src 'self'` policy was considered to protect against framing/base-tag injection, which it does not). Introduced `CSP_NO_FALLBACK_DIRECTIVES`.
- **More robust header parsing** in `csp_header_to_dict`: directive names are now case-insensitive, valueless directives (e.g. `upgrade-insecure-requests`) are kept, and orphan values left by a misplaced semicolon are skipped instead of being mistaken for directives.

## Tests

- Unit tests updated and extended (unknown directives, no-fallback behaviour, case-insensitivity, valueless directives, orphan values). All passive tests pass, pylint 10/10.
- Integration fixtures updated: `csp_secured.php` now includes `form-action 'self'` to stay clean, and the `csp_insecured` assertion reflects the new findings (including the unknown `foobar-src`).

## Note

`frame-ancestors` and `form-action` are now reported as missing on sites that don't set them, which increases the number of low/medium findings. This matches the original intent (`frame-ancestors` was already meant to be medium) but can be toned down if considered too noisy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)