### PR TITLE
Migrate from httpx to httpxyz (fixes #690, closes #786)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,7 +38,7 @@ dependencies = [
     "browser-cookie3>=0.19,<0.21",
     "dnspython>=2.6,<3.0",
     "httpcore>=1.0,<2.0",
-    "httpx[brotli,socks]>=0.27,<1.0",
+    "httpxyz[brotli,socks]>=0.31,<1.0",
     "httpx-ntlm>=1.4,<2.0",
     "mako>=1.2,<2.0",
     "mitmproxy>=12.0,<13.0",
@@ -83,7 +83,9 @@ find = {exclude=["tests*"]}
 testpaths = [
     "tests",
 ]
-addopts = "--cov --cov-report=xml"
+# "-p httpxyz" loads the httpxyz pytest plugin first so httpxyz/httpcorexyz shadow httpx/httpcore
+# before respx or any test module imports the real httpx (required by httpxyz's sys.modules aliasing).
+addopts = "-p httpxyz --cov --cov-report=xml"
 
 [tool.coverage.run]
 source = ["wapitiCore"]

--- a/tests/net/test_crawler.py
+++ b/tests/net/test_crawler.py
@@ -1,3 +1,4 @@
+import base64
 import ssl
 from itertools import zip_longest
 from unittest.mock import patch
@@ -5,9 +6,10 @@ from unittest.mock import patch
 import httpx
 import pytest
 import respx
+import spnego
 
 from wapitiCore.net.crawler import AsyncCrawler
-from wapitiCore.net.classes import CrawlerConfiguration
+from wapitiCore.net.classes import CrawlerConfiguration, HttpCredential
 from wapitiCore.parsers.html_parser import Html
 from wapitiCore.net import Request
 
@@ -99,6 +101,44 @@ async def test_redirect_with_invalid_location_is_returned():
 
     assert response.status == 302
     assert response.headers["location"] == location
+
+
+@respx.mock
+@pytest.mark.asyncio
+async def test_ntlm_authentication(tmp_path, monkeypatch):
+    # NTLM auth relies on the third-party httpx-ntlm, which only works with httpxyz through the
+    # sys.modules alias (it does "from httpx import Auth"). Drive a full NTLM handshake against a
+    # pyspnego acceptor to make sure HttpNtlmAuth still authenticates on the (aliased) client.
+    domain, user, password = "DOMAIN", "user", "Password123!"
+    cred_file = tmp_path / "ntlm_creds"
+    cred_file.write_text(f"{domain}:{user}:{password}\n")
+    monkeypatch.setenv("NTLM_USER_FILE", str(cred_file))  # pyspnego acceptor credential store
+
+    server_ctx = spnego.server(protocol="ntlm")
+
+    def responder(request):
+        authorization = request.headers.get("authorization")
+        if not authorization:
+            return httpx.Response(401, headers={"WWW-Authenticate": "NTLM"})
+        token = base64.b64decode(authorization.split(" ", 1)[1])
+        out = server_ctx.step(token)
+        if not server_ctx.complete:
+            return httpx.Response(401, headers={"WWW-Authenticate": f"NTLM {base64.b64encode(out).decode()}"})
+        return httpx.Response(200, text="authenticated")
+
+    respx.get("http://ntlm.test/").mock(side_effect=responder)
+
+    crawler_configuration = CrawlerConfiguration(
+        Request("http://ntlm.test/"),
+        http_credential=HttpCredential(username=f"{domain}\\{user}", password=password, method="ntlm"),
+        timeout=5,
+    )
+    async with AsyncCrawler.with_configuration(crawler_configuration) as crawler:
+        response = await crawler.async_send(Request("http://ntlm.test/"))
+
+    assert response.status == 200
+    assert response.content == "authenticated"
+    assert server_ctx.complete
 
 
 def test_extract_disconnect_urls():

--- a/tests/net/test_crawler.py
+++ b/tests/net/test_crawler.py
@@ -82,6 +82,25 @@ async def test_multiple_redirecton():
         assert response.content == "OK"
 
 
+@respx.mock
+@pytest.mark.asyncio
+async def test_redirect_with_invalid_location_is_returned():
+    # A redirect response whose Location is not a valid URL (here a data: URI) used to make httpx
+    # raise InvalidURL while building the redirect request, even with follow_redirects=False, so the
+    # response never reached the caller and its headers were lost. httpxyz returns the response as-is.
+    # Regression test for https://github.com/wapiti-scanner/wapiti/issues/690
+    target_url = "http://perdu.com/redirect"
+    location = "data:;base64,PD9waHAgZWNobyAndzRwMXQxJywnX2V2YWwnOyA/Pg=="
+    respx.get(target_url).mock(return_value=httpx.Response(302, headers={"Location": location}))
+
+    crawler_configuration = CrawlerConfiguration(Request("http://perdu.com/"), timeout=1)
+    async with AsyncCrawler.with_configuration(crawler_configuration) as crawler:
+        response = await crawler.async_send(Request(target_url), follow_redirects=False)
+
+    assert response.status == 302
+    assert response.headers["location"] == location
+
+
 def test_extract_disconnect_urls():
     target_url = "http://perdu.com/"
     text = (

--- a/wapitiCore/__init__.py
+++ b/wapitiCore/__init__.py
@@ -18,5 +18,16 @@
 # You should have received a copy of the GNU General Public License
 # along with this program; if not, write to the Free Software
 # Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+
+# Wapiti relies on httpxyz, a maintained fork of httpx, to work around unfixed httpx bugs
+# (notably the loss of the Location header on redirect responses carrying an invalid URL when
+# follow_redirects=False, see https://github.com/wapiti-scanner/wapiti/issues/690 and #786).
+# Importing httpcorexyz/httpxyz here registers them as "httpcore"/"httpx" in sys.modules so that
+# every subsequent "import httpx" (in Wapiti and in third-party libraries such as httpx-ntlm and
+# mitmproxy) transparently resolves to the fork. This must happen before anything imports httpx,
+# hence its placement at the very top of the package.
+import httpcorexyz  # noqa: F401  pylint: disable=unused-import,wrong-import-position
+import httpxyz  # noqa: F401  pylint: disable=unused-import,wrong-import-position
+
 parser_name = "html.parser"
 WAPITI_VERSION = "3.3.0"

--- a/wapitiCore/attack/active_scanner.py
+++ b/wapitiCore/attack/active_scanner.py
@@ -382,7 +382,7 @@ class ActiveScanner:
                 print_tb(traceback_, file=traceback_fd)
                 print(f"{exception.__class__.__name__}: {exception}", file=traceback_fd)
                 print(f"Occurred in {module_name} on {original_request}", file=traceback_fd)
-                logging.info("Wapiti %s. httpx %s. OS %s", WAPITI_VERSION, httpx_version, sys.platform)
+                logging.info("Wapiti %s. httpxyz %s. OS %s", WAPITI_VERSION, httpx_version, sys.platform)
 
             try:
                 with open(traceback_file, "rb") as traceback_byte_fd:


### PR DESCRIPTION
## What

Migrate the HTTP layer from `httpx` to [`httpxyz`](https://httpxyz.org/), a maintained fork of httpx, to fix the lost `Location` header on redirect injections (#690).

Fixes #690. Closes #786.

## Why

`httpx`'s `Client._send_handling_redirects` unconditionally builds `response.next_request` whenever a response has a redirect status + a `Location` header — **even with `follow_redirects=False`**. When the `Location` is an invalid URL (e.g. a malformed `data:` URI produced by payload injection), building the redirect request raises `InvalidURL` before the response reaches the caller. The response object — and its headers — are therefore lost, so reflected-payload detection (notably `mod_redirect`) cannot inspect them.

`httpxyz` returns the full response with the `Location` header intact and `next_request=None` in that exact scenario, restoring detection.

Reproduced against both libraries (302 + `Location: data:foo;bar,baz aaa`, `follow_redirects=False`):
- httpx → raises `InvalidURL`
- httpxyz → returns the 302 with `Location` intact, `next_request=None`

`httpx` has had no release since 0.28.1 (December 2024), while several real-world issues (this one included) stay unresolved. httpxyz is a drop-in maintenance fork whose stated policy is bug-fixes-only with no breaking API changes.

## How

`httpxyz` registers itself as `httpx` in `sys.modules` on import (and its companion `httpcorexyz` as `httpcore`), so it is a drop-in: no call sites change.

- **`wapitiCore/__init__.py`** — import `httpcorexyz`/`httpxyz` at the very top of the package so the aliasing is installed before anything (Wapiti code or third-party deps such as `httpx-ntlm` and `mitmproxy`) imports `httpx`. The aliasing is order-sensitive (`sys.modules.setdefault`), hence the placement.
- **`pyproject.toml`** — replace `httpx[brotli,socks]` with `httpxyz[brotli,socks]>=0.31,<1.0` (httpxyz declares the same `brotli`/`socks` extras), and add `-p httpxyz` to pytest `addopts` so the fork shadows httpx before `respx` / test modules import the real one.
- **`active_scanner.py`** — the crash banner now reports `httpxyz` instead of `httpx`.

Wapiti already uses the modern httpx API (`proxy=`, no `proxies=` / `app=` / `.raw`), so no code needed adapting to the newer version httpxyz tracks. The now-redundant `except InvalidURL` guard in `mod_redirect` is kept as harmless defensive code.

Note on third-party compatibility: libraries like `httpx-ntlm`, `respx` and `mitmproxy` depend on `httpx`, not on httpxyz — they work with the fork *only* through the `sys.modules` alias, not through any native support. That is why the alias is installed as early as possible and guarded by a regression test.

## Bonus: async performance

Beyond the bug fix, httpxyz 0.31.0 switched its transport to `httpcorexyz`, which acquires the connection-pool lock/semaphore with anyio's `fast_acquire=True` (absent from stock `httpcore`). Its changelog reports ~3.3× lower latency on the async GET microbenchmark. Since Wapiti drives many concurrent requests through a shared `AsyncClient`, this reduces pool-contention overhead per request.

This is a synchronization-primitive microbenchmark, **not** a claim of 3.3× faster scans — real scan time is dominated by network RTT and target latency. The gain is most noticeable on high-concurrency scans against fast/local targets; it is essentially free here.

## Testing

- Reproduced the bug and its fix directly (see above).
- `httpx-ntlm` and `mitmproxy` import and run against the fork; `pip install .[test]` resolves with no conflicts.
- `pylint --rcfile=.pylintrc wapitiCore` → 10.00/10.
- Added two regression tests in `tests/net/test_crawler.py`:
  - `test_redirect_with_invalid_location_is_returned` — a 302 with a `data:` URI `Location` must be returned with its header intact (fails on httpx with `InvalidURL`, passes on httpxyz). Directly covers #690, which had no test.
  - `test_ntlm_authentication` — full NTLM handshake against a pyspnego acceptor, ensuring `httpx-ntlm` (which reaches the fork only via the alias) still authenticates on the aliased `AsyncClient`. NTLM auth previously had no test at all.
- Local run of the respx-heavy and redirect/`InvalidURL`-related suites (`tests/net`, `tests/cookies`, `tests/cli`, and attack modules sql/exec/file/ssrf/backup/crlf/redirect/active_scanner) passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
