### PR TITLE
Report distinct passive postures per host + shared PassiveModule base (#617)

### DIFF
--- a/tests/attack/passive/test_base.py
+++ b/tests/attack/passive/test_base.py
@@ -1,0 +1,25 @@
+from wapitiCore.attack.modules.passive.base import PassiveModule
+
+
+def test_should_report_defaults_to_report_once_per_key():
+    module = PassiveModule()
+
+    assert module.should_report(("host", "type")) is True
+    # Same key again is suppressed with the default LIMIT of 1
+    assert module.should_report(("host", "type")) is False
+    assert module.should_report(("host", "type")) is False
+    # A different key is reported independently
+    assert module.should_report(("host", "other")) is True
+
+    assert module.suppressed_findings == 2
+
+
+def test_limit_allows_several_occurrences_before_suppressing():
+    module = PassiveModule()
+    module.LIMIT = 2
+
+    assert module.should_report("k") is True
+    assert module.should_report("k") is True
+    assert module.should_report("k") is False
+
+    assert module.suppressed_findings == 1

--- a/tests/attack/passive/test_mod_csp.py
+++ b/tests/attack/passive/test_mod_csp.py
@@ -9,6 +9,7 @@ from wapitiCore.attack.modules.passive.mod_csp import (
     MSG_CSP_MISSING,
     MSG_CSP_UNSAFE,
     MSG_CSP_UNKNOWN,
+    csp_posture,
 )
 from wapitiCore.definitions.csp import CspFinding
 from wapitiCore.language.vulnerability import MEDIUM_LEVEL, LOW_LEVEL
@@ -229,3 +230,38 @@ def test_module_csp_analyze(module, headers, expected_msgs, expected_severities)
         assert vuln.finding_class == CspFinding
         assert vuln.info == expected_msg
         assert vuln.severity == expected_sev
+
+
+def test_csp_posture_neutralizes_nonces_and_ordering():
+    """Nonces/hashes and directive ordering must not change the posture."""
+    a = csp_posture("script-src 'self' 'nonce-abc123'; object-src 'none'")
+    b = csp_posture("object-src 'none'; script-src 'nonce-XYZ789' 'self'")
+    assert a == b  # per-request nonce + directive ordering neutralized
+    # A genuinely different policy is a different posture.
+    assert csp_posture("script-src 'self' 'unsafe-inline'; object-src 'none'") != a
+
+
+def test_module_csp_same_posture_deduplicated_across_pages(module):
+    """Same weak CSP (modulo nonce) on two URLs of the same host -> reported once."""
+    headers1 = {"Content-Type": "text/html",
+                "Content-Security-Policy": "script-src 'self' 'unsafe-inline' 'nonce-aaa'"}
+    headers2 = {"Content-Type": "text/html",
+                "Content-Security-Policy": "script-src 'self' 'unsafe-inline' 'nonce-bbb'"}
+    req1, resp1 = create_mock_objects("http://example.com/a", response_headers=headers1)
+    req2, resp2 = create_mock_objects("http://example.com/b", response_headers=headers2)
+
+    assert list(module.analyze(req1, resp1))          # first page reports
+    assert not list(module.analyze(req2, resp2))       # identical posture -> deduplicated
+
+
+def test_module_csp_distinct_posture_reported_across_pages(module):
+    """Two genuinely different CSPs on the same host -> each posture surfaces (fixes #617)."""
+    headers1 = {"Content-Type": "text/html",
+                "Content-Security-Policy": "script-src 'self' 'unsafe-inline'"}
+    headers2 = {"Content-Type": "text/html",
+                "Content-Security-Policy": "script-src 'self' *"}
+    req1, resp1 = create_mock_objects("http://example.com/a", response_headers=headers1)
+    req2, resp2 = create_mock_objects("http://example.com/b", response_headers=headers2)
+
+    assert list(module.analyze(req1, resp1))
+    assert list(module.analyze(req2, resp2))           # different posture -> reported again

--- a/tests/attack/passive/test_mod_http_headers.py
+++ b/tests/attack/passive/test_mod_http_headers.py
@@ -134,3 +134,28 @@ def test_module_http_headers_deduplication(module):
     req2, resp2 = create_mock_objects(URL_HTTPS, {})
     vulns2 = list(module.analyze(req2, resp2))
     assert not vulns2
+
+
+def test_module_http_headers_same_invalid_value_deduplicated(module):
+    """Same header carrying the same invalid value on the same host -> reported once."""
+    req1, resp1 = create_mock_objects(
+        URL_HTTP, {"X-Frame-Options": "ALLOWALL", "X-Content-Type-Options": "nosniff"}
+    )
+    req2, resp2 = create_mock_objects(
+        URL_HTTP, {"X-Frame-Options": "ALLOWALL", "X-Content-Type-Options": "nosniff"}
+    )
+    assert [v.info for v in module.analyze(req1, resp1)] == [INVALID_XFRAME_OPTIONS]
+    assert not list(module.analyze(req2, resp2))  # identical posture -> deduplicated
+
+
+def test_module_http_headers_distinct_invalid_values_reported(module):
+    """Same header with two DIFFERENT invalid values on the same host -> both surface."""
+    req1, resp1 = create_mock_objects(
+        URL_HTTP, {"X-Frame-Options": "ALLOWALL", "X-Content-Type-Options": "nosniff"}
+    )
+    req2, resp2 = create_mock_objects(
+        URL_HTTP, {"X-Frame-Options": "SOMETHING-ELSE", "X-Content-Type-Options": "nosniff"}
+    )
+    assert [v.info for v in module.analyze(req1, resp1)] == [INVALID_XFRAME_OPTIONS]
+    # Different offending value -> distinct posture -> reported again.
+    assert [v.info for v in module.analyze(req2, resp2)] == [INVALID_XFRAME_OPTIONS]

--- a/tests/attack/passive/test_passive_scanner.py
+++ b/tests/attack/passive/test_passive_scanner.py
@@ -27,6 +27,25 @@ def test_import_error_is_handled(mock_log_error, _, mock_persister):
     )
 
 
+@patch("pathlib.Path.glob", return_value=[])
+@patch("wapitiCore.attack.passive_scanner.logging.info")
+def test_log_summary_reports_only_modules_with_suppressed_findings(mock_log_info, _, mock_persister):
+    """Only modules that actually suppressed alerts are logged."""
+    scanner = PassiveScanner(persister=mock_persister)
+
+    noisy = MagicMock()
+    noisy.suppressed_findings = 3
+    silent = MagicMock()
+    silent.suppressed_findings = 0
+    scanner._modules = {"noisy": noisy, "silent": silent}
+
+    scanner.log_summary()
+
+    mock_log_info.assert_called_once_with(
+        "%s similar alerts were suppressed by module %s", 3, "noisy"
+    )
+
+
 @patch("pathlib.Path.glob", return_value=[Path("mod_broken.py")])
 @patch("wapitiCore.attack.passive_scanner.import_module")
 @patch("wapitiCore.main.log.logging.error")

--- a/wapitiCore/attack/modules/passive/base.py
+++ b/wapitiCore/attack/modules/passive/base.py
@@ -1,0 +1,60 @@
+# This file is part of the Wapiti project (https://wapiti-scanner.github.io)
+# Copyright (C) 2026 Nicolas Surribas
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA
+from collections import defaultdict
+from typing import Any, Generator
+
+from wapitiCore.model.vulnerability import VulnerabilityInstance
+from wapitiCore.net import Request, Response
+
+
+class PassiveModule:
+    """Base class shared by every passive module.
+
+    It centralizes the anti-flood logic that used to be copy-pasted in each
+    module: a per-key occurrence cap (:attr:`LIMIT`) and a counter of the alerts
+    that were suppressed once that cap was reached. Historically each module kept
+    its own ``set`` of already reported identifiers, which is exactly this model
+    with ``LIMIT = 1``.
+    """
+
+    name: str = ""
+    # Maximum number of alerts reported per deduplication key. The default of 1
+    # reproduces the historical "report once per key" behavior.
+    LIMIT: int = 1
+
+    def __init__(self):
+        self._occurrences: dict = defaultdict(int)
+        # Number of alerts dropped because their key already reached LIMIT.
+        self.suppressed_findings: int = 0
+
+    def should_report(self, key: Any) -> bool:
+        """Return True for the first :attr:`LIMIT` occurrences of a key, then False.
+
+        A single decision drives both logging and persistence: when it returns
+        False the caller must emit nothing (no log line, no finding) — the alert
+        is only counted as suppressed. This guarantees logs and report never
+        diverge.
+        """
+        if self._occurrences[key] >= self.LIMIT:
+            self.suppressed_findings += 1
+            return False
+
+        self._occurrences[key] += 1
+        return True
+
+    def analyze(self, request: Request, response: Response) -> Generator[VulnerabilityInstance, Any, None]:
+        raise NotImplementedError

--- a/wapitiCore/attack/modules/passive/mod_cookie_flags.py
+++ b/wapitiCore/attack/modules/passive/mod_cookie_flags.py
@@ -16,6 +16,7 @@
 # Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 from typing import Generator, Any, List, Tuple
 
+from wapitiCore.attack.modules.passive.base import PassiveModule
 from wapitiCore.model.vulnerability import VulnerabilityInstance
 from wapitiCore.net.web import urlparse
 from wapitiCore.net import Request, Response
@@ -80,18 +81,12 @@ def _get_cookies_from_response(response: Response) -> List[Tuple[str, str, bool,
     return cookies_list
 
 
-class ModuleCookieFlags:
+class ModuleCookieFlags(PassiveModule):
     """
     Passively evaluates the security of cookies present in HTTP responses.
     """
 
     name = "cookieflags"
-
-    def __init__(self):
-        # To avoid reporting the same issue for the same cookie multiple times.
-        # We will store identifiers of already reported cookies.
-        # An identifier could be (cookie_name, cookie_domain, flag_type_missing)
-        self._reported_cookies: set[tuple[str, str, str]] = set()
 
     def analyze(
         self, request: Request, response: Response
@@ -110,8 +105,7 @@ class ModuleCookieFlags:
             # HttpOnly check
             if not httponly_flag:
                 identifier = (cookie_name, cookie_domain, "HttpOnly")
-                if identifier not in self._reported_cookies:
-                    self._reported_cookies.add(identifier)
+                if self.should_report(identifier):
                     log_red(INFO_COOKIE_HTTPONLY.format(cookie_name, request.url))
                     yield VulnerabilityInstance(
                         finding_class=HttpOnlyFinding,
@@ -124,8 +118,7 @@ class ModuleCookieFlags:
             # Secure flag check
             if not secure_flag:
                 identifier = (cookie_name, cookie_domain, "Secure")
-                if identifier not in self._reported_cookies:
-                    self._reported_cookies.add(identifier)
+                if self.should_report(identifier):
                     log_red(INFO_COOKIE_SECURE.format(cookie_name, request.url))
                     yield VulnerabilityInstance(
                         finding_class=SecureCookieFinding,

--- a/wapitiCore/attack/modules/passive/mod_csp.py
+++ b/wapitiCore/attack/modules/passive/mod_csp.py
@@ -16,6 +16,7 @@
 # along with this program; if not, write to the Free Software
 # Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA
 
+import re
 from typing import Generator, Any
 
 from wapitiCore.attack.modules.passive.base import PassiveModule
@@ -36,6 +37,24 @@ MSG_CSP_MISSING = "CSP attribute \"{0}\" is missing for URL: {1}"
 MSG_CSP_UNSAFE = "CSP \"{0}\" value is not safe for URL: {1}"
 MSG_CSP_UNKNOWN = "CSP directive \"{0}\" is unknown or misspelled for URL: {1}"
 
+# Nonces and hashes rotate on every response; they must not turn one policy into a
+# distinct posture per page, otherwise every crawled page would re-report the same
+# CSP weakness.
+_CSP_DYNAMIC_TOKEN = re.compile(r"'(?:nonce-[^']*|sha(?:256|384|512)-[^']*)'", re.IGNORECASE)
+
+
+def csp_posture(csp_header_value: str) -> str:
+    """Return a canonical, dynamic-free fingerprint of a CSP header for deduplication.
+
+    Two responses whose policies are equivalent (modulo token ordering and per-request
+    nonces/hashes) share the same posture and are reported once; a genuinely different
+    policy served elsewhere on the site is a distinct posture and reported separately.
+    """
+    without_dynamic = _CSP_DYNAMIC_TOKEN.sub("", csp_header_value.lower())
+    # Make ';' a standalone token so directive separators fingerprint the same
+    # regardless of the surrounding whitespace in the raw header.
+    return " ".join(sorted(without_dynamic.replace(";", " ; ").split()))
+
 
 class ModuleCsp(PassiveModule):
     """
@@ -51,9 +70,12 @@ class ModuleCsp(PassiveModule):
             return
 
         csp_header_value = response.headers.get("Content-Security-Policy")
+        # Distinct CSP configurations across the site are distinct postures: each is
+        # reported once (LIMIT), instead of only the first crawled page (was per-netloc).
+        posture = csp_posture(csp_header_value or "")
 
         if not csp_header_value:
-            identifier = (request.netloc, "CSP", "Missing")
+            identifier = (request.netloc, "CSP", "Missing", posture)
 
             if self.should_report(identifier):
                 log_red(MSG_NO_CSP.format(request.url))
@@ -68,7 +90,7 @@ class ModuleCsp(PassiveModule):
             csp_dict = csp_header_to_dict(csp_header_value)
 
             for directive in find_unknown_directives(csp_dict):
-                identifier = (request.netloc, directive, "Unknown")
+                identifier = (request.netloc, directive, "Unknown", posture)
                 if self.should_report(identifier):
                     info = MSG_CSP_UNKNOWN.format(directive, request.url)
                     log_red(info)
@@ -96,7 +118,7 @@ class ModuleCsp(PassiveModule):
                         severity = MEDIUM_LEVEL
 
                 if info:
-                    identifier = (request.netloc, policy_name, "Unsafe" if result == 0 else "Missing")
+                    identifier = (request.netloc, policy_name, "Unsafe" if result == 0 else "Missing", posture)
                     if self.should_report(identifier):
                         log_red(info)
                         yield VulnerabilityInstance(

--- a/wapitiCore/attack/modules/passive/mod_csp.py
+++ b/wapitiCore/attack/modules/passive/mod_csp.py
@@ -16,8 +16,9 @@
 # along with this program; if not, write to the Free Software
 # Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA
 
-from typing import Generator, Any, Tuple
+from typing import Generator, Any
 
+from wapitiCore.attack.modules.passive.base import PassiveModule
 from wapitiCore.model.vulnerability import VulnerabilityInstance
 from wapitiCore.net import Request, Response
 from wapitiCore.net.csp_utils import (
@@ -36,16 +37,11 @@ MSG_CSP_UNSAFE = "CSP \"{0}\" value is not safe for URL: {1}"
 MSG_CSP_UNKNOWN = "CSP directive \"{0}\" is unknown or misspelled for URL: {1}"
 
 
-class ModuleCsp:
+class ModuleCsp(PassiveModule):
     """
     Passively evaluates the security level of Content Security Policies in HTTP responses.
     """
     name = "csp"
-
-    def __init__(self):
-        # We wait to avoid flooding the user with repeated CSP misconfiguration
-        # Keep some identified cases here for each netloc
-        self._reported_csp_issues: set[Tuple[str, str, str]] = set()
 
     def analyze(self, request: Request, response: Response) -> Generator[VulnerabilityInstance, Any, None]:
         """
@@ -59,8 +55,7 @@ class ModuleCsp:
         if not csp_header_value:
             identifier = (request.netloc, "CSP", "Missing")
 
-            if identifier not in self._reported_csp_issues:
-                self._reported_csp_issues.add(identifier)
+            if self.should_report(identifier):
                 log_red(MSG_NO_CSP.format(request.url))
                 yield VulnerabilityInstance(
                     finding_class=CspFinding,
@@ -74,8 +69,7 @@ class ModuleCsp:
 
             for directive in find_unknown_directives(csp_dict):
                 identifier = (request.netloc, directive, "Unknown")
-                if identifier not in self._reported_csp_issues:
-                    self._reported_csp_issues.add(identifier)
+                if self.should_report(identifier):
                     info = MSG_CSP_UNKNOWN.format(directive, request.url)
                     log_red(info)
                     yield VulnerabilityInstance(
@@ -103,8 +97,7 @@ class ModuleCsp:
 
                 if info:
                     identifier = (request.netloc, policy_name, "Unsafe" if result == 0 else "Missing")
-                    if identifier not in self._reported_csp_issues:
-                        self._reported_csp_issues.add(identifier)
+                    if self.should_report(identifier):
                         log_red(info)
                         yield VulnerabilityInstance(
                             finding_class=CspFinding,

--- a/wapitiCore/attack/modules/passive/mod_http_headers.py
+++ b/wapitiCore/attack/modules/passive/mod_http_headers.py
@@ -15,8 +15,9 @@
 # You should have received a copy of the GNU General Public License
 # along with this program; if not, write to the Free Software
 # Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
-from typing import List, Optional, Type, Generator, Any, Tuple
+from typing import List, Optional, Type, Generator, Any
 
+from wapitiCore.attack.modules.passive.base import PassiveModule
 from wapitiCore.definitions import FindingBase
 from wapitiCore.net.web import urlparse
 from wapitiCore.net.response import Response
@@ -34,7 +35,7 @@ INVALID_XCONTENT_TYPE = "X-Content-Type-Options has an invalid value ('nosniff' 
 INVALID_XFRAME_OPTIONS = "X-Frame-Options has an invalid value ('deny' or 'sameorigin' or not found)"
 
 
-class ModuleHttpHeaders:
+class ModuleHttpHeaders(PassiveModule):
     """
     Passively evaluates the security of HTTP headers present in HTTP responses.
     """
@@ -61,10 +62,6 @@ class ModuleHttpHeaders:
             "finding": HstsFinding,
         }
     }
-
-    def __init__(self):
-        self._reported_findings: set[Tuple[str, str, str]] = set()
-
 
     @staticmethod
     def is_set(response: Response, header_name: str) -> bool:
@@ -94,8 +91,7 @@ class ModuleHttpHeaders:
             finding_info = info_messages["error"]
             identifier = (target, header_name, "not_set")
 
-            if identifier not in self._reported_findings:
-                self._reported_findings.add(identifier)
+            if self.should_report(identifier):
                 log_red(f"{finding_info} on {request.url}")
                 return VulnerabilityInstance(
                     finding_class=finding_class,
@@ -107,8 +103,7 @@ class ModuleHttpHeaders:
         elif not self.contains(response, header_name, check_list):
             finding_info = info_messages["warning"]
             identifier = (target, header_name, "invalid_value")
-            if identifier not in self._reported_findings:
-                self._reported_findings.add(identifier)
+            if self.should_report(identifier):
                 log_orange(f"{finding_info} on {request.url}")
                 return VulnerabilityInstance(
                     finding_class=finding_class,

--- a/wapitiCore/attack/modules/passive/mod_http_headers.py
+++ b/wapitiCore/attack/modules/passive/mod_http_headers.py
@@ -89,7 +89,9 @@ class ModuleHttpHeaders(PassiveModule):
 
         if not self.is_set(response, header_name):
             finding_info = info_messages["error"]
-            identifier = (target, header_name, "not_set")
+            # A missing header is a single posture (empty value), so it is reported
+            # once per (netloc, header), as before.
+            identifier = (target, header_name, "not_set", "")
 
             if self.should_report(identifier):
                 log_red(f"{finding_info} on {request.url}")
@@ -102,7 +104,10 @@ class ModuleHttpHeaders(PassiveModule):
                 )
         elif not self.contains(response, header_name, check_list):
             finding_info = info_messages["warning"]
-            identifier = (target, header_name, "invalid_value")
+            # Include the offending value so pages that carry *different* invalid values
+            # for the same header each surface, while identical ones are deduplicated.
+            posture = response.headers[header_name].strip().lower()
+            identifier = (target, header_name, "invalid_value", posture)
             if self.should_report(identifier):
                 log_orange(f"{finding_info} on {request.url}")
                 return VulnerabilityInstance(

--- a/wapitiCore/attack/modules/passive/mod_https_redirect.py
+++ b/wapitiCore/attack/modules/passive/mod_https_redirect.py
@@ -18,8 +18,9 @@
 # You should have received a copy of the GNU General Public License
 # along with this program; if not, write to the Free Software
 # Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA
-from typing import Generator, Any, Tuple
+from typing import Generator, Any
 
+from wapitiCore.attack.modules.passive.base import PassiveModule
 from wapitiCore.net import Request
 from wapitiCore.net.web import urlparse
 from wapitiCore.net.response import Response
@@ -29,7 +30,7 @@ from wapitiCore.language.vulnerability import LOW_LEVEL, MEDIUM_LEVEL
 from wapitiCore.main.log import log_orange, log_red
 
 
-class ModuleHttpsRedirect:
+class ModuleHttpsRedirect(PassiveModule):
     """Check for HTTPS redirections on sensitive HTTP requests."""
     name = "https_redirect"
 
@@ -48,13 +49,6 @@ class ModuleHttpsRedirect:
     MSG_REASON_RESPONSE_COOKIES = "cookie in the response"
 
     MSG_INFO_NO_REDIRECT = "No HTTPS redirection for this host. All HTTP requests are served in clear text."
-
-    def __init__(self):
-        """
-        Init the module along with the set of reported findings.
-        """
-        self._reported_findings_sensitive: set[Tuple[str, str, str]] = set()
-        self._reported_info_non_sensitive: set[str] = set()
 
     def _get_sensitive_reason(self, request: Request, response: Response) -> str:
         """
@@ -91,9 +85,7 @@ class ModuleHttpsRedirect:
                 finding_type = "no_redirect"
 
             identifier = (host, sensitive_reason, finding_type)
-            if identifier not in self._reported_findings_sensitive:
-                self._reported_findings_sensitive.add(identifier)
-
+            if self.should_report(identifier):
                 # Report the vulnerability based on the type of redirection
                 if finding_type == "redirect_to_https":
                     full_info = self.MSG_SENSITIVE_REDIRECT_TO_HTTPS.format(reason=sensitive_reason, url=request.url)
@@ -115,8 +107,7 @@ class ModuleHttpsRedirect:
                 )
         elif "html" in response.headers.get("content-type", "html").lower():
             # Non-sensitive case, check for general lack of HTTPS redirection
-            if host not in self._reported_info_non_sensitive:
-                self._reported_info_non_sensitive.add(host)
+            if self.should_report(host):
                 if not response.is_redirect or urlparse(response.redirection_url).scheme != "https":
                     log_orange(f"Host {host} serves HTTP content without redirecting to HTTPS.")
                     yield VulnerabilityInstance(

--- a/wapitiCore/attack/modules/passive/mod_inconsistent_redirection.py
+++ b/wapitiCore/attack/modules/passive/mod_inconsistent_redirection.py
@@ -1,6 +1,7 @@
 from typing import Generator, Any, Optional
 from urllib.parse import urlparse
 
+from wapitiCore.attack.modules.passive.base import PassiveModule
 from wapitiCore.definitions.inconsistent_redirection import InconsistentRedirectionFinding
 from wapitiCore.language.vulnerability import MEDIUM_LEVEL
 from wapitiCore.main.log import log_orange
@@ -29,17 +30,13 @@ def _points_to_redirection_target(link: str, target: Optional[str]) -> bool:
     return _resource_key(link) == _resource_key(target)
 
 
-class ModuleInconsistentRedirection:
+class ModuleInconsistentRedirection(PassiveModule):
     """
     Detects when a 3xx redirection response also returns meaningful HTML content
     (like links or forms), which may confuse clients and pose security risks.
     """
 
     name = "inconsistent_redirection"
-
-    def __init__(self):
-        # Keep track of already-reported responses, by response MD5
-        self._reported_hashes = set()
 
     def analyze(self, request: Request, response: Response) -> Generator[VulnerabilityInstance, Any, None]:
         if not response.is_redirect:
@@ -70,10 +67,8 @@ class ModuleInconsistentRedirection:
             return
 
         # Deduplicate with response MD5
-        if response.md5 in self._reported_hashes:
+        if not self.should_report(response.md5):
             return
-
-        self._reported_hashes.add(response.md5)
 
         log_orange(
             f"Redirection response at {request.url} contains HTML content with links/forms"

--- a/wapitiCore/attack/modules/passive/mod_information_disclosure.py
+++ b/wapitiCore/attack/modules/passive/mod_information_disclosure.py
@@ -1,6 +1,7 @@
 import re
 from typing import Generator, Any
 
+from wapitiCore.attack.modules.passive.base import PassiveModule
 from wapitiCore.definitions.information_disclosure import InformationDisclosureFinding
 from wapitiCore.language.vulnerability import LOW_LEVEL
 from wapitiCore.main.log import log_orange
@@ -62,17 +63,13 @@ def _is_realistic_path(candidate: str) -> bool:
     )
 
 
-class ModuleInformationDisclosure:
+class ModuleInformationDisclosure(PassiveModule):
     """
     Detects disclosure of full system paths (Windows/Unix) in HTTP responses.
     Such paths may reveal sensitive information about the server environment.
     """
 
     name = "information_disclosure"
-
-    def __init__(self):
-        # track already-reported paths
-        self._reported_paths = set()
 
     def analyze(
         self, request: Request, response: Response
@@ -90,10 +87,8 @@ class ModuleInformationDisclosure:
             if not _is_realistic_path(evidence):
                 continue
 
-            if evidence.rstrip(".") in self._reported_paths:
+            if not self.should_report(evidence.rstrip(".")):
                 continue
-
-            self._reported_paths.add(evidence.rstrip("."))
 
             log_orange(f"Potential full path disclosure in {request.url}: {evidence}")
             yield VulnerabilityInstance(

--- a/wapitiCore/attack/modules/passive/mod_stacktrace_disclosure.py
+++ b/wapitiCore/attack/modules/passive/mod_stacktrace_disclosure.py
@@ -1,6 +1,7 @@
 import re
 from typing import Generator, Any
 
+from wapitiCore.attack.modules.passive.base import PassiveModule
 from wapitiCore.definitions.stacktrace_disclosure import StacktraceDisclosureFinding
 from wapitiCore.language.vulnerability import MEDIUM_LEVEL
 from wapitiCore.main.log import log_orange
@@ -90,7 +91,7 @@ STACKTRACE_PATTERNS = [
 ]
 
 
-class ModuleStacktraceDisclosure:
+class ModuleStacktraceDisclosure(PassiveModule):
     """
     Detects framework/language stack traces and unhandled error messages
     leaked in HTTP responses (Python, PHP, Java, .NET, Node.js, Ruby, Go).
@@ -98,10 +99,6 @@ class ModuleStacktraceDisclosure:
     """
 
     name = "stacktrace_disclosure"
-
-    def __init__(self):
-        # Track already-reported (language, evidence) pairs across the scan.
-        self._reported = set()
 
     def analyze(
         self, request: Request, response: Response
@@ -125,9 +122,8 @@ class ModuleStacktraceDisclosure:
                 evidence = evidence[:150] + "..."
 
             key = (label, evidence)
-            if key in self._reported:
+            if not self.should_report(key):
                 continue
-            self._reported.add(key)
 
             log_orange(
                 f"Potential {label} stack trace disclosure in {request.url}: {evidence}"

--- a/wapitiCore/attack/modules/passive/mod_unsecure_password.py
+++ b/wapitiCore/attack/modules/passive/mod_unsecure_password.py
@@ -1,5 +1,6 @@
 from typing import Generator, Any
 
+from wapitiCore.attack.modules.passive.base import PassiveModule
 from wapitiCore.definitions.cleartext_password_submission import CleartextPasswordSubmissionFinding
 from wapitiCore.language.vulnerability import HIGH_LEVEL
 from wapitiCore.main.log import log_red
@@ -9,14 +10,11 @@ from wapitiCore.net import Request, Response
 from wapitiCore.parsers.html_parser import Html
 
 
-class ModuleUnsecurePassword:
+class ModuleUnsecurePassword(PassiveModule):
     """
     Detects passwords sent over a non-encrypted (TLS) channel
     """
     name = "unsecure_password"
-
-    def __init__(self):
-        self._known_vulnerable_forms = set()
 
     def analyze(self, request: Request, response: Response) ->  Generator[VulnerabilityInstance, Any, None]:
         if "text/html" not in response.type:
@@ -29,10 +27,9 @@ class ModuleUnsecurePassword:
                     if field.tag_type == "password":
                         form_identifier = (form.url, form.method.upper(), field.name)
 
-                        if form_identifier in self._known_vulnerable_forms:
+                        if not self.should_report(form_identifier):
                             continue
 
-                        self._known_vulnerable_forms.add(form_identifier)
                         log_red(
                             "Cleartext transmission of sensitive information: "
                             f"Password field '{field.name}' is sent over unencrypted connections from URL {request.url}"

--- a/wapitiCore/attack/passive_scanner.py
+++ b/wapitiCore/attack/passive_scanner.py
@@ -51,6 +51,21 @@ class PassiveScanner:
             for vulnerability in passive_module_instance.analyze(request, response):
                 await self._record_vulnerability_instance(vulnerability, passive_module_name)
 
+    def log_summary(self):
+        """Log, once at the end of the crawl, how many alerts each module suppressed.
+
+        Passive modules cap the number of alerts they emit per deduplication key
+        to avoid flooding the report (see ``PassiveModule.should_report``). This
+        reports the volume that was silently dropped, mirroring the way the active
+        scanner surfaces its ``network_errors`` counter.
+        """
+        for module_name, module_instance in self._modules.items():
+            suppressed = getattr(module_instance, "suppressed_findings", 0)
+            if suppressed:
+                logging.info(
+                    "%s similar alerts were suppressed by module %s", suppressed, module_name
+                )
+
     async def _record_vulnerability_instance(self, vuln_instance: VulnerabilityInstance, module: str):
         await self._persister.add_payload(
             payload_type=vuln_instance.finding_class.type(),

--- a/wapitiCore/controller/wapiti.py
+++ b/wapitiCore/controller/wapiti.py
@@ -309,6 +309,8 @@ class Wapiti:
 
             await run_explorer(explorer)
 
+        self._passive_scanner.log_summary()
+
     async def write_report(self):
         if not self.output_file:
             if self.report_generator_type == "html":


### PR DESCRIPTION
## Summary

Addresses #617: passive modules were reporting a given misconfiguration only once per host, hiding genuine variations of the same posture found on other pages.

This branch has two commits:

1. **`refactor(passive): add PassiveModule base with per-key alert cap and suppression counter`**
   - The 8 passive modules each copy-pasted their own anti-flood logic (a `set` of already-reported identifiers gated with `if identifier not in set`), conflating three concerns: what enters the report, the dedup key, and what gets logged.
   - Introduces a shared `PassiveModule` base class with a single decision `should_report(key)` (a per-key occurrence cap, `LIMIT = 1` by default, reproducing the historical "report once per key" behavior) and a `suppressed_findings` counter.
   - `PassiveScanner.log_summary()` now surfaces, once after the crawl, how many alerts each module suppressed — mirroring how the active scanner reports its `network_errors`.
   - Behavior is strictly identical to before, plus the new counter.

2. **`feat(passive): report distinct CSP/header postures per host instead of once`**
   - Adds the security-relevant value to the deduplication key so distinct postures each surface, while identical ones stay deduplicated (`LIMIT` still 1):
     - **http_headers**: the offending header value for the `invalid_value` case (a missing header keeps an empty posture, so it is still reported once per host).
     - **csp**: a canonical, dynamic-free fingerprint of the CSP header (per-request nonces/hashes stripped, tokens sorted) so a rotating nonce does not re-flood, while a genuinely different policy elsewhere on the site is reported.
   - `https_redirect` is left unchanged: its key `(host, reason, finding_type)` already encodes the posture; the only per-request element is the URL, and keying on it would flood.

No CLI knob is added; `LIMIT` stays 1.

## Test plan

- New unit tests: `tests/attack/passive/test_base.py`, plus additions to `test_mod_csp.py`, `test_mod_http_headers.py`, `test_passive_scanner.py`.
- Verified end-to-end: two pages serving different CSPs now both yield findings, while an identical CSP site-wide still reports on a single page.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
