### PR TITLE
Silence bs4 XMLParsedAsHTMLWarning when parsing XML responses during crawl

### DIFF
--- a/tests/parsers/test_html_parser.py
+++ b/tests/parsers/test_html_parser.py
@@ -1,12 +1,29 @@
+import warnings
 from unittest.mock import patch
 
 import respx
 import httpx
-from bs4 import BeautifulSoup
+from bs4 import BeautifulSoup, XMLParsedAsHTMLWarning
 
 from wapitiCore.net.crawler import Response
 from wapitiCore.parsers.html_parser import Html
 import wapitiCore.parsers.html_parser as html_parser_module
+
+
+def test_parsing_xml_does_not_emit_xml_as_html_warning():
+    """Parsing an XML document (e.g. an RSS feed) with the HTML parser must not
+    surface bs4's XMLParsedAsHTMLWarning, which would otherwise pollute the crawl output."""
+    xml = (
+        b'<?xml version="1.0" encoding="UTF-8"?>'
+        b'<rss version="2.0"><channel><title>Feed</title>'
+        b'<item><link>http://example.com/article</link></item></channel></rss>'
+    )
+    with warnings.catch_warnings(record=True) as caught:
+        # Keep the module-level filter registered at import time (do not reset it)
+        page = Html(xml, "http://example.com/feed")
+        _ = page.soup, list(page.links)
+
+    assert not any(issubclass(w.category, XMLParsedAsHTMLWarning) for w in caught)
 
 
 @respx.mock

--- a/wapitiCore/parsers/html_parser.py
+++ b/wapitiCore/parsers/html_parser.py
@@ -19,13 +19,14 @@
 # Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 # Standard libraries
 import re
+import warnings
 from functools import lru_cache
 from hashlib import md5
 from posixpath import normpath
 from urllib.parse import urlunparse
 from typing import Iterator, List, Optional, Dict, Set, Tuple, Union, Any
 
-from bs4 import BeautifulSoup, ParserRejectedMarkup
+from bs4 import BeautifulSoup, ParserRejectedMarkup, XMLParsedAsHTMLWarning
 from bs4.element import Comment, Doctype
 from tld import get_fld
 from tld.exceptions import TldBadUrl, TldDomainNotFound
@@ -284,10 +285,15 @@ class Html:
         self._content = text
         self._url = url
         self._base = None
-        try:
-            self._soup = BeautifulSoup(self._content, parser_name)
-        except (ParserRejectedMarkup, ValueError):
-            self._soup = BeautifulSoup("", parser_name)
+        # bs4 emits XMLParsedAsHTMLWarning when it parses an XML document (e.g. an RSS
+        # feed) with the HTML parser. Scanning arbitrary responses this way is intended,
+        # so we silence that warning to avoid polluting the crawl output.
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", category=XMLParsedAsHTMLWarning)
+            try:
+                self._soup = BeautifulSoup(self._content, parser_name)
+            except (ParserRejectedMarkup, ValueError):
+                self._soup = BeautifulSoup("", parser_name)
         self._encoding = encoding
         self._allow_fragments = allow_fragments
 


### PR DESCRIPTION
## Problem

Crawling a target that serves an XML document (e.g. an RSS/Atom feed) makes BeautifulSoup print a noisy warning to the crawl output:

```
.../html/parser.py:171: XMLParsedAsHTMLWarning: It looks like you're parsing an XML document using an HTML parser. ...
  k = self.parse_starttag(i)
```

`XMLParsedAsHTMLWarning` is a subclass of `UserWarning`, but it surfaces from the stdlib `html.parser` stack (its origin file is `parser.py`, not a `bs4` module). The existing `warnings.filterwarnings(action='ignore', category=UserWarning, module='bs4')` filters therefore do **not** match it, and the warning leaks through.

## Fix

Wrap the `BeautifulSoup` construction in `Html.__init__` with a local `warnings.catch_warnings()` block that ignores `XMLParsedAsHTMLWarning`. Parsing arbitrary responses with the HTML parser is intended behaviour here, so the warning carries no actionable information.

A **local** suppression is used rather than a process-global `filterwarnings` at import time: the global approach is reset by pytest's per-test warning handling (so it cannot be tested reliably) and is a fragile process-wide side effect. The local block is deterministic.

## Tests

Added `test_parsing_xml_does_not_emit_xml_as_html_warning` (parses an RSS feed and asserts the warning is not raised). Verified in real execution under `python -W error::UserWarning` that parsing an XML feed no longer raises. pylint 10/10.

🤖 Generated with [Claude Code](https://claude.com/claude-code)