### PR TITLE
feat(sql): make boolean-based detection robust to dynamic pages and r…

### DIFF
--- a/tests/attack/test_mod_sql.py
+++ b/tests/attack/test_mod_sql.py
@@ -1,3 +1,4 @@
+import re
 from urllib.parse import parse_qs
 from tempfile import NamedTemporaryFile
 import sqlite3
@@ -158,8 +159,9 @@ async def test_blind_detection():
             await module.attack(request)
 
             assert persister.add_payload.call_count
-            # One request for error-based, one to get normal response, four to test boolean-based attack
-            assert respx.calls.call_count == 6
+            # One request for error-based, two to sample the normal response (stability check),
+            # four to test boolean-based attack
+            assert respx.calls.call_count == 7
 
 
 @pytest.mark.asyncio
@@ -182,9 +184,9 @@ async def test_negative_blind():
         assert not persister.add_payload.call_count
         # We have:
         # - 1 request for error-based test
-        # - 1 request to get normal response
+        # - 2 requests to sample the normal response (stability check)
         # - 2*3 requests for the first test of each "session" (as the first test fails others are skipped)
-        assert respx.calls.call_count == 8
+        assert respx.calls.call_count == 9
 
 
 @pytest.mark.asyncio
@@ -241,9 +243,74 @@ async def test_blind_detection_parenthesis():
             assert persister.add_payload.call_count
             # We have:
             # - 1 request for error-based test
-            # - 1 request to get normal response
+            # - 2 requests to sample the normal response (stability check)
             # - 2 requests for boolean False test without parenthesis
             # - 1 request for boolean True test without parenthesis => this check fails
             # - 2 requests for boolean False test WITH parenthesis
             # - 2 requests for boolean True test WITH parenthesis
-            assert respx.calls.call_count == 9
+            assert respx.calls.call_count == 10
+
+
+@pytest.mark.asyncio
+@respx.mock
+async def test_no_false_positive_when_rate_limited():
+    # Regression test: a server that rate-limits us (HTTP 429) on the "false" boolean
+    # requests must not be reported as vulnerable. A 429 differs from the normal page,
+    # which would otherwise satisfy a false-section test and produce a false positive.
+    def process(http_request):
+        query = urlparse(str(http_request.url)).query
+        values = " ".join(value for values in parse_qs(query).values() for value in values)
+        pairs = re.findall(r"(\d+)=(\d+)", values)
+        # A boolean "false" payload compares two different numbers (e.g. AND 13=37)
+        if any(left != right for left, right in pairs):
+            return httpx.Response(429, text="Too Many Requests")
+        return httpx.Response(200, text="Hello there")
+
+    respx.get(url__regex=r"http://perdu\.com/.*").mock(side_effect=process)
+
+    persister = AsyncMock()
+
+    request = Request("http://perdu.com/?foo=bar")
+    request.path_id = 1
+
+    crawler_configuration = CrawlerConfiguration(Request("http://perdu.com/"), timeout=1)
+    async with AsyncCrawler.with_configuration(crawler_configuration) as crawler:
+        options = {"timeout": 10, "level": 1}
+
+        module = ModuleSql(crawler, persister, options, crawler_configuration)
+        await module.attack(request)
+
+        # Without the rate-limit guard, the "false" tests would pass (429 != normal page)
+        # and the "true" tests too, yielding a false positive.
+        assert not persister.add_payload.call_count
+
+
+@pytest.mark.asyncio
+@respx.mock
+async def test_no_false_positive_on_dynamic_page():
+    # Regression test: a page whose content changes between two identical requests is
+    # dynamic. Boolean comparison cannot be trusted, so detection must be skipped instead
+    # of producing false results.
+    counter = {"n": 0}
+
+    def process(http_request):
+        counter["n"] += 1
+        return httpx.Response(200, text="unique dynamic content " + "x" * (counter["n"] * 100))
+
+    respx.get(url__regex=r"http://perdu\.com/.*").mock(side_effect=process)
+
+    persister = AsyncMock()
+
+    request = Request("http://perdu.com/?foo=bar")
+    request.path_id = 1
+
+    crawler_configuration = CrawlerConfiguration(Request("http://perdu.com/"), timeout=1)
+    async with AsyncCrawler.with_configuration(crawler_configuration) as crawler:
+        options = {"timeout": 10, "level": 1}
+
+        module = ModuleSql(crawler, persister, options, crawler_configuration)
+        await module.attack(request)
+
+        assert not persister.add_payload.call_count
+        # 1 error-based request + 2 baseline samples that differ => boolean detection skipped
+        assert respx.calls.call_count == 3

--- a/tests/attack/test_mod_sql.py
+++ b/tests/attack/test_mod_sql.py
@@ -185,8 +185,12 @@ async def test_negative_blind():
         # We have:
         # - 1 request for error-based test
         # - 2 requests to sample the normal response (stability check)
-        # - 2*3 requests for the first test of each "session" (as the first test fails others are skipped)
-        assert respx.calls.call_count == 9
+        # - 1 request for the first test of each of the 6 AND-based "sessions" (fails
+        #   immediately, others are skipped)
+        # - 3 requests for each of the 4 OR+comment-based "sessions" (the two "OR false"
+        #   tests pass since the response matches the baseline either way, the first
+        #   "OR true" test then fails and the last one is skipped)
+        assert respx.calls.call_count == 21
 
 
 @pytest.mark.asyncio
@@ -283,6 +287,146 @@ async def test_no_false_positive_when_rate_limited():
         # Without the rate-limit guard, the "false" tests would pass (429 != normal page)
         # and the "true" tests too, yielding a false positive.
         assert not persister.add_payload.call_count
+
+
+@pytest.mark.asyncio
+@respx.mock
+async def test_detection_via_or_comment_payload_when_and_based_fails():
+    # Regression test: some injectable parameters (e.g. a login field compared against a
+    # value that structurally never matches any row, or matched via a LIKE pattern) make
+    # the AND-based technique blind: appending "AND true/false" never changes the outcome,
+    # since the original condition was already false. An OR-based payload that comments
+    # out the rest of the query can still prove the injection, by making the condition
+    # unconditionally true (e.g. a login bypass) instead of relying on the original
+    # condition ever matching.
+    def process(http_request):
+        query = urlparse(str(http_request.url)).query
+        values = " ".join(value for values in parse_qs(query).values() for value in values)
+        match = re.search(r"OR (\d+)=(\d+)", values)
+        if match and match.group(1) == match.group(2):
+            return httpx.Response(200, text="Session opened!")
+        return httpx.Response(200, text="Invalid login!")
+
+    respx.get(url__regex=r"http://perdu\.com/.*").mock(side_effect=process)
+
+    persister = AsyncMock()
+
+    request = Request("http://perdu.com/?foo=bar")
+    request.path_id = 1
+
+    crawler_configuration = CrawlerConfiguration(Request("http://perdu.com/"), timeout=1)
+    async with AsyncCrawler.with_configuration(crawler_configuration) as crawler:
+        options = {"timeout": 10, "level": 1}
+
+        module = ModuleSql(crawler, persister, options, crawler_configuration)
+        await module.attack(request)
+
+        assert persister.add_payload.call_count
+
+
+@pytest.mark.asyncio
+@respx.mock
+async def test_detection_despite_unrelated_dynamic_content():
+    # A page can carry small per-request dynamic content unrelated to the injected value
+    # (e.g. a CSRF token) without being genuinely "unstable": the same boolean outcome
+    # should still be considered a match even though the two responses aren't byte-for-byte
+    # identical. This is the original motivation for the similarity ratio, now that it's
+    # safe from reflection-driven false positives (see the reflected-payload test above).
+    filler = "Lorem ipsum dolor sit amet consectetur " * 5
+    counter = {"n": 0}
+
+    def process(http_request):
+        counter["n"] += 1
+        query = urlparse(str(http_request.url)).query
+        values = " ".join(value for values in parse_qs(query).values() for value in values)
+        pairs = re.findall(r"(\d+)=(\d+)", values)
+        matched = not pairs or all(left == right for left, right in pairs)
+        tail = (
+            "Result: something interesting was found here in the database" if matched
+            else "Sorry, absolutely nothing matched your search criteria today"
+        )
+        return httpx.Response(200, text=f"{filler}<input type='hidden' value='csrf-{counter['n']}'>{tail}")
+
+    respx.get(url__regex=r"http://perdu\.com/.*").mock(side_effect=process)
+
+    persister = AsyncMock()
+
+    request = Request("http://perdu.com/?foo=bar")
+    request.path_id = 1
+
+    crawler_configuration = CrawlerConfiguration(Request("http://perdu.com/"), timeout=1)
+    async with AsyncCrawler.with_configuration(crawler_configuration) as crawler:
+        options = {"timeout": 10, "level": 1}
+
+        module = ModuleSql(crawler, persister, options, crawler_configuration)
+        await module.attack(request)
+
+        assert persister.add_payload.call_count
+
+
+@pytest.mark.asyncio
+@respx.mock
+async def test_no_false_positive_when_payload_is_reflected():
+    # Regression test: a page that reflects the injected value back verbatim (e.g. a
+    # search page showing "You searched for '<value>'") makes the "true" and "false"
+    # responses differ from the baseline by construction, even when the underlying SQL
+    # behaves identically both times (e.g. no results either way). A fuzzy similarity
+    # ratio can be fooled into treating this superficial difference as a real signal;
+    # an exact match on the visible text is not.
+    def process(http_request):
+        query = urlparse(str(http_request.url)).query
+        value = parse_qs(query).get("foo", [""])[0]
+        return httpx.Response(200, text=f"You searched for '{value}', no results")
+
+    respx.get(url__regex=r"http://perdu\.com/.*").mock(side_effect=process)
+
+    persister = AsyncMock()
+
+    request = Request("http://perdu.com/?foo=bar")
+    request.path_id = 1
+
+    crawler_configuration = CrawlerConfiguration(Request("http://perdu.com/"), timeout=1)
+    async with AsyncCrawler.with_configuration(crawler_configuration) as crawler:
+        options = {"timeout": 10, "level": 1}
+
+        module = ModuleSql(crawler, persister, options, crawler_configuration)
+        await module.attack(request)
+
+        assert not persister.add_payload.call_count
+
+
+@pytest.mark.asyncio
+@respx.mock
+async def test_detection_when_false_payload_triggers_server_error():
+    # Regression test: a server that returns HTTP 500 on the "false" boolean requests
+    # (e.g. a broken injected query crashing the backend) is a genuine SQLi signal and
+    # must still be reported as vulnerable, unlike a 429 rate-limit response.
+    def process(http_request):
+        query = urlparse(str(http_request.url)).query
+        values = " ".join(value for values in parse_qs(query).values() for value in values)
+        pairs = re.findall(r"(\d+)=(\d+)", values)
+        # A boolean "false" payload compares two different numbers (e.g. AND 13=37)
+        if any(left != right for left, right in pairs):
+            return httpx.Response(500, text="Internal Server Error")
+        return httpx.Response(200, text="Hello there")
+
+    respx.get(url__regex=r"http://perdu\.com/.*").mock(side_effect=process)
+
+    persister = AsyncMock()
+
+    request = Request("http://perdu.com/?foo=bar")
+    request.path_id = 1
+
+    crawler_configuration = CrawlerConfiguration(Request("http://perdu.com/"), timeout=1)
+    async with AsyncCrawler.with_configuration(crawler_configuration) as crawler:
+        options = {"timeout": 10, "level": 1}
+
+        module = ModuleSql(crawler, persister, options, crawler_configuration)
+        await module.attack(request)
+
+        # The 500 on "false" payloads differs from the stable baseline, confirming the
+        # boolean test just like a normal differing page would.
+        assert persister.add_payload.call_count
 
 
 @pytest.mark.asyncio

--- a/wapitiCore/attack/mod_sql.py
+++ b/wapitiCore/attack/mod_sql.py
@@ -43,6 +43,11 @@ class PayloadInfo:
     payload: str
     platform: str
     section: bool
+    # The part of `payload` appended after the parameter's own (untouched) value. Used to
+    # strip the payload's own reflection out of a response before comparing it to the
+    # baseline, so a page that echoes the injected value back (e.g. a search results page)
+    # isn't mistaken for "different" just because of that echo.
+    injected_suffix: str = ""
 
 
 # Two responses whose visible text is more similar than this are considered to be
@@ -301,12 +306,63 @@ DBMS_ERROR_PATTERNS = {
 }
 
 
+# SQL comment markers used to truncate the rest of the query after an OR-based boolean
+# injection, so the payload doesn't depend on the original condition ever matching a row
+# (e.g. a LIKE pattern or a value that never matches) the way the AND-based technique does.
+COMMENT_MARKERS = ("-- ", "#")
+
+
 def generate_boolean_payloads(_: Request, __: Parameter) -> Iterator[PayloadInfo]:
     # payloads = []
     for use_parenthesis in (False, True):
         for separator in ("", "'", "\""):
             yield from generate_boolean_test_values(separator, use_parenthesis)
+
+    for separator in ("'", "\""):
+        for comment in COMMENT_MARKERS:
+            yield from generate_boolean_comment_values(separator, comment)
     # return payloads
+
+
+def generate_boolean_comment_values(separator: str, comment: str) -> Iterator[PayloadInfo]:
+    # OR-based payloads that comment out the rest of the query instead of trying to keep
+    # the trailing quotes/parentheses balanced like the AND-based technique. This catches
+    # injections where the original condition can never be satisfied by construction
+    # (e.g. a LIKE pattern, or a value that matches no row), which defeats the AND
+    # technique regardless of what follows in the query.
+    #
+    # Polarity is inverted compared to the AND technique: there, a true condition
+    # preserves the original (matching) outcome and a false one breaks it. Here the
+    # original condition never matches to begin with, so a false OR'd condition leaves
+    # the outcome unchanged (same as baseline) while a true one matches unconditionally
+    # (differs from baseline, e.g. a login bypass).
+    fmt_string = "[VALUE]{sep} OR {left_value}={right_value}{comment}"
+    suffix_fmt = fmt_string[len("[VALUE]"):]
+
+    for __ in range(2):
+        value1 = randint(10, 99)
+        value2 = randint(10, 99) + value1
+
+        # OR'd condition is false: behaves like the unmodified request, response should
+        # match the baseline
+        yield PayloadInfo(
+            payload=fmt_string.format(left_value=value1, right_value=value2, sep=separator, comment=comment),
+            section=True,
+            platform=f"c_{separator}_{comment}",
+            injected_suffix=suffix_fmt.format(left_value=value1, right_value=value2, sep=separator, comment=comment),
+        )
+
+    for __ in range(2):
+        value1 = randint(10, 99)
+
+        # OR'd condition is always true: matches unconditionally, response should differ
+        # from the baseline
+        yield PayloadInfo(
+            payload=fmt_string.format(left_value=value1, right_value=value1, sep=separator, comment=comment),
+            section=False,
+            platform=f"c_{separator}_{comment}",
+            injected_suffix=suffix_fmt.format(left_value=value1, right_value=value1, sep=separator, comment=comment),
+        )
 
 
 def generate_boolean_test_values(separator: str, parenthesis: bool) -> Iterator[PayloadInfo]:
@@ -314,6 +370,7 @@ def generate_boolean_test_values(separator: str, parenthesis: bool) -> Iterator[
         "[VALUE]{sep} AND {left_value}={right_value} AND {sep}{padding_value}{sep}={sep}{padding_value}",
         "[VALUE]{sep}) AND {left_value}={right_value} AND ({sep}{padding_value}{sep}={sep}{padding_value}"
     )[parenthesis]
+    suffix_fmt = fmt_string[len("[VALUE]"):]
 
     for __ in range(2):
         value1 = randint(10, 99)
@@ -330,6 +387,12 @@ def generate_boolean_test_values(separator: str, parenthesis: bool) -> Iterator[
             ),
             section=False,
             platform=f"{'p' if parenthesis else ''}_{separator}",
+            injected_suffix=suffix_fmt.format(
+                left_value=value1,
+                right_value=value2,
+                padding_value=padding_value,
+                sep=separator
+            ),
         )
 
     for __ in range(2):
@@ -346,6 +409,12 @@ def generate_boolean_test_values(separator: str, parenthesis: bool) -> Iterator[
             ),
             section=True,
             platform=f"{'p' if parenthesis else ''}_{separator}",
+            injected_suffix=suffix_fmt.format(
+                left_value=value1,
+                right_value=value1,
+                padding_value=padding_value,
+                sep=separator,
+            ),
         )
 
 
@@ -624,19 +693,33 @@ class ModuleSql(Attack):
                 test_results.append(False)
                 continue
 
-            # A rate-limit or server-error response is not a trustworthy boolean
-            # signal: don't let it count as a legitimate "different page", which
-            # would otherwise satisfy a false-section test and cause a false positive.
-            if response.status == TOO_MANY_REQUESTS_STATUS or response.is_server_error:
+            # A rate-limit response is not a trustworthy boolean signal: don't let it count
+            # as a legitimate "different page", which would otherwise satisfy a
+            # false-section test and cause a false positive.
+            if response.status == TOO_MANY_REQUESTS_STATUS:
                 test_results.append(False)
                 continue
 
-            resp_text = Html(response.content, url=mutated_request.url).text_only
-            comparison = (
-                    response.status == good_status and
-                    response.redirection_url == good_redirect and
-                    text_similarity(resp_text, good_text) >= BOOLEAN_MATCH_THRESHOLD
-            )
+            if response.is_server_error:
+                # The baseline is confirmed stable and non-erroring, so a server error here
+                # is a genuine "differs from baseline" signal (e.g. a broken injected query
+                # crashing the backend), not noise — let it flow through the normal
+                # comparison logic below.
+                comparison = False
+            else:
+                resp_text = Html(response.content, url=mutated_request.url).text_only
+                # The injected suffix itself may be reflected back in the page (e.g. a
+                # search page echoing the query). Strip it before comparing, otherwise it
+                # differs deterministically between the "true" and "false" payloads
+                # regardless of the actual SQL outcome, which can fool the similarity ratio
+                # into a false positive.
+                if payload_info.injected_suffix:
+                    resp_text = resp_text.replace(payload_info.injected_suffix, "")
+                comparison = (
+                        response.status == good_status and
+                        response.redirection_url == good_redirect and
+                        text_similarity(resp_text, good_text) >= BOOLEAN_MATCH_THRESHOLD
+                )
 
             test_results.append(comparison == (payload_info.section is True))
             last_mutated_request = mutated_request

--- a/wapitiCore/attack/mod_sql.py
+++ b/wapitiCore/attack/mod_sql.py
@@ -18,6 +18,7 @@
 # along with this program; if not, write to the Free Software
 # Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 import dataclasses
+import difflib
 import re
 from math import ceil
 from random import randint
@@ -42,6 +43,30 @@ class PayloadInfo:
     payload: str
     platform: str
     section: bool
+
+
+# Two responses whose visible text is more similar than this are considered to be
+# "the same page". Using a similarity ratio instead of an exact hash absorbs small
+# dynamic bits (tokens, counters, timestamps) that would otherwise break blind detection.
+BOOLEAN_MATCH_THRESHOLD = 0.95
+
+# HTTP status returned by servers that rate-limit us. Such a response is not a
+# trustworthy boolean signal and must not be mistaken for a "different page".
+TOO_MANY_REQUESTS_STATUS = 429
+
+
+def text_similarity(text_a: str, text_b: str) -> float:
+    """Return a 0..1 similarity ratio between two texts (1.0 = identical)."""
+    if text_a == text_b:
+        return 1.0
+
+    matcher = difflib.SequenceMatcher(None, text_a, text_b, autojunk=True)
+    # quick_ratio() is a cheap upper bound: if it is already below the threshold,
+    # the exact ratio is too, so we can skip the expensive computation.
+    quick = matcher.quick_ratio()
+    if quick < BOOLEAN_MATCH_THRESHOLD:
+        return quick
+    return matcher.ratio()
 
 
 # From https://github.com/sqlmapproject/sqlmap/blob/master/data/xml/errors.xml
@@ -479,20 +504,41 @@ class ModuleSql(Attack):
 
         return vulnerable_parameters
 
-    async def boolean_based_attack(self, request: Request, parameters_to_skip: set):
+    async def _get_stable_baseline(self, request: Request):
+        """Sample the request twice and return (status, redirect, text) if the page is
+        stable enough for boolean comparison, otherwise None.
+
+        Returns None when the server is rate-limiting us or erroring out, when the status
+        flaps between two identical requests, or when the visible text changes between
+        them (dynamic page). In those cases boolean comparison cannot be trusted and would
+        yield false positives (or false negatives)."""
         try:
-            good_response = await self.crawler.async_send(request)
-            good_status = good_response.status
-            good_redirect = good_response.redirection_url
-            # good_title = response.title
-            html = Html(good_response.content, request.url)
-            good_hash = html.text_only_md5
-        except ReadTimeout:
+            first = await self.crawler.async_send(request)
+            second = await self.crawler.async_send(request)
+            first_text = Html(first.content, request.url).text_only
+            second_text = Html(second.content, request.url).text_only
+        except (ReadTimeout, RequestError):
             self.network_errors += 1
-            return
+            return None
         except ParserRejectedMarkup as exc:
             logging.warning(exc)
+            return None
+
+        if (
+            first.is_server_error
+            or first.status == TOO_MANY_REQUESTS_STATUS
+            or second.status != first.status
+            or text_similarity(first_text, second_text) < BOOLEAN_MATCH_THRESHOLD
+        ):
+            return None
+
+        return first.status, first.redirection_url, first_text
+
+    async def boolean_based_attack(self, request: Request, parameters_to_skip: set):
+        baseline = await self._get_stable_baseline(request)
+        if baseline is None:
             return
+        good_status, good_redirect, good_text = baseline
 
         methods = ""
         if self.do_get:
@@ -578,11 +624,18 @@ class ModuleSql(Attack):
                 test_results.append(False)
                 continue
 
-            Html(response.content, url=mutated_request.url)
+            # A rate-limit or server-error response is not a trustworthy boolean
+            # signal: don't let it count as a legitimate "different page", which
+            # would otherwise satisfy a false-section test and cause a false positive.
+            if response.status == TOO_MANY_REQUESTS_STATUS or response.is_server_error:
+                test_results.append(False)
+                continue
+
+            resp_text = Html(response.content, url=mutated_request.url).text_only
             comparison = (
                     response.status == good_status and
                     response.redirection_url == good_redirect and
-                    Html(response.content, url=mutated_request.url).text_only_md5 == good_hash
+                    text_similarity(resp_text, good_text) >= BOOLEAN_MATCH_THRESHOLD
             )
 
             test_results.append(comparison == (payload_info.section is True))


### PR DESCRIPTION
…ate-limiting

Boolean-based (blind) SQLi detection compared attack responses against a single baseline using an exact md5 of the visible text. This was fragile:

- Any per-request dynamic content (tokens, counters, timestamps) changed the hash, breaking detection (false negatives).
- A server that rate-limited us mid-attack could return responses that "differ" from the baseline, spuriously satisfying the false-section tests and producing false positives (observed on a rate-limiting target).

Improvements:
- Sample the request twice up front and skip boolean detection when the page is unstable (status flapping, or visible text differing between two identical requests) or when the server is already erroring / rate-limiting (5xx / 429).
- Compare responses with a text similarity ratio (difflib) against a threshold instead of an exact hash, so small dynamic bits no longer break detection.
- Treat a 429 / 5xx response during the tests as an untrustworthy signal (it can no longer count as a legitimate "different page").

Adds regression tests for the rate-limiting and dynamic-page false-positive cases.