### PR TITLE
Fix inconsistent_redirection false positive on directory (trailing-slash) redirects

### DIFF
--- a/tests/attack/passive/test_mod_inconsistent_redirection.py
+++ b/tests/attack/passive/test_mod_inconsistent_redirection.py
@@ -60,6 +60,31 @@ def test_standard_object_moved_body_is_not_reported():
     assert len(list(module.analyze(Request(url), response))) == 0
 
 
+def test_directory_redirection_boilerplate_is_not_reported():
+    """A directory redirection (the Location only appends a trailing slash) whose
+    'Object Moved' boilerplate links to the target must not be flagged, even when
+    the body link uses a different scheme (http) than the Location header (https).
+    Real-world case: https://example.com/blogs -> https://example.com/blogs/
+    """
+    module = ModuleInconsistentRedirection()
+    url = "https://example.com/blogs"
+    location = "https://example.com/blogs/"
+    body = (
+        b"<head><title>Document Moved</title></head>\n"
+        b'<body><h1>Object Moved</h1>This document may be found '
+        b'<a HREF="http://example.com/blogs/">here</a></body>'
+    )
+    response = Response(
+        response=httpx.Response(
+            status_code=301,
+            headers={"Content-Type": "text/html; charset=UTF-8", "Location": location},
+            content=body,
+        ),
+        url=url,
+    )
+    assert len(list(module.analyze(Request(url), response))) == 0
+
+
 def test_redirect_body_with_extra_link_is_reported():
     """A redirect body linking somewhere *other* than the target is the real
     leak and must be reported."""

--- a/wapitiCore/attack/modules/passive/mod_inconsistent_redirection.py
+++ b/wapitiCore/attack/modules/passive/mod_inconsistent_redirection.py
@@ -1,4 +1,5 @@
 from typing import Generator, Any, Optional
+from urllib.parse import urlparse
 
 from wapitiCore.definitions.inconsistent_redirection import InconsistentRedirectionFinding
 from wapitiCore.language.vulnerability import MEDIUM_LEVEL
@@ -9,11 +10,23 @@ from wapitiCore.net import Request, Response
 from wapitiCore.parsers.html_parser import Html
 
 
+def _resource_key(url: str) -> tuple:
+    """Normalized identity of a URL, ignoring the scheme and a trailing slash.
+
+    Server-generated redirect boilerplate often links to the destination with a
+    different scheme (an http:// link while the Location header is https://) or
+    with/without a trailing slash — most commonly for directory redirects that
+    only append a slash to the path. Those differences are not meaningful here."""
+    parts = urlparse(url)
+    return parts.netloc.lower(), parts.path.rstrip("/"), parts.query
+
+
 def _points_to_redirection_target(link: str, target: Optional[str]) -> bool:
-    """True when a body link is just the redirection destination itself."""
-    if target is None:
+    """True when a body link is just the redirection destination itself,
+    even if it differs only by scheme (http/https) or a trailing slash."""
+    if not target:
         return False
-    return link.rstrip("/") == target.rstrip("/")
+    return _resource_key(link) == _resource_key(target)
 
 
 class ModuleInconsistentRedirection:


### PR DESCRIPTION
## Problem

The passive `inconsistent_redirection` module flags a 3xx response whose body contains links or forms other than the redirection target. It produced a false positive on plain **directory redirects** — the ones that only append a trailing slash to the path (`/blogs` -> `/blogs/`).

Such redirects return the standard server boilerplate:

```html
<head><title>Document Moved</title></head>
<body><h1>Object Moved</h1>This document may be found <a HREF="http://example.com/blogs/">here</a></body>
```

The boilerplate link points to the redirection destination, but the server writes it with the `http://` scheme while the `Location` header uses `https://`. The previous comparison in `_points_to_redirection_target` only stripped a trailing slash, so the scheme mismatch made the link look like "meaningful content" and the benign redirect was reported.

## Fix

Compare the **normalized resource identity** of the link and the target — `netloc` + path (without trailing slash) + query — ignoring the scheme (`http` vs `https`). A body link that is really the redirection destination is now correctly recognized regardless of scheme or trailing slash, while a link pointing somewhere else is still reported.

## Tests

Added `test_directory_redirection_boilerplate_is_not_reported` reproducing the case. All existing tests still pass (a redirect body linking elsewhere is still flagged), pylint 10/10.

🤖 Generated with [Claude Code](https://claude.com/claude-code)