### PR TITLE
Report timeout/500 anomalies in mod_ssrf and harden finish()

### DIFF
--- a/tests/attack/test_mod_ssrf.py
+++ b/tests/attack/test_mod_ssrf.py
@@ -114,3 +114,119 @@ async def test_query_string_injection():
         assert parameter.name == ""
         assert parameter.situation == ParameterSituation.QUERY_STRING
         assert payload_info.payload == "http://wapiti3.ovh/ssrf/yolo/1/51554552595f535452494e47/"
+
+
+@pytest.mark.asyncio
+@respx.mock
+async def test_finish_with_missing_request_id():
+    # finish() must skip request IDs that no longer resolve to a stored request instead of crashing
+    respx.route(host="perdu.com").mock(return_value=httpx.Response(200, text="Hello there"))
+
+    persister = AsyncMock()
+
+    request = Request("http://perdu.com/?foo=bar")
+    request.path_id = 2
+
+    # get_path_by_id returns None for the unknown request_id "999" but the real request for "2"
+    def get_path_by_id(request_id):
+        if int(request_id) == 2:
+            return request
+        return None
+
+    persister.get_path_by_id.side_effect = get_path_by_id
+
+    crawler_configuration = CrawlerConfiguration(Request("http://perdu.com/"), timeout=1)
+    async with AsyncCrawler.with_configuration(crawler_configuration) as crawler:
+        options = {"timeout": 10, "level": 2}
+
+        module = ModuleSsrf(crawler, persister, options, crawler_configuration)
+        module.do_post = True
+
+        respx.get("https://wapiti3.ovh/get_ssrf.php?session_id=" + module._session_id).mock(
+            return_value=httpx.Response(
+                200,
+                json={
+                    # request_id "999" does not exist in persister and must be skipped
+                    "999": {
+                        "666f6f": [
+                            {
+                                "date": "2019-08-17T16:52:41+00:00",
+                                "url": "https://wapiti3.ovh/ssrf_data/yolo/999/666f6f/31337-0-10.0.0.1.txt",
+                                "ip": "10.0.0.1",
+                                "method": "GET"
+                            }
+                        ]
+                    },
+                    # request_id "2" exists and must still be reported
+                    "2": {
+                        "666f6f": [
+                            {
+                                "date": "2019-08-17T16:53:00+00:00",
+                                "url": "https://wapiti3.ovh/ssrf_data/yolo/2/666f6f/31337-0-10.0.0.2.txt",
+                                "ip": "10.0.0.2",
+                                "method": "GET"
+                            }
+                        ]
+                    }
+                }
+            )
+        )
+
+        # Must not raise, must skip the missing ID and report the valid one
+        await module.finish()
+
+        assert persister.add_payload.call_count == 1
+        assert persister.add_payload.call_args_list[0][1]["parameter"] == "foo"
+        assert persister.add_payload.call_args_list[0][1]["category"] == "Server Side Request Forgery"
+
+
+@pytest.mark.asyncio
+@respx.mock
+async def test_timeout_reported_as_resource_consumption():
+    # A timed-out injection must be reported once as a resource consumption anomaly
+    respx.route(host="perdu.com").mock(side_effect=httpx.ReadTimeout("Connection timed out"))
+
+    persister = AsyncMock()
+
+    request = Request("http://perdu.com/?url=http://safe.example.com")
+    request.path_id = 1
+
+    crawler_configuration = CrawlerConfiguration(Request("http://perdu.com/"), timeout=1)
+    async with AsyncCrawler.with_configuration(crawler_configuration) as crawler:
+        options = {"timeout": 10, "level": 1}
+
+        module = ModuleSsrf(crawler, persister, options, crawler_configuration)
+
+        await module.attack(request)
+
+        timeout_findings = [
+            call for call in persister.add_payload.call_args_list
+            if call[1].get("category") == "Resource consumption"
+        ]
+        assert len(timeout_findings) == 1
+
+
+@pytest.mark.asyncio
+@respx.mock
+async def test_server_error_reported_as_internal_error():
+    # A 500 response to an injection must be reported once as an internal error anomaly
+    respx.route(host="perdu.com").mock(return_value=httpx.Response(500, text="Internal Server Error"))
+
+    persister = AsyncMock()
+
+    request = Request("http://perdu.com/?url=http://safe.example.com")
+    request.path_id = 1
+
+    crawler_configuration = CrawlerConfiguration(Request("http://perdu.com/"), timeout=1)
+    async with AsyncCrawler.with_configuration(crawler_configuration) as crawler:
+        options = {"timeout": 10, "level": 1}
+
+        module = ModuleSsrf(crawler, persister, options, crawler_configuration)
+
+        await module.attack(request)
+
+        error_findings = [
+            call for call in persister.add_payload.call_args_list
+            if call[1].get("category") == "Internal Server Error"
+        ]
+        assert len(error_findings) == 1

--- a/wapitiCore/attack/mod_ssrf.py
+++ b/wapitiCore/attack/mod_ssrf.py
@@ -21,12 +21,14 @@ from asyncio import sleep
 from typing import Optional, Iterator
 from binascii import hexlify, unhexlify
 
-from httpx import RequestError, InvalidURL
+from httpx import ReadTimeout, RequestError, InvalidURL
 
-from wapitiCore.main.log import logging, log_red, log_verbose
+from wapitiCore.main.log import logging, log_red, log_orange, log_verbose
 from wapitiCore.attack.attack import Attack, Mutator, Parameter, ParameterSituation
 from wapitiCore.language.vulnerability import Messages
 from wapitiCore.definitions.ssrf import SsrfFinding
+from wapitiCore.definitions.resource_consumption import ResourceConsumptionFinding
+from wapitiCore.definitions.internal_error import InternalErrorFinding
 from wapitiCore.model import PayloadInfo, str_to_payloadinfo
 from wapitiCore.net import Request, Response
 from wapitiCore.net.web import http_repr
@@ -70,18 +72,67 @@ class ModuleSsrf(Attack):
         yield PayloadInfo(payload=payload)
 
     async def attack(self, request: Request, response: Optional[Response] = None):
-        # Let's just send payloads, we don't care of the response as what we want to know is if the target
-        # contacted the endpoint.
-        for mutated_request, _parameter, _payload in self.mutator.mutate(request, self.get_payloads):
+        # SSRF detection itself is out-of-band: what we care about is whether the target contacted our
+        # endpoint (checked later in finish()). We still inspect responses to report anomalies (timeouts,
+        # internal errors) triggered by the injected payloads.
+        timeouted = False
+        page = request.path
+        saw_internal_error = False
+
+        for mutated_request, parameter, _payload in self.mutator.mutate(request, self.get_payloads):
             log_verbose(f"[¨] {mutated_request}")
 
             try:
-                await self.crawler.async_send(mutated_request)
+                response = await self.crawler.async_send(mutated_request)
+            except ReadTimeout:
+                self.network_errors += 1
+                if timeouted:
+                    continue
+
+                log_orange("---")
+                log_orange(Messages.MSG_TIMEOUT, page)
+                log_orange(Messages.MSG_EVIL_REQUEST)
+                log_orange(http_repr(mutated_request))
+                log_orange("---")
+
+                if parameter.is_qs_injection:
+                    anom_msg = Messages.MSG_QS_TIMEOUT
+                else:
+                    anom_msg = Messages.MSG_PARAM_TIMEOUT.format(parameter.display_name)
+
+                await self.add_medium(
+                    finding_class=ResourceConsumptionFinding,
+                    request=mutated_request,
+                    info=anom_msg,
+                    parameter=parameter.display_name,
+                )
+                timeouted = True
             except RequestError:
                 self.network_errors += 1
                 continue
             except InvalidURL:
                 continue
+            else:
+                if response.is_server_error and not saw_internal_error:
+                    saw_internal_error = True
+                    if parameter.is_qs_injection:
+                        anom_msg = Messages.MSG_QS_500
+                    else:
+                        anom_msg = Messages.MSG_PARAM_500.format(parameter.display_name)
+
+                    await self.add_high(
+                        finding_class=InternalErrorFinding,
+                        request=mutated_request,
+                        info=anom_msg,
+                        parameter=parameter.display_name,
+                        response=response
+                    )
+
+                    log_orange("---")
+                    log_orange(Messages.MSG_500, page)
+                    log_orange(Messages.MSG_EVIL_REQUEST)
+                    log_orange(http_repr(mutated_request))
+                    log_orange("---")
 
     async def finish(self):
         endpoint_url = f"{self.internal_endpoint}get_ssrf.php?session_id={self._session_id}"
@@ -102,7 +153,11 @@ class ModuleSsrf(Attack):
                 for request_id in data:
                     original_request = await self.persister.get_path_by_id(request_id)
                     if original_request is None:
-                        raise ValueError("Could not find the original request with that ID")
+                        logging.warning(
+                            "[!] Could not find original request with ID %s, skipping",
+                            request_id
+                        )
+                        continue
 
                     page = original_request.path
                     for hex_param in data[request_id]:


### PR DESCRIPTION
## Summary

Small, focused improvement to `mod_ssrf`, extracted from the useful parts of #748.

SSRF detection stays out-of-band (we care whether the target contacted our endpoint, checked in `finish()`). On top of that, the module now inspects the responses to injected payloads to report anomalies, mirroring the conventions already used by `mod_file`/`mod_sql`:

- a read timeout is reported **once per request** as a `ResourceConsumption` finding (a server hanging while fetching an injected URL is a meaningful SSRF hint);
- an HTTP 500 is reported **once per request** as an `InternalError` finding.

It also hardens `finish()`: when the endpoint returns a request ID that no longer resolves to a stored request, it used to `raise ValueError` and abort the whole result parsing — it now logs a warning and skips that ID.

The existing `except InvalidURL` handling in `attack()` is preserved.

## What this intentionally leaves out (vs #748)

#748 also added in-band payloads (local file disclosure + cloud metadata). After review those are not worth carrying:

- `file:///etc/passwd` / `file://C:\...` duplicate what `mod_file` already tests (same payloads, same `root:x:0:0` rule);
- `/etc/networks` is weaker and less reliable than `mod_file`'s `/etc/services` (rule `defined by IANA`), and its rules (`loopback`, `link-local`) are noise-prone;
- GCP and Azure metadata endpoints are header-gated (`Metadata-Flavor: Google` / `Metadata: true`); a plain value injection cannot set those headers on the server's outbound request, so they can't trigger;
- AWS IMDSv1 is deprecated.

## Tests

- Unit: added coverage for the `finish()` skip, the timeout anomaly and the 500 anomaly (`tests/attack/test_mod_ssrf.py`).
- Integration: `test_mod_ssrf` still passes (assertion respected).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
