### PR TITLE
fix(cli): don't hang on Ctrl+C during an attack (#802)

### DIFF
--- a/tests/attack/test_active_scanner.py
+++ b/tests/attack/test_active_scanner.py
@@ -1,3 +1,4 @@
+import asyncio
 import types
 from pathlib import Path
 from typing import Tuple
@@ -447,3 +448,33 @@ async def test_init_attack_modules_sorts_by_priority():
     assert {m.name for m in modules} == {"low", "high"}
     # Ensure they are sorted by PRIORITY (high first, then low)
     assert [m.name for m in modules] == ["high", "low"]
+
+
+@pytest.mark.asyncio
+async def test_attack_wrapper_returns_early_when_task_cancelled():
+    scanner = ActiveScanner(MagicMock(), MagicMock())
+    task = asyncio.create_task(asyncio.sleep(3600))
+    task.cancel()
+    try:
+        await task
+    except asyncio.CancelledError:
+        pass
+    scanner._current_attack_task = task
+    assert task.cancelled()
+
+    scanner._bug_report = True
+    scanner.send_bug_report = AsyncMock()
+
+    attack_module = MagicMock()
+    attack_module.name = "test_module"
+    attack_module.must_attack = AsyncMock(side_effect=Exception("db error during cancellation"))
+    attack_module.attack = AsyncMock()
+
+    request = MagicMock()
+    response = MagicMock()
+    attacked_ids = set()
+    semaphore = asyncio.Semaphore(10)
+
+    await scanner._attack_wrapper(attack_module, request, response, attacked_ids, semaphore)
+
+    scanner.send_bug_report.assert_not_called()

--- a/tests/cli/test_shutdown.py
+++ b/tests/cli/test_shutdown.py
@@ -1,0 +1,75 @@
+import sys
+from unittest import mock
+
+import asyncio
+import pytest
+
+from wapitiCore.main.wapiti import _shutdown, wapiti_asyncio_wrapper
+
+
+class TestShutdown:
+    @pytest.mark.asyncio
+    async def test_shutdown_no_pending_tasks(self):
+        loop = asyncio.get_running_loop()
+        await _shutdown(loop, timeout=1.0)
+
+    @pytest.mark.asyncio
+    async def test_shutdown_pending_tasks_are_cancelled(self):
+        loop = asyncio.get_running_loop()
+
+        async def never_finish():
+            while True:
+                await asyncio.sleep(3600)
+
+        task = asyncio.create_task(never_finish())
+        await asyncio.sleep(0)
+        assert not task.cancelled()
+
+        await _shutdown(loop, timeout=0.5)
+        assert task.cancelled()
+
+    @pytest.mark.asyncio
+    async def test_shutdown_hanging_task_times_out(self):
+        loop = asyncio.get_running_loop()
+
+        hang = asyncio.Event()
+
+        async def hanging_task():
+            await hang.wait()
+
+        task = asyncio.create_task(hanging_task())
+        await asyncio.sleep(0)
+        assert not task.done()
+
+        await _shutdown(loop, timeout=0.1)
+        assert task.cancelled()
+
+
+class TestMonkeyPatch:
+    def test_patch_applied_when_sqlalchemy_available(self):
+        from wapitiCore.main.wapiti import _timed_terminate_graceful_close
+        import sqlalchemy.dialects.sqlite.aiosqlite as sa_aiosqlite
+        assert sa_aiosqlite.AsyncAdapt_terminate._terminate_graceful_close is _timed_terminate_graceful_close
+
+    @pytest.mark.asyncio
+    async def test_timed_terminate_calls_original(self):
+        from wapitiCore.main.wapiti import _timed_terminate_graceful_close, _ORIGINAL_TERMINATE
+        original = _ORIGINAL_TERMINATE
+
+        async def dummy_original(_self):
+            pass
+
+        with mock.patch("wapitiCore.main.wapiti._ORIGINAL_TERMINATE", dummy_original):
+            mock_self = mock.AsyncMock()
+            await _timed_terminate_graceful_close(mock_self)
+
+    @pytest.mark.asyncio
+    async def test_timed_terminate_timeout_does_not_raise(self):
+        from wapitiCore.main.wapiti import _timed_terminate_graceful_close
+
+        async def hanging(_self):
+            await asyncio.Event().wait()
+
+        with mock.patch("wapitiCore.main.wapiti._ORIGINAL_TERMINATE", hanging):
+            mock_self = mock.AsyncMock()
+            await _timed_terminate_graceful_close(mock_self)

--- a/wapitiCore/attack/active_scanner.py
+++ b/wapitiCore/attack/active_scanner.py
@@ -201,6 +201,10 @@ class ActiveScanner:
             except InvalidURL:
                 pass
             except Exception as exception:  # pylint: disable=broad-except
+                # If the attack task was cancelled, DB connection errors during
+                # cleanup are expected side effects, not real bugs.
+                if self._current_attack_task is not None and self._current_attack_task.cancelled():
+                    return
                 exception_traceback = sys.exc_info()[2]
                 logging.exception("An exception occurred in module %s", attack_module.name)
                 if self._bug_report:

--- a/wapitiCore/main/wapiti.py
+++ b/wapitiCore/main/wapiti.py
@@ -39,7 +39,7 @@ from sqlite3 import OperationalError
 try:
     import sqlalchemy.dialects.sqlite.aiosqlite as sa_aiosqlite  # type: ignore[import-untyped] # noqa: E501
 
-    _ORIGINAL_TERMINATE = sa_aiosqlite.AsyncAdapt_terminate._terminate_graceful_close
+    _ORIGINAL_TERMINATE = sa_aiosqlite.AsyncAdapt_terminate._terminate_graceful_close  # pylint: disable=protected-access
 
     async def _timed_terminate_graceful_close(self):
         try:
@@ -47,7 +47,7 @@ try:
         except asyncio.TimeoutError:
             pass  # terminate() will call force_close()
 
-    sa_aiosqlite.AsyncAdapt_terminate._terminate_graceful_close = (  # type: ignore[method-assign] # noqa: E501
+    sa_aiosqlite.AsyncAdapt_terminate._terminate_graceful_close = (  # type: ignore[method-assign] # pylint: disable=protected-access  # noqa: E501
         _timed_terminate_graceful_close
     )
 except (ImportError, AttributeError):

--- a/wapitiCore/main/wapiti.py
+++ b/wapitiCore/main/wapiti.py
@@ -27,6 +27,32 @@ from importlib import import_module
 from inspect import getdoc
 from sqlite3 import OperationalError
 
+# ── Monkey-patch SQLAlchemy's aiosqlite connection termination ──────────────
+# With aiosqlite >= 0.22, Connection.close() can hang when called from inside
+# asyncio.shield() during task cancellation (the worker-thread future never
+# resolves).  SQLAlchemy wraps it in asyncio.shield() so the hang propagates
+# to the event loop teardown and the process must be killed.
+#
+# We add a 5-second timeout to the graceful close.  If the close hangs,
+# asyncio.TimeoutError is raised, which terminate() catches (it is listed in
+# _terminate_handled_exceptions) and falls back to _terminate_force_close().
+try:
+    import sqlalchemy.dialects.sqlite.aiosqlite as sa_aiosqlite  # type: ignore[import-untyped] # noqa: E501
+
+    _ORIGINAL_TERMINATE = sa_aiosqlite.AsyncAdapt_terminate._terminate_graceful_close
+
+    async def _timed_terminate_graceful_close(self):
+        try:
+            await asyncio.wait_for(_ORIGINAL_TERMINATE(self), timeout=5.0)
+        except asyncio.TimeoutError:
+            pass  # terminate() will call force_close()
+
+    sa_aiosqlite.AsyncAdapt_terminate._terminate_graceful_close = (  # type: ignore[method-assign] # noqa: E501
+        _timed_terminate_graceful_close
+    )
+except (ImportError, AttributeError):
+    pass  # aiosqlite or SQLAlchemy not available (tests, minimal install)
+
 import httpx
 from httpx import RequestError
 
@@ -515,4 +541,28 @@ async def wapiti_main():
 
 
 def wapiti_asyncio_wrapper():
-    asyncio.run(wapiti_main())
+    loop = asyncio.new_event_loop()
+    asyncio.set_event_loop(loop)
+    try:
+        loop.run_until_complete(wapiti_main())
+    except (KeyboardInterrupt, RuntimeError):
+        pass
+    finally:
+        try:
+            loop.run_until_complete(_shutdown(loop))
+        except (asyncio.TimeoutError, KeyboardInterrupt, RuntimeError):
+            pass
+        try:
+            loop.run_until_complete(loop.shutdown_asyncgens())
+        except (RuntimeError, KeyboardInterrupt):
+            pass
+        loop.close()
+
+
+async def _shutdown(loop, timeout=5.0):
+    current = asyncio.current_task()
+    pending = [t for t in asyncio.all_tasks(loop) if t is not current]
+    for t in pending:
+        t.cancel()
+    if pending:
+        await asyncio.wait(pending, timeout=timeout)


### PR DESCRIPTION
## Summary

Fixes #802: interrupting an attack with Ctrl+C during an active scan could leave Wapiti hanging forever, forcing the user to kill the process.

## Root cause

On interrupt, attack tasks still hold aiosqlite connections checked out from the SQLAlchemy pool. During cancellation SQLAlchemy's aiosqlite dialect tears them down through `_terminate_graceful_close()`, wrapped in `asyncio.shield()`. With aiosqlite >= 0.22, `Connection.close()` awaits an internal worker-thread future that never resolves in that cancelled context, so the event-loop teardown deadlocks.

## Fix

Three changes:

1. **Monkey-patch SQLAlchemy's aiosqlite termination** — wrap `_terminate_graceful_close()` with a 5 s timeout. If the close hangs, `asyncio.TimeoutError` is raised and `terminate()` falls back to `_terminate_force_close()`.

2. **Replace `asyncio.run()` with manual loop control** — `new_event_loop()` + `run_until_complete()` + a custom `_shutdown()` that cancels pending tasks with `asyncio.wait(tasks, timeout=5.0)`.

3. **Skip bug reports in `_attack_wrapper` after cancellation** — DB errors during cleanup are expected side effects, not real bugs.

## Testing

- `pylint` → 10.00/10.
- New tests cover `_shutdown()`, the timed monkey-patch function, and the early return in `_attack_wrapper`.
- Reproduced the original hang and verified the fix with a standalone reproducer (Python 3.13.13, aiosqlite 0.22.1): before → hang; after → clean exit.
