### PR TITLE
fix(buster): stop reporting soft 404s, catch-all redirects and 5xx as pages

### DIFF
--- a/tests/attack/test_mod_buster.py
+++ b/tests/attack/test_mod_buster.py
@@ -1,3 +1,4 @@
+import logging
 from unittest import mock
 from unittest.mock import AsyncMock
 from asyncio import sleep
@@ -169,6 +170,39 @@ async def test_server_errors_are_not_reported():
         # the 503 candidates must be discarded.
         reported = {call[1]["request"].url for call in persister.add_payload.call_args_list}
         assert reported == {"http://perdu.com/real", "http://perdu.com/login"}
+
+
+@pytest.mark.asyncio
+@respx.mock
+async def test_rate_limiting_warning_emitted_once(caplog):
+    # A storm of 503 responses must trigger a single warning per host, not one per response.
+    caplog.set_level(logging.INFO)
+    respx.get("http://perdu.com/").mock(return_value=httpx.Response(200, text="Default page"))
+    respx.get(url__regex=r"http://perdu\.com/.*").mock(return_value=httpx.Response(503, text="nope"))
+
+    persister = AsyncMock()
+    request = Request("http://perdu.com/")
+    request.path_id = 1
+    persister.get_links = AsyncIterator([(request, None)])
+
+    crawler_configuration = CrawlerConfiguration(Request("http://perdu.com/"), timeout=1)
+    async with AsyncCrawler.with_configuration(crawler_configuration) as crawler:
+        options = {"timeout": 10, "level": 2, "tasks": 20}
+
+        files = {"wordlist.txt": "\n".join(f"path{i}" for i in range(30))}
+        with mock.patch("builtins.open", get_mock_open(files)):
+            module = ModuleBuster(crawler, persister, options, crawler_configuration)
+            module.DATA_DIR = ""
+            module.PATHS_FILE = "wordlist.txt"
+            module.do_get = True
+            await module.attack(request)
+
+        # No path reported despite the flood of 503...
+        assert persister.add_payload.call_count == 0
+        # ...and exactly one rate-limiting warning for the host
+        warnings = [rec.message for rec in caplog.records if "rate limiting or overload" in rec.message]
+        assert len(warnings) == 1
+        assert "perdu.com" in warnings[0]
 
 
 async def delayed_response():

--- a/tests/attack/test_mod_buster.py
+++ b/tests/attack/test_mod_buster.py
@@ -55,6 +55,122 @@ async def test_whole_stuff():
         assert "http://perdu.com/admin/authconfig.php" in persister.add_payload.call_args_list[2][1]["info"]
 
 
+@pytest.mark.asyncio
+@respx.mock
+async def test_soft_404():
+    # The server returns a 200 "not found" page for every unknown path (soft 404).
+    # Only paths whose body clearly differs from that generic page must be reported.
+    soft_404_body = "<html><body><h1>Sorry, this page does not exist</h1></body></html>"
+
+    respx.get("http://perdu.com/").mock(return_value=httpx.Response(200, text="Default page"))
+    # A real, discoverable page with a distinctive body
+    respx.get("http://perdu.com/secret").mock(
+        return_value=httpx.Response(200, text="Top secret administration console")
+    )
+    # Everything else (the improbable probe and the other candidates) is a soft 404
+    respx.get(url__regex=r"http://perdu\.com/.*").mock(return_value=httpx.Response(200, text=soft_404_body))
+
+    persister = AsyncMock()
+    request = Request("http://perdu.com/")
+    request.path_id = 1
+    persister.get_links = AsyncIterator([(request, None)])
+
+    crawler_configuration = CrawlerConfiguration(Request("http://perdu.com/"), timeout=1)
+    async with AsyncCrawler.with_configuration(crawler_configuration) as crawler:
+        options = {"timeout": 10, "level": 2, "tasks": 20}
+
+        files = {"wordlist.txt": "nawak\nsecret\nanother"}
+        with mock.patch("builtins.open", get_mock_open(files)):
+            module = ModuleBuster(crawler, persister, options, crawler_configuration)
+            module.DATA_DIR = ""
+            module.PATHS_FILE = "wordlist.txt"
+            module.do_get = True
+            await module.attack(request)
+
+        # Only /secret should be reported, the soft-404 candidates must be discarded
+        assert persister.add_payload.call_count == 1
+        assert "http://perdu.com/secret" in persister.add_payload.call_args_list[0][1]["info"]
+
+
+@pytest.mark.asyncio
+@respx.mock
+async def test_catch_all_redirection():
+    # The server redirects every unknown path to the same location (catch-all).
+    # Such redirections must not be reported as discovered pages.
+    respx.get("http://perdu.com/").mock(return_value=httpx.Response(200, text="Default page"))
+    # A real page that redirects somewhere specific
+    respx.get("http://perdu.com/login").mock(
+        return_value=httpx.Response(302, headers={"Location": "http://perdu.com/dashboard"})
+    )
+    # Everything else is redirected to the generic error page
+    respx.get(url__regex=r"http://perdu\.com/.*").mock(
+        return_value=httpx.Response(302, headers={"Location": "http://perdu.com/not-found"})
+    )
+
+    persister = AsyncMock()
+    request = Request("http://perdu.com/")
+    request.path_id = 1
+    persister.get_links = AsyncIterator([(request, None)])
+
+    crawler_configuration = CrawlerConfiguration(Request("http://perdu.com/"), timeout=1)
+    async with AsyncCrawler.with_configuration(crawler_configuration) as crawler:
+        options = {"timeout": 10, "level": 2, "tasks": 20}
+
+        files = {"wordlist.txt": "nawak\nlogin\nanother"}
+        with mock.patch("builtins.open", get_mock_open(files)):
+            module = ModuleBuster(crawler, persister, options, crawler_configuration)
+            module.DATA_DIR = ""
+            module.PATHS_FILE = "wordlist.txt"
+            module.do_get = True
+            await module.attack(request)
+
+        # Only /login (redirected to a different location) should be reported
+        assert persister.add_payload.call_count == 1
+        assert "http://perdu.com/login" in persister.add_payload.call_args_list[0][1]["info"]
+
+
+@pytest.mark.asyncio
+@respx.mock
+async def test_server_errors_are_not_reported():
+    # Under the load of the wordlist the target starts answering 503 (rate limiting).
+    # A 5xx must never be reported as a discovered page, unlike genuine 200/redirects.
+    respx.get("http://perdu.com/").mock(return_value=httpx.Response(200, text="Default page"))
+    # A real page
+    respx.get("http://perdu.com/real").mock(return_value=httpx.Response(200, text="Actual content"))
+    # A real page redirecting to a specific location
+    respx.get("http://perdu.com/login").mock(
+        return_value=httpx.Response(302, headers={"Location": "http://perdu.com/auth"})
+    )
+    # Candidates the server chokes on once the scan ramps up
+    respx.get("http://perdu.com/overloaded").mock(return_value=httpx.Response(503, text="Service Unavailable"))
+    respx.get("http://perdu.com/another").mock(return_value=httpx.Response(503, text="Service Unavailable"))
+    # The improbable baseline probe is sent first and still gets a clean 404,
+    # so it does not match the 503 candidates (that is what made the bug slip through).
+    respx.get(url__regex=r"http://perdu\.com/.*").mock(return_value=httpx.Response(404))
+
+    persister = AsyncMock()
+    request = Request("http://perdu.com/")
+    request.path_id = 1
+    persister.get_links = AsyncIterator([(request, None)])
+
+    crawler_configuration = CrawlerConfiguration(Request("http://perdu.com/"), timeout=1)
+    async with AsyncCrawler.with_configuration(crawler_configuration) as crawler:
+        options = {"timeout": 10, "level": 2, "tasks": 20}
+
+        files = {"wordlist.txt": "overloaded\nreal\nlogin\nanother"}
+        with mock.patch("builtins.open", get_mock_open(files)):
+            module = ModuleBuster(crawler, persister, options, crawler_configuration)
+            module.DATA_DIR = ""
+            module.PATHS_FILE = "wordlist.txt"
+            module.do_get = True
+            await module.attack(request)
+
+        # Only /real (200) and /login (302 to a specific location) are reported;
+        # the 503 candidates must be discarded.
+        reported = {call[1]["request"].url for call in persister.add_payload.call_args_list}
+        assert reported == {"http://perdu.com/real", "http://perdu.com/login"}
+
+
 async def delayed_response():
     await sleep(15)
     return httpx.Response(200, text="Hello there")

--- a/wapitiCore/attack/mod_buster.py
+++ b/wapitiCore/attack/mod_buster.py
@@ -19,13 +19,14 @@
 # along with this program; if not, write to the Free Software
 # Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 import asyncio
+from collections import defaultdict
 from difflib import SequenceMatcher
 from os.path import join as path_join
 from typing import Optional
 
 from httpx import RequestError
 
-from wapitiCore.main.log import log_red, log_verbose
+from wapitiCore.main.log import log_red, log_orange, log_verbose
 from wapitiCore.attack.attack import Attack, random_string
 from wapitiCore.net import Request, Response
 from wapitiCore.definitions.buster import BusterFinding
@@ -76,12 +77,36 @@ class ModuleBuster(Attack):
     do_get = True
     do_post = False
 
+    # Warn (once per host) only after that many HTTP 429/5xx responses, so a single
+    # transient error does not trigger a false alarm.
+    RATE_LIMIT_WARNING_THRESHOLD = 5
+
     def __init__(self, crawler, persister, attack_options, crawler_configuration):
         Attack.__init__(self, crawler, persister, attack_options, crawler_configuration)
         self.known_dirs = []
         self.known_pages = []
         self.new_resources = []
         self.network_errors = 0
+        self.server_error_counts = defaultdict(int)
+        self.rate_limited_netlocs = set()
+
+    def warn_on_rate_limiting(self, request: Request, response: Response):
+        # HTTP 429 (rate limiting) and 5xx (overload) make path discovery unreliable:
+        # warn the user once per host instead of logging every single occurrence.
+        if response.status != 429 and response.status < 500:
+            return
+
+        netloc = request.netloc
+        if netloc in self.rate_limited_netlocs:
+            return
+
+        self.server_error_counts[netloc] += 1
+        if self.server_error_counts[netloc] >= self.RATE_LIMIT_WARNING_THRESHOLD:
+            self.rate_limited_netlocs.add(netloc)
+            log_orange(
+                f"[!] {netloc} is answering with HTTP 429/5xx responses (rate limiting or "
+                "overload): some paths may have been missed, consider lowering the scan speed."
+            )
 
     async def check_path(self, url, not_found_response: Response):
         request = Request(url)
@@ -90,6 +115,8 @@ class ModuleBuster(Attack):
         except RequestError:
             self.network_errors += 1
             return False
+
+        self.warn_on_rate_limiting(request, response)
 
         if response.redirection_url and response.is_directory_redirection:
             # A server that appends a trailing slash to every path (the improbable

--- a/wapitiCore/attack/mod_buster.py
+++ b/wapitiCore/attack/mod_buster.py
@@ -19,15 +19,49 @@
 # along with this program; if not, write to the Free Software
 # Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 import asyncio
+from difflib import SequenceMatcher
 from os.path import join as path_join
 from typing import Optional
 
 from httpx import RequestError
 
 from wapitiCore.main.log import log_red, log_verbose
-from wapitiCore.attack.attack import Attack
+from wapitiCore.attack.attack import Attack, random_string
 from wapitiCore.net import Request, Response
 from wapitiCore.definitions.buster import BusterFinding
+
+# Above this similarity ratio, a candidate response is considered a mere copy of
+# the server's generic "not found" page (soft 404).
+SIMILARITY_THRESHOLD = 0.9
+
+
+def responses_are_similar(response1: str, response2: str) -> bool:
+    """Return True when the two response bodies are near-identical."""
+    return SequenceMatcher(None, response1, response2).quick_ratio() > SIMILARITY_THRESHOLD
+
+
+def is_false_positive(response: Response, not_found_response: Response) -> bool:
+    """
+    Return True when `response` merely replays the generic "not found" answer of the
+    server, captured in `not_found_response` by requesting an improbable resource.
+
+    This catches two common setups that would otherwise flood the results:
+      - catch-all redirection: any unknown path is redirected to the same location;
+      - soft 404: any unknown path returns a 200 with the same "not found" body.
+    """
+    # Catch-all redirection: both the improbable path and the candidate are
+    # redirected to the very same location.
+    if response.redirection_url and not_found_response.redirection_url:
+        return response.redirection_url == not_found_response.redirection_url
+
+    # Soft 404: same status code and a near-identical body as the improbable path.
+    if not response.redirection_url and not not_found_response.redirection_url:
+        return (
+            response.status == not_found_response.status
+            and responses_are_similar(response.content, not_found_response.content)
+        )
+
+    return False
 
 
 class ModuleBuster(Attack):
@@ -49,7 +83,7 @@ class ModuleBuster(Attack):
         self.new_resources = []
         self.network_errors = 0
 
-    async def check_path(self, url):
+    async def check_path(self, url, not_found_response: Response):
         request = Request(url)
         try:
             response = await self.crawler.async_send(request)
@@ -58,6 +92,10 @@ class ModuleBuster(Attack):
             return False
 
         if response.redirection_url and response.is_directory_redirection:
+            # A server that appends a trailing slash to every path (the improbable
+            # path included) would otherwise turn every candidate into a fake directory.
+            if not_found_response.is_directory_redirection:
+                return False
             loc = response.redirection_url
             log_red(f"Found webpage {loc}")
             self.new_resources.append(loc)
@@ -66,8 +104,12 @@ class ModuleBuster(Attack):
                 request=request,
                 info=f"Found webpage {loc} on {url}",
             )
-        elif (response.redirection_url and not response.is_directory_redirection) \
-                or response.status not in [403, 404, 429]:
+        elif not is_false_positive(response, not_found_response) and (
+            (response.redirection_url and not response.is_directory_redirection)
+            # A 5xx means the server failed to answer (often it is rate-limiting the
+            # scan), not that the resource exists: never report those.
+            or (response.status not in [403, 404, 429] and response.status < 500)
+        ):
             log_red(f"Found webpage {request.path}")
             self.new_resources.append(request.path)
             await self.add_info(
@@ -82,15 +124,15 @@ class ModuleBuster(Attack):
     async def test_directory(self, path: str):
         log_verbose(f"[¨] Testing directory {path}")
 
-        test_page = Request(path + "does_n0t_exist.htm")
+        # Request an improbable resource to learn how the server answers to non-existent
+        # paths in this directory. The wordlist candidates have no extension, so the probe
+        # must be extension-less too, otherwise application routing (soft 404, catch-all
+        # redirection) is missed and every candidate ends up being a false positive.
+        not_found_request = Request(path + random_string())
         try:
-            response = await self.crawler.async_send(test_page)
+            not_found_response = await self.crawler.async_send(not_found_request)
         except RequestError:
             self.network_errors += 1
-            return
-
-        if response.status not in [403, 404]:
-            # we don't want to deal with this at the moment
             return
 
         tasks = set()
@@ -107,7 +149,7 @@ class ModuleBuster(Attack):
                     else:
                         url = path + candidate
                         if url not in self.known_dirs and url not in self.known_pages and url not in self.new_resources:
-                            task = asyncio.create_task(self.check_path(url))
+                            task = asyncio.create_task(self.check_path(url, not_found_response))
                             tasks.add(task)
 
                 if not tasks:


### PR DESCRIPTION
## Problem

`mod_buster` reports many false positives on servers that don't return a clean 404:

- **soft 404s** — any unknown path returns `200` with a generic "not found" body;
- **catch-all redirections** — any unknown path is redirected to the same location;
- **5xx / 429 responses** — treated as if the resource existed, when it is often just the server rate-limiting the scan.

The `does_n0t_exist.htm` probe also carried an extension while wordlist candidates don't, so application-level routing (soft 404 / catch-all redirection) was missed and every candidate ended up being a false positive.

## Changes

- Probe each directory with an **extension-less random path** to learn the server's "not found" behaviour, and compare every candidate against it (`is_false_positive`: same redirection target, or same status code + near-identical body via `SequenceMatcher.quick_ratio`).
- Skip directory-redirection false positives when the server appends a trailing slash to every path.
- Never report `5xx` responses as a discovered page.
- Warn **once per host** (after 5 occurrences) when the server answers with `429/5xx`, instead of logging every single occurrence.

## Testing

Adds `tests/attack/test_mod_buster.py` covering soft 404, catch-all redirection, 5xx handling and the rate-limit warning.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
