### PR TITLE
fix(report): HTML-escape all template expressions in the HTML report

### DIFF
--- a/tests/reports/data/report.html
+++ b/tests/reports/data/report.html
@@ -323,7 +323,7 @@
                         </section>
                     </div>
 
-                <dl><dt>Solutions</dt><dd>The best way to protect a web application from XSS attacks is ensure that the application performs validation of all headers, cookies, query strings, form fields, and hidden fields. Encoding user supplied output in the server side can also defeat XSS vulnerabilities by preventing inserted scripts from being transmitted to users in an executable form. Applications can gain significant protection from javascript based attacks by converting the following characters in all generated output to the appropriate HTML entity encoding: <, >, &, ', (, ), #, %, ; , +, -</dd></dl>
+                <dl><dt>Solutions</dt><dd>The best way to protect a web application from XSS attacks is ensure that the application performs validation of all headers, cookies, query strings, form fields, and hidden fields. Encoding user supplied output in the server side can also defeat XSS vulnerabilities by preventing inserted scripts from being transmitted to users in an executable form. Applications can gain significant protection from javascript based attacks by converting the following characters in all generated output to the appropriate HTML entity encoding: &lt;, &gt;, &amp;, &#39;, (, ), #, %, ; , +, -</dd></dl>
                 <h5>References</h5>
                 <ul>
                     <li><a href="https://owasp.org/www-community/attacks/xss/">OWASP: Cross Site Scripting (XSS)</a></li>

--- a/tests/reports/data/report_level1.html
+++ b/tests/reports/data/report_level1.html
@@ -323,7 +323,7 @@
                         </section>
                     </div>
 
-                <dl><dt>Solutions</dt><dd>The best way to protect a web application from XSS attacks is ensure that the application performs validation of all headers, cookies, query strings, form fields, and hidden fields. Encoding user supplied output in the server side can also defeat XSS vulnerabilities by preventing inserted scripts from being transmitted to users in an executable form. Applications can gain significant protection from javascript based attacks by converting the following characters in all generated output to the appropriate HTML entity encoding: <, >, &, ', (, ), #, %, ; , +, -</dd></dl>
+                <dl><dt>Solutions</dt><dd>The best way to protect a web application from XSS attacks is ensure that the application performs validation of all headers, cookies, query strings, form fields, and hidden fields. Encoding user supplied output in the server side can also defeat XSS vulnerabilities by preventing inserted scripts from being transmitted to users in an executable form. Applications can gain significant protection from javascript based attacks by converting the following characters in all generated output to the appropriate HTML entity encoding: &lt;, &gt;, &amp;, &#39;, (, ), #, %, ; , +, -</dd></dl>
                 <h5>References</h5>
                 <ul>
                     <li><a href="https://owasp.org/www-community/attacks/xss/">OWASP: Cross Site Scripting (XSS)</a></li>

--- a/tests/reports/data/report_level2.html
+++ b/tests/reports/data/report_level2.html
@@ -323,7 +323,7 @@
                         </section>
                     </div>
 
-                <dl><dt>Solutions</dt><dd>The best way to protect a web application from XSS attacks is ensure that the application performs validation of all headers, cookies, query strings, form fields, and hidden fields. Encoding user supplied output in the server side can also defeat XSS vulnerabilities by preventing inserted scripts from being transmitted to users in an executable form. Applications can gain significant protection from javascript based attacks by converting the following characters in all generated output to the appropriate HTML entity encoding: <, >, &, ', (, ), #, %, ; , +, -</dd></dl>
+                <dl><dt>Solutions</dt><dd>The best way to protect a web application from XSS attacks is ensure that the application performs validation of all headers, cookies, query strings, form fields, and hidden fields. Encoding user supplied output in the server side can also defeat XSS vulnerabilities by preventing inserted scripts from being transmitted to users in an executable form. Applications can gain significant protection from javascript based attacks by converting the following characters in all generated output to the appropriate HTML entity encoding: &lt;, &gt;, &amp;, &#39;, (, ), #, %, ; , +, -</dd></dl>
                 <h5>References</h5>
                 <ul>
                     <li><a href="https://owasp.org/www-community/attacks/xss/">OWASP: Cross Site Scripting (XSS)</a></li>

--- a/tests/reports/test_reports.py
+++ b/tests/reports/test_reports.py
@@ -279,6 +279,43 @@ def test_detailed_reports(report_format, level):
         os.remove(output)
 
 
+def test_html_report_escapes_target_controlled_data():
+    """The HTML report must not render target-controlled data as raw HTML.
+
+    Login form field names are auto-detected from the scanned target (see
+    Html.find_login_form): a malicious login page can name an input
+    `user"><script>...` and it ends up in the report auth section. The Mako
+    template must HTML-escape it, otherwise opening the report executes the
+    injected script in the auditor's browser (stored XSS).
+    """
+    payload = "\"><script>alert('XSS')</script>"
+
+    report_gen = GENERATORS["html"]()
+    report_gen.set_report_info(
+        f"http://perdu.com/?p={payload}",
+        "folder",
+        gmtime(0),
+        "WAPITI_VERSION",
+        {
+            "url": f"http://perdu.com/login?{payload}",
+            "logged_in": True,
+            "form": {"login_field": f"user{payload}", "password_field": f"pass{payload}"},
+        },
+        None,
+        123456,
+        0,
+    )
+
+    with tempfile.TemporaryDirectory() as output:
+        report_gen.generate_report(output)
+        with open(report_gen.final_path, "r", encoding="utf-8") as report_fd:
+            report = report_fd.read()
+
+    # The raw payload must never appear; only its HTML-escaped form may.
+    assert "<script>alert('XSS')</script>" not in report
+    assert "&lt;script&gt;alert(&#39;XSS&#39;)&lt;/script&gt;" in report
+
+
 def test_level_to_css_class():
     assert level_to_css_class(CRITICAL_LEVEL) == "severity-critical"
     assert level_to_css_class(HIGH_LEVEL) == "severity-high"

--- a/wapitiCore/report/htmlreportgenerator.py
+++ b/wapitiCore/report/htmlreportgenerator.py
@@ -82,7 +82,13 @@ class HTMLReportGenerator(JSONReportGenerator):
         mytemplate = Template(
             filename=str(files("wapitiCore").joinpath(self.REPORT_DIR, "report.html")),
             input_encoding="utf-8",
-            output_encoding="utf-8"
+            output_encoding="utf-8",
+            # HTML-escape every ${...} expression by default. Report data comes from the
+            # scanned target (e.g. auto-detected login form field names) and must never be
+            # rendered as raw HTML, otherwise it could inject script into the report opened
+            # by the auditor. Expressions that already carry an explicit "| h" stay escaped
+            # exactly once (Mako does not double-apply the default filter).
+            default_filters=["h"],
         )
 
         report_target_name = urlparse(self._infos['target']).netloc.replace(':', '_')


### PR DESCRIPTION
## Summary

Harden the HTML report generator so that **every** Mako template expression is HTML-escaped by default.

Mako does not escape `${...}` expressions unless told to, and several fields in `report_template/report.html` were rendered raw. Most carried Wapiti-internal data, but at least one field can carry data taken verbatim from the scanned target, so a crafted target could inject markup into the generated report. Tracked privately in advisory GHSA-7456-hg28-pf5m (low severity).

## Change

`HTMLReportGenerator` now builds the Mako `Template` with `default_filters=["h"]`, so all expressions are HTML-escaped by default. Expressions that already carry an explicit `| h` stay escaped exactly once (Mako does not double-apply the default filter), so the change is minimal and low-risk. None of the rendered values are meant to contain HTML markup.

## Testing

- Added `tests/reports/test_reports.py::test_html_report_escapes_target_controlled_data`, asserting target-controlled data is escaped in the generated report.
- Regenerated the report fixtures: the only content change is one solution text that literally lists `<, >, &` — now correctly entity-encoded.
- `tests/reports/test_reports.py` passes (20 tests); `pylint --rcfile=.pylintrc wapitiCore/report/htmlreportgenerator.py` = 10/10.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
