### PR TITLE
fix(headless): run host-level modules (ssl, http_headers) against hosts the MITM proxy filters out

### DIFF
--- a/tests/web/test_intercepting_explorer.py
+++ b/tests/web/test_intercepting_explorer.py
@@ -260,3 +260,71 @@ class TestInterceptingExplorer:
         assert results[0][1].status == 200
         mock_seed_crawler.async_send.assert_not_awaited()
         mock_launch_headless.assert_called_once()
+
+    @patch("wapitiCore.net.intercepting_explorer.AsyncCrawler")
+    @patch("wapitiCore.net.intercepting_explorer.launch_proxy")
+    @patch("wapitiCore.net.intercepting_explorer.launch_headless_explorer")
+    @pytest.mark.asyncio
+    async def test_seed_fallback_disabled_in_both_mode(
+        self, mock_launch_headless, mock_launch_proxy, mock_crawler_cls
+    ):
+        # GIVEN an explorer with the seed fallback disabled (as done in --headless both, where a
+        # standard Explorer already seeded every host into the persister)
+        stop_event = asyncio.Event()
+        crawler_config = CrawlerConfiguration(Request("https://example.com/"))
+        scope = Scope(Request("https://example.com/"), "folder")
+        explorer = InterceptingExplorer(
+            crawler_config, scope, stop_event, headless="hidden", seed_fallback=False
+        )
+
+        async def mock_proxy(*args, **kwargs):  # pylint: disable=unused-argument
+            stop_event.set()
+
+        mock_launch_proxy.side_effect = mock_proxy
+
+        mock_seed_crawler = AsyncMock()
+        mock_crawler_cls.with_configuration.return_value.__aenter__.return_value = mock_seed_crawler
+
+        # WHEN exploring an uncovered host
+        results = [
+            (req, res) async for req, res in explorer.async_explore(deque([Request("https://example.com/")]))
+        ]
+
+        # THEN no fallback fetch happens: the standard crawler already covered the host
+        assert results == []
+        mock_seed_crawler.async_send.assert_not_awaited()
+        mock_launch_headless.assert_called_once()
+
+    @patch("wapitiCore.net.intercepting_explorer.AsyncCrawler")
+    @patch("wapitiCore.net.intercepting_explorer.launch_proxy")
+    @patch("wapitiCore.net.intercepting_explorer.launch_headless_explorer")
+    @pytest.mark.asyncio
+    async def test_seed_fallback_honors_exclusions(
+        self, mock_launch_headless, mock_launch_proxy, mock_crawler_cls
+    ):
+        # GIVEN a headless crawl that captures nothing for the host
+        stop_event = asyncio.Event()
+        crawler_config = CrawlerConfiguration(Request("https://example.com/"))
+        scope = Scope(Request("https://example.com/"), "folder")
+        explorer = InterceptingExplorer(crawler_config, scope, stop_event, headless="hidden")
+
+        async def mock_proxy(*args, **kwargs):  # pylint: disable=unused-argument
+            stop_event.set()
+
+        mock_launch_proxy.side_effect = mock_proxy
+
+        mock_seed_crawler = AsyncMock()
+        mock_crawler_cls.with_configuration.return_value.__aenter__.return_value = mock_seed_crawler
+
+        # WHEN the seed URL matches an exclusion pattern
+        results = [
+            (req, res) async for req, res in explorer.async_explore(
+                deque([Request("https://example.com/")]),
+                excluded_urls=["https://example.com/*"],
+            )
+        ]
+
+        # THEN the fallback skips it instead of fetching it directly
+        assert results == []
+        mock_seed_crawler.async_send.assert_not_awaited()
+        mock_launch_headless.assert_called_once()

--- a/tests/web/test_intercepting_explorer.py
+++ b/tests/web/test_intercepting_explorer.py
@@ -187,3 +187,76 @@ class TestInterceptingExplorer:
         assert len(requests) == 1
         assert requests[0].url == "http://example.com/test"
         mock_launch_headless.assert_called_once()
+
+    @patch("wapitiCore.net.intercepting_explorer.AsyncCrawler")
+    @patch("wapitiCore.net.intercepting_explorer.launch_proxy")
+    @patch("wapitiCore.net.intercepting_explorer.launch_headless_explorer")
+    @pytest.mark.asyncio
+    async def test_seed_fallback_covers_uncovered_host(
+        self, mock_launch_headless, mock_launch_proxy, mock_crawler_cls
+    ):
+        # GIVEN a headless crawl that captures nothing (e.g. an index returning 403 that the
+        # MITM proxy dropped), so no request is produced for the target host
+        stop_event = asyncio.Event()
+        crawler_config = CrawlerConfiguration(Request("https://example.com/"))
+        scope = Scope(Request("https://example.com/"), "folder")
+        explorer = InterceptingExplorer(crawler_config, scope, stop_event, headless="hidden")
+
+        async def mock_proxy(*args, **kwargs):  # pylint: disable=unused-argument
+            stop_event.set()
+
+        mock_launch_proxy.side_effect = mock_proxy
+
+        # AND a direct (non-proxied) seed fetch that returns the 403 the proxy would have dropped
+        seed_response = Response(httpx.Response(403, text="Forbidden"), url="https://example.com/")
+        mock_seed_crawler = AsyncMock()
+        mock_seed_crawler.async_send.return_value = seed_response
+        mock_crawler_cls.with_configuration.return_value.__aenter__.return_value = mock_seed_crawler
+
+        # WHEN exploring
+        results = [
+            (req, res) async for req, res in explorer.async_explore(deque([Request("https://example.com/")]))
+        ]
+
+        # THEN the seed is fetched directly and emitted so host-level modules get their request
+        assert len(results) == 1
+        assert results[0][0].url == "https://example.com/"
+        assert results[0][1].status == 403
+        mock_seed_crawler.async_send.assert_awaited_once()
+        mock_launch_headless.assert_called_once()
+
+    @patch("wapitiCore.net.intercepting_explorer.AsyncCrawler")
+    @patch("wapitiCore.net.intercepting_explorer.launch_proxy")
+    @patch("wapitiCore.net.intercepting_explorer.launch_headless_explorer")
+    @pytest.mark.asyncio
+    async def test_seed_fallback_skips_covered_host(
+        self, mock_launch_headless, mock_launch_proxy, mock_crawler_cls
+    ):
+        # GIVEN a headless crawl that already captured the index (200 html) for the host
+        stop_event = asyncio.Event()
+        crawler_config = CrawlerConfiguration(Request("https://example.com/"))
+        scope = Scope(Request("https://example.com/"), "folder")
+        explorer = InterceptingExplorer(crawler_config, scope, stop_event, headless="hidden")
+
+        async def mock_proxy(*args, **kwargs):  # pylint: disable=unused-argument
+            queue = args[1]
+            request = Request("https://example.com/")
+            response = Response(httpx.Response(200, text="<html></html>"), url="https://example.com/")
+            await queue.put((request, response))
+            stop_event.set()
+
+        mock_launch_proxy.side_effect = mock_proxy
+
+        mock_seed_crawler = AsyncMock()
+        mock_crawler_cls.with_configuration.return_value.__aenter__.return_value = mock_seed_crawler
+
+        # WHEN exploring
+        results = [
+            (req, res) async for req, res in explorer.async_explore(deque([Request("https://example.com/")]))
+        ]
+
+        # THEN the host is already covered: no direct fetch, no duplicate
+        assert len(results) == 1
+        assert results[0][1].status == 200
+        mock_seed_crawler.async_send.assert_not_awaited()
+        mock_launch_headless.assert_called_once()

--- a/wapitiCore/controller/wapiti.py
+++ b/wapitiCore/controller/wapiti.py
@@ -281,6 +281,9 @@ class Wapiti:
                     headless="hidden",
                     cookies=self.crawler_configuration.cookies,
                     wait_time=self._wait_time,
+                    # The standard Explorer above already seeded every host into the same
+                    # persister, so the seed fallback would only re-persist a duplicate here.
+                    seed_fallback=False,
                 )
                 logging.info("Start headless crawler.")
                 await run_explorer(intercepting_explorer)

--- a/wapitiCore/net/intercepting_explorer.py
+++ b/wapitiCore/net/intercepting_explorer.py
@@ -419,7 +419,8 @@ class InterceptingExplorer(Explorer):
             drop_cookies: bool = False,
             headless: str = "no",
             cookies: Optional[CookieJar] = None,
-            wait_time: float = 2.
+            wait_time: float = 2.,
+            seed_fallback: bool = True
     ):
         super().__init__(crawler_configuration, scope, stop_event, parallelism)
         # Kept so the seed fallback can build a crawler that bypasses the MITM proxy
@@ -428,6 +429,10 @@ class InterceptingExplorer(Explorer):
         self._proxy = proxy
         self._drop_cookies = drop_cookies
         self._headless = headless
+        # Whether to directly fetch uncovered seeds after the headless crawl. Disabled in
+        # "both" mode, where a standard Explorer already seeded every host into the same
+        # persister, so a fallback fetch would only re-persist a duplicate.
+        self._seed_fallback_enabled = seed_fallback
         self._final_cookies = None
         self._cookies = cookies or CookieJar()
         self._wait_time = wait_time
@@ -541,14 +546,19 @@ class InterceptingExplorer(Explorer):
         # index returning 403, or a non-text root) would never produce a single request, so
         # host-level modules (ssl, http_headers, ...) that need one request per host would
         # never run against it. Fetch the uncovered seeds directly to restore that coverage.
-        if self._headless != "no":
-            async for request, response in self._seed_fallback(seed_requests, covered_hosts):
+        # Skipped in "both" mode (see self._seed_fallback_enabled).
+        if self._headless != "no" and self._seed_fallback_enabled:
+            async for request, response in self._seed_fallback(
+                seed_requests, covered_hosts, excluded_requests, exclusion_regexes
+            ):
                 yield request, response
 
     async def _seed_fallback(
             self,
             seed_requests: List[Request],
             covered_hosts: set,
+            excluded_requests: set,
+            exclusion_regexes: List[re.Pattern],
     ) -> AsyncIterator[Tuple[Request, Response]]:
         """
         Directly fetch the seed URLs of hosts the headless crawl did not cover, bypassing the
@@ -564,6 +574,12 @@ class InterceptingExplorer(Explorer):
                     continue
 
                 if not self._scope.check(request):
+                    continue
+
+                # Honor the same exclusions process_requests applies to intercepted requests.
+                if request in excluded_requests or any(
+                    regex.match(request.url) for regex in exclusion_regexes
+                ):
                     continue
 
                 try:

--- a/wapitiCore/net/intercepting_explorer.py
+++ b/wapitiCore/net/intercepting_explorer.py
@@ -20,6 +20,7 @@
 import asyncio
 import re
 import sys
+from dataclasses import replace
 from traceback import print_tb
 from typing import Tuple, List, AsyncIterator, Dict, Optional, Deque
 from logging import getLogger, WARNING, CRITICAL
@@ -421,6 +422,8 @@ class InterceptingExplorer(Explorer):
             wait_time: float = 2.
     ):
         super().__init__(crawler_configuration, scope, stop_event, parallelism)
+        # Kept so the seed fallback can build a crawler that bypasses the MITM proxy
+        self._crawler_configuration = crawler_configuration
         self._mitm_port = mitm_port
         self._proxy = proxy
         self._drop_cookies = drop_cookies
@@ -477,6 +480,9 @@ class InterceptingExplorer(Explorer):
     ) -> AsyncIterator[Tuple[Request, Response]]:
         self._queue = asyncio.Queue()
 
+        # Snapshot the seeds now: launch_headless_explorer drains the to_explore deque below.
+        seed_requests = list(to_explore)
+
         exclusion_regexes = []
         excluded_requests = set()
 
@@ -519,10 +525,59 @@ class InterceptingExplorer(Explorer):
                 )
             )
 
+        # Track which hosts the headless crawl actually produced a request for. We build this
+        # ourselves rather than reading self._processed_requests because process_requests marks
+        # a request processed only after its yield, and the loop below may break right after the
+        # last yield (stop event) before that happens.
+        covered_hosts = set()
         async for request, response in self.process_requests(excluded_requests, exclusion_regexes):
+            covered_hosts.add(request.hostname)
             yield request, response
             if self._stopped.is_set():
                 break
+
+        # The MITM proxy only forwards responses that are not 4xx and whose content-type is
+        # text/json/html/xml. A host whose only reachable endpoint is filtered out (e.g. an
+        # index returning 403, or a non-text root) would never produce a single request, so
+        # host-level modules (ssl, http_headers, ...) that need one request per host would
+        # never run against it. Fetch the uncovered seeds directly to restore that coverage.
+        if self._headless != "no":
+            async for request, response in self._seed_fallback(seed_requests, covered_hosts):
+                yield request, response
+
+    async def _seed_fallback(
+            self,
+            seed_requests: List[Request],
+            covered_hosts: set,
+    ) -> AsyncIterator[Tuple[Request, Response]]:
+        """
+        Directly fetch the seed URLs of hosts the headless crawl did not cover, bypassing the
+        MITM proxy filters, so host-level modules always get at least one request per host even
+        when the index returns a 4xx or a non-text response. Headless-captured requests, when
+        they exist, always take precedence (the host is already in covered_hosts).
+        """
+        # self._crawler routes through the MITM proxy; use the real upstream proxy (often none).
+        seed_configuration = replace(self._crawler_configuration, proxy=self._proxy)
+        async with AsyncCrawler.with_configuration(seed_configuration) as seed_crawler:
+            for request in seed_requests:
+                if request.method != "GET" or request.hostname in covered_hosts:
+                    continue
+
+                if not self._scope.check(request):
+                    continue
+
+                try:
+                    # follow_redirects=True so the terminal 200 is stored: a bare 3xx to the
+                    # trailing-slash variant would be skipped by must_attack as a directory
+                    # redirection.
+                    response = await seed_crawler.async_send(request, follow_redirects=True)
+                except (ConnectionError, httpx.RequestError) as exception:
+                    logging.error("[!] %s while seeding %s", type(exception).__name__, request.url)
+                    continue
+
+                covered_hosts.add(request.hostname)
+                self._processed_requests.add(request)
+                yield request, response
 
     def empty_queue(self):
         while not self._queue.empty():


### PR DESCRIPTION
## Problem

In headless mode (`--headless hidden` / `visible`), the requests fed to the attack modules come **only** from the MITM interception layer. That layer is stricter than the standard crawler: it drops every `4xx` response and every response whose content-type is not `text`/`json`/`html`/`xml`.

As a result, a host whose only reachable endpoint is filtered out (e.g. an index returning `403`, an auth-gated site, a WAF, or a non-text API root) **never produces a single request**, so host-level modules that need just one request per host — most notably `ssl` — silently never run against it.

The symptom is misleading: `ssl` reports a **clean result** under `--headless` while reporting real findings without it. `sslscan` runs as a direct subprocess independent of the proxy, so a clean result there only means the module never executed. Reported in #641.

## Fix

After the headless crawl completes, fetch the seed URLs of any host that no intercepted request covered, using a crawler that **bypasses the MITM proxy** so the responses escape its filters. Coverage is tracked by hostname (the grain host-level modules need), and headless-captured requests always take precedence, so there is no duplicate in the normal case.

This restores, inside the headless path, the guarantee the standard crawler already provides (the seed is always evaluated) without degrading the rich headless-captured requests.

### Follow-up hardening (second commit)

- **No duplicate in `--headless both`.** In `both` mode a standard `Explorer` already seeds every host into the same persister before the headless crawl. The fallback is therefore disabled in that mode (`seed_fallback=False`) so it does not re-persist an already-saved seed.
- **Exclusions honored.** The fallback now re-applies the same `--exclude` / excluded-request filters that `process_requests` applies, so an excluded seed is not fetched directly.

## Tests

Unit tests in `tests/web/test_intercepting_explorer.py` cover: fallback fires for an uncovered host, is skipped when the host is already covered, is disabled in `both` mode, and honors exclusions.

Refs #641

🤖 Generated with [Claude Code](https://claude.com/claude-code)