### PR TITLE
fix(crawler): apply a read timeout so a stalled response can't hang the scan (#797)

### DIFF
--- a/tests/net/test_crawler.py
+++ b/tests/net/test_crawler.py
@@ -113,6 +113,23 @@ def test_extract_disconnect_urls():
     assert all(url in disconnect_urls for url in test_disconnect_urls) is True
 
 
+@pytest.mark.asyncio
+async def test_read_timeout_is_not_disabled():
+    """Regression for issue #797: a stalled HTTP read must not hang forever.
+
+    The crawler's read timeout used to be None (unbounded), so a server that
+    sent its headers then stalled the body blocked ``response.read()``
+    indefinitely (the whole scan hung unless --max-scan-time was set). Every
+    timeout phase, read included, must honor the configured value.
+    """
+    crawler_configuration = CrawlerConfiguration(Request("http://perdu.com/"), timeout=7)
+    async with AsyncCrawler.with_configuration(crawler_configuration) as crawler:
+        assert crawler.timeout.read == 7
+        assert crawler.timeout.connect == 7
+        assert crawler.timeout.write == 7
+        assert crawler.timeout.pool == 7
+
+
 @respx.mock
 @pytest.mark.asyncio
 async def test_async_send():

--- a/wapitiCore/net/crawler.py
+++ b/wapitiCore/net/crawler.py
@@ -102,7 +102,14 @@ class AsyncCrawler:
     ):
         self._base_request = base_request
         self._client = client
-        self._timeout = httpx.Timeout(timeout, read=None)
+        # Apply the configured timeout to every phase, including read. A None read
+        # timeout lets a stalled/slow-trickling server block `response.read()`
+        # forever (the whole scan hangs unless --max-scan-time / --max-attack-time
+        # is set). httpx's read timeout is per-chunk, so a large but progressing
+        # download is unaffected; only a genuine stall (no data for `timeout`s)
+        # is interrupted. This also matches the per-call timeout paths below,
+        # which already build httpx.Timeout(timeout) with every phase set.
+        self._timeout = httpx.Timeout(timeout)
 
         self.is_logged_in = False
         self.auth_url: str = self._base_request.url


### PR DESCRIPTION
## Context

Follow-up to #797. The issue reports that `browse()` hangs indefinitely *after* `--max-scan-time` expires, with high CPU and no `paths` saved.

I could **not** reproduce that specific behavior: with a server that sends its headers and then stalls the response body, `--max-scan-time` **does** interrupt the crawl (the whole crawl is wrapped in `asyncio.wait_for(..., max_scan_time)` in `browse()`), the discovered URLs are saved, and the report is generated — even when every task slot is stuck on a stalled read.

However, investigating it surfaced a real, related defect that hangs a scan run **without** those time limits.

## The actual bug

`AsyncCrawler.__init__` built its default timeout as:

```python
self._timeout = httpx.Timeout(timeout, read=None)
```

The `read=None` disables the read timeout. A server that sends its headers and then stalls the body makes `response.read()` block **forever**. A single such resource hangs the whole scan unless `--max-scan-time` / `--max-attack-time` is set — and `-t/--timeout` does not help, because it only covered the connect/write/pool phases. The per-call timeout paths already build `httpx.Timeout(timeout)` (read included), so the default was the inconsistent one.

## Fix

Build the timeout as `httpx.Timeout(timeout)` so every phase, read included, honors the configured value. httpx applies the read timeout **per received chunk**, so a large but progressing download is unaffected — only a genuine stall (no data for `timeout` seconds) is interrupted.

## Testing

- Repro before fix: server stalls the body, no `--max-scan-time` → scan hangs indefinitely (had to hard-kill).
- After fix: same scenario exits cleanly once the read timeout fires.
- Added `tests/net/test_crawler.py::test_read_timeout_is_not_disabled` asserting every timeout phase (including read) honors the configured value.
- Full `tests/net/test_crawler.py` suite passes; `pylint --rcfile=.pylintrc wapitiCore/net/crawler.py` = 10/10.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
