### PR TITLE
fix(explorer): cap repeated parameter occurrences in crawled URLs (#252)

### DIFF
--- a/tests/web/test_explorer.py
+++ b/tests/web/test_explorer.py
@@ -197,6 +197,39 @@ async def test_explorer_extract_links():
 
 @pytest.mark.asyncio
 @respx.mock
+async def test_explorer_extract_links_caps_repeated_parameters():
+    # Regression test for issue #252: a link that keeps appending the same parameter
+    # must not produce an ever-growing URL. The crawler caps repeated parameter names.
+    from wapitiCore.net.explorer import MAX_PARAMETER_OCCURRENCES
+
+    crawler_configuration = CrawlerConfiguration(Request("http://perdu.com/"), drop_cookies=True)
+    scope = Scope(Request("http://perdu.com/"), "folder")
+    explorer = Explorer(crawler_configuration, scope, Event())
+
+    repeated = "".join(f"&selectedPageVersions={i}" for i in range(58, 0, -1))
+    respx.get("http://perdu.com/").mock(
+        return_value=httpx.Response(
+            200,
+            text=f'<html><body><a href="/script?pageId=1{repeated}">link</a></body></html>',
+        )
+    )
+
+    request = Request("http://perdu.com/")
+    async with AsyncCrawler.with_configuration(crawler_configuration) as crawler:
+        response = await crawler.async_send(request)
+        results = list(explorer.extract_links(response, request))
+
+    # The crawler also adds the path-only variant ("/script"), so look at the one with params
+    with_params = [req for req in results if req.get_params]
+    assert len(with_params) == 1
+    kept = [value for name, value in with_params[0].get_params if name == "selectedPageVersions"]
+    assert len(kept) == MAX_PARAMETER_OCCURRENCES
+    # The first occurrences are kept, so the capped URL is stable when more are appended
+    assert kept == ["58", "57", "56", "55", "54"]
+
+
+@pytest.mark.asyncio
+@respx.mock
 async def test_explorer_extract_links_from_js():
     crawler_configuration = CrawlerConfiguration(Request("http://perdu.com/"), drop_cookies=True)
     scope = Scope(Request("http://perdu.com/"), "folder")

--- a/wapitiCore/net/explorer.py
+++ b/wapitiCore/net/explorer.py
@@ -46,6 +46,13 @@ MIME_TEXT_TYPES = ('text/', 'application/xml')
 # Limit page size to 2MB
 MAX_PAGE_SIZE = 2097152
 
+# Maximum number of times a same parameter name is kept in a crawled URL.
+# Some applications generate links that keep appending the same parameter
+# (e.g. ...&sel=3&sel=2&sel=1). Following them would produce ever-growing URLs
+# that never repeat, so the crawler would loop forever (issue #252). Capping the
+# occurrences bounds the URL and lets the crawler recognize an already-seen request.
+MAX_PARAMETER_OCCURRENCES = 5
+
 COMMON_PAGE_EXTENSIONS = {
     'php', 'html', 'htm', 'xml', 'xhtml', 'xht', 'xhtm', 'cgi',
     'asp', 'aspx', 'php3', 'php4', 'php5', 'txt', 'shtm',
@@ -61,6 +68,20 @@ EXCLUDED_MEDIA_EXTENSIONS = (
 
 
 BAD_URL_REGEX = re.compile(r"https?:/[^/]+")
+
+
+def limit_parameter_occurrences(params: List[list], max_occurrences: int = MAX_PARAMETER_OCCURRENCES) -> List[list]:
+    """Keep at most `max_occurrences` occurrences of each parameter name, preserving order.
+
+    Prevents the crawler from following links that endlessly append the same
+    parameter, which would otherwise produce ever-growing URLs (issue #252)."""
+    counts: dict = {}
+    limited = []
+    for key, value in params:
+        counts[key] = counts.get(key, 0) + 1
+        if counts[key] <= max_occurrences:
+            limited.append([key, value])
+    return limited
 
 
 class Explorer:
@@ -252,12 +273,12 @@ class Explorer:
             if "?" in new_url:
                 path, query_string = new_url.split("?", 1)
                 # TODO: encoding parameter ?
-                get_params = [
+                get_params = limit_parameter_occurrences([
                     list(t) for t in filter(
                         lambda param_tuple: param_tuple[0] not in self._bad_params,
                         web.parse_qsl(query_string)
                     )
-                ]
+                ])
             elif new_url.endswith(EXCLUDED_MEDIA_EXTENSIONS):
                 # exclude static media files
                 continue


### PR DESCRIPTION
Some applications generate links that keep appending the same GET parameter (e.g. ...&selectedPageVersions=3&selectedPageVersions=2&selectedPageVersions=1). The crawler parsed those query strings keeping every duplicate, and since a request's identity includes parameter values, each appended occurrence produced a brand-new, never-seen URL. The crawler followed them endlessly, generating ever-growing URLs.

Cap each parameter name to MAX_PARAMETER_OCCURRENCES (5) occurrences when extracting links, keeping the first ones. This bounds the URL size and, because appended occurrences are dropped, the capped request stabilizes and is recognized as already processed, breaking the loop.