### PR TITLE
chore(deps): update dependencies and dev tooling

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -18,7 +18,7 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install -e .
-          pip install "pylint==3.3.6"
+          pip install "pylint==4.0.6"
       - name: Pylint
         run: |
           pylint --rcfile=.pylintrc wapitiCore

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,7 @@ classifiers = [
         "Topic :: Software Development :: Testing"
 ]
 dependencies = [
-    "aiosqlite>=0.19,<0.22.0",
+    "aiosqlite>=0.22.1,<0.23",
     "playwright>=1.42,<2.0",
     "beautifulsoup4>=4.12,<5.0",
     "browser-cookie3>=0.19,<0.21",
@@ -41,8 +41,8 @@ dependencies = [
     "httpx[brotli,socks]>=0.27,<1.0",
     "httpx-ntlm>=1.4,<2.0",
     "mako>=1.2,<2.0",
-    "mitmproxy>=12.0,<13.0",
-    "packaging>=23.0,<26.0",
+    "mitmproxy>=12.2.3,<13.0",
+    "packaging>=23.0,<27.0",
     "sqlalchemy>=2.0,<3.0",
     "tld>=0.13,<0.14",
     "wapiti-swagger>=0.1.9,<0.2.0",
@@ -59,20 +59,20 @@ wapiti-install-headless-browser = "wapitiCore.main.headless:install_browser"
 
 [project.optional-dependencies]
 test = [
-  "pytest>=8.0,<9.0",
-  "pytest-cov>=4.1,<5.0",
-  "pytest-asyncio>=0.23,<1.0",
-  "respx>=0.22,<1.0",
+  "pytest>=8.0,<10.0",
+  "pytest-cov>=7.0,<8.0",
+  "pytest-asyncio>=1.0,<2.0",
+  "respx>=0.23.1,<1.0",
 ]
 
 dev = [
   "build",
   "wheel",
-  "pylint>=3.2,<4.0",
-  "pytest>=8.0,<9.0",
-  "pytest-cov>=4.1,<5.0",
-  "pytest-asyncio>=0.23,<1.0",
-  "respx>=0.22,<1.0",
+  "pylint>=4.0,<5.0",
+  "pytest>=8.0,<10.0",
+  "pytest-cov>=7.0,<8.0",
+  "pytest-asyncio>=1.0,<2.0",
+  "respx>=0.23.1,<1.0",
   "humanize>=4.5,<5.0",
 ]
 
@@ -84,6 +84,7 @@ testpaths = [
     "tests",
 ]
 addopts = "--cov --cov-report=xml"
+asyncio_default_fixture_loop_scope = "function"
 
 [tool.coverage.run]
 source = ["wapitiCore"]


### PR DESCRIPTION
## Summary

Refresh of runtime and dev/test dependency bounds. Each change was validated by running the full test suite against the bumped versions in a throwaway venv (Python 3.13); no regressions were introduced by these bumps.

### Runtime

| Dependency | Before | After | Why |
|---|---|---|---|
| `aiosqlite` | `>=0.19,<0.22.0` | `>=0.22.1,<0.23` | 0.22.0 was a breaking release (`Connection` no longer subclasses `Thread`) and triggered a SQLAlchemy async hang ([omnilib/aiosqlite#369](https://github.com/omnilib/aiosqlite/issues/369), now fixed). Pin to the fixed **0.22.1** — validated against the persister tests, no hang. |
| `mitmproxy` | `>=12.0,<13.0` | `>=12.2.3,<13.0` | Picks up the LDAP-injection security fix and Python 3.14 support. Addon API used by Wapiti is unchanged. |
| `packaging` | `>=23.0,<26.0` | `>=23.0,<27.0` | Allow the 26.x CalVer line (no API break). |

`httpx` / `httpcore` / `httpx-ntlm` are intentionally left untouched here.

### Dev / test tooling

Bumped to current majors: `pytest` 9, `pytest-cov` 7, `pytest-asyncio` 1, `respx` 0.23.1 (skips the 0.23.0 `params` regression), `pylint` 4.

- The CI `code_style` job pin is bumped to `pylint==4.0.6` so the range bump is actually exercised. `wapitiCore` is still rated **10.00/10**.
- Added `asyncio_default_fixture_loop_scope = "function"` to `[tool.pytest.ini_options]` to silence the pytest-asyncio 1.x deprecation warning.

## Test plan

- [x] `pylint --rcfile=.pylintrc wapitiCore` → 10.00/10 (pylint 4.0.6)
- [x] Full unit test suite run against the bumped versions — pre-existing environment-dependent failures only (HTML-parser differences per #698, missing headless browser / OOB targets), identical to a baseline run with the old pins
- [x] Persister / passive-scanner tests pass against aiosqlite 0.22.1 with no hang

🤖 Generated with [Claude Code](https://claude.com/claude-code)