### PR TITLE
fix(cli): don't hang on Ctrl+C during an attack (#802)

### DIFF
--- a/tests/attack/test_active_scanner.py
+++ b/tests/attack/test_active_scanner.py
@@ -1,3 +1,4 @@
+import asyncio
 import types
 from pathlib import Path
 from typing import Tuple
@@ -447,3 +448,35 @@ async def test_init_attack_modules_sorts_by_priority():
     assert {m.name for m in modules} == {"low", "high"}
     # Ensure they are sorted by PRIORITY (high first, then low)
     assert [m.name for m in modules] == ["high", "low"]
+
+
+@pytest.mark.asyncio
+async def test_attack_wrapper_returns_early_when_task_cancelled():
+    # A DB error raised while the current attack task is being cancelled (Ctrl+C)
+    # must not be treated as a bug: no crash report should be sent.
+    scanner = ActiveScanner(MagicMock(), MagicMock())
+    task = asyncio.create_task(asyncio.sleep(3600))
+    task.cancel()
+    try:
+        await task
+    except asyncio.CancelledError:
+        pass
+    scanner._current_attack_task = task
+    assert task.cancelled()
+
+    scanner._bug_report = True
+    scanner.send_bug_report = AsyncMock()
+
+    attack_module = MagicMock()
+    attack_module.name = "test_module"
+    attack_module.must_attack = AsyncMock(side_effect=Exception("db error during cancellation"))
+    attack_module.attack = AsyncMock()
+
+    request = MagicMock()
+    response = MagicMock()
+    attacked_ids = set()
+    semaphore = asyncio.Semaphore(10)
+
+    await scanner._attack_wrapper(attack_module, request, response, attacked_ids, semaphore)
+
+    scanner.send_bug_report.assert_not_called()

--- a/tests/cli/test_shutdown.py
+++ b/tests/cli/test_shutdown.py
@@ -1,0 +1,74 @@
+import time
+from unittest import mock
+
+from wapitiCore.main import wapiti as wapiti_main_module
+
+
+class TestShutdownWatchdog:
+    def test_force_process_exit_calls_os_exit_zero(self):
+        # The watchdog must exit with status 0 after flushing the standard streams.
+        with mock.patch.object(wapiti_main_module.os, "_exit") as os_exit, \
+                mock.patch.object(wapiti_main_module.sys.stdout, "flush") as out_flush, \
+                mock.patch.object(wapiti_main_module.sys.stderr, "flush") as err_flush:
+            wapiti_main_module._force_process_exit()  # pylint: disable=protected-access
+
+        out_flush.assert_called_once()
+        err_flush.assert_called_once()
+        os_exit.assert_called_once_with(0)
+
+    def test_watchdog_is_disarmed_on_clean_shutdown(self):
+        # A shutdown that finishes quickly must cancel the watchdog before it can
+        # fire, so the process exits normally (no os._exit).
+        created = {}
+        real_timer = wapiti_main_module.threading.Timer
+
+        def fake_timer(interval, func):
+            timer = real_timer(interval, func)
+            created["timer"] = timer
+            created["cancel"] = mock.Mock(wraps=timer.cancel)
+            timer.cancel = created["cancel"]
+            return timer
+
+        async def fast_main():
+            return None
+
+        with mock.patch.object(wapiti_main_module.threading, "Timer", side_effect=fake_timer), \
+                mock.patch.object(wapiti_main_module, "wapiti_main", fast_main), \
+                mock.patch.object(wapiti_main_module.os, "_exit") as os_exit:
+            wapiti_main_module.wapiti_asyncio_wrapper()
+
+        os_exit.assert_not_called()
+        created["cancel"].assert_called()
+
+    def test_watchdog_fires_when_shutdown_hangs(self):
+        # If the event loop teardown never returns, the watchdog must force the
+        # process out. We shorten the timeout and simulate a hanging teardown.
+        async def hanging_main():
+            return None
+
+        fired = {"exit": False}
+
+        def fake_exit(_code):
+            fired["exit"] = True
+
+        # A Runner whose close() blocks forever mimics the aiosqlite deadlock.
+        class HangingRunner:
+            def __enter__(self):
+                return self
+
+            def __exit__(self, *exc):
+                # Block until the watchdog fires, then let the test proceed.
+                deadline = time.monotonic() + 5.0
+                while not fired["exit"] and time.monotonic() < deadline:
+                    time.sleep(0.01)
+
+            def run(self, _coro):
+                _coro.close()
+
+        with mock.patch.object(wapiti_main_module, "SHUTDOWN_WATCHDOG_TIMEOUT", 0.2), \
+                mock.patch.object(wapiti_main_module.asyncio, "Runner", HangingRunner), \
+                mock.patch.object(wapiti_main_module, "wapiti_main", hanging_main), \
+                mock.patch.object(wapiti_main_module.os, "_exit", side_effect=fake_exit):
+            wapiti_main_module.wapiti_asyncio_wrapper()
+
+        assert fired["exit"] is True

--- a/wapitiCore/attack/active_scanner.py
+++ b/wapitiCore/attack/active_scanner.py
@@ -201,6 +201,10 @@ class ActiveScanner:
             except InvalidURL:
                 pass
             except Exception as exception:  # pylint: disable=broad-except
+                # If the attack task was cancelled, DB connection errors during
+                # cleanup are expected side effects, not real bugs.
+                if self._current_attack_task is not None and self._current_attack_task.cancelled():
+                    return
                 exception_traceback = sys.exc_info()[2]
                 logging.exception("An exception occurred in module %s", attack_module.name)
                 if self._bug_report:

--- a/wapitiCore/main/wapiti.py
+++ b/wapitiCore/main/wapiti.py
@@ -22,6 +22,7 @@ import codecs
 import os
 import signal
 import sys
+import threading
 from argparse import Namespace
 from importlib import import_module
 from inspect import getdoc
@@ -514,5 +515,38 @@ async def wapiti_main():
         pass
 
 
+# Safety net: if the asyncio event loop shutdown deadlocks, force the process
+# out after this many seconds. A normal shutdown finishes in well under a
+# second, so this timer is disarmed long before it can fire.
+SHUTDOWN_WATCHDOG_TIMEOUT = 5.0
+
+
+def _force_process_exit():
+    # Called from a watchdog thread when the event loop teardown hangs.
+    sys.stdout.flush()
+    sys.stderr.flush()
+    os._exit(0)  # pylint: disable=protected-access
+
+
 def wapiti_asyncio_wrapper():
-    asyncio.run(wapiti_main())
+    # We can't simply call asyncio.run(): its shutdown step cancels the tasks
+    # left pending and waits for them to complete. When the user interrupts an
+    # attack (Ctrl+C), the attack tasks still hold aiosqlite connections and
+    # SQLAlchemy tries to tear them down while they are being cancelled. With
+    # aiosqlite >= 0.22 on Python 3.13 that connection close never completes,
+    # so the shutdown hangs forever and Wapiti has to be killed (see #802).
+    #
+    # The report and the session database are already flushed once wapiti_main()
+    # returns, so we run the coroutine through an explicit asyncio.Runner and
+    # arm a watchdog around its close() step: a clean shutdown disarms it at
+    # once, a deadlocked one lets the watchdog force a graceful exit.
+    watchdog = threading.Timer(SHUTDOWN_WATCHDOG_TIMEOUT, _force_process_exit)
+    watchdog.daemon = True
+    try:
+        with asyncio.Runner() as runner:
+            try:
+                runner.run(wapiti_main())
+            finally:
+                watchdog.start()
+    finally:
+        watchdog.cancel()


### PR DESCRIPTION
## Problem

Interrupting an attack with <kbd>Ctrl+C</kbd> and then choosing to quit (`q`) or generate the report (`r`) could hang Wapiti forever, forcing the user to kill the process (#802).

Root cause: `asyncio.run()`'s teardown (`_cancel_all_tasks`) cancels the pending attack tasks and waits for them with an **unbounded** `gather()`. With `aiosqlite >= 0.22` (now required by `pyproject.toml`), a task caught mid-DB-operation at cancellation time gets its SQLAlchemy/aiosqlite connection torn down through a *shielded* graceful close whose worker-thread future never resolves — so the wait never returns.

The race needs one or more connections checked out at the exact instant of the interrupt, which is why a manual Ctrl+C misses it more often than not. It reproduces deterministically on Python 3.13 with a harness that sends `SIGINT` right after a module starts attacking.

## Fix

Run the coroutine through an explicit `asyncio.Runner` and arm a `threading` watchdog around its `close()` step:

- a **clean** shutdown disarms the watchdog immediately (unchanged behavior);
- a **deadlocked** shutdown is forced out with `os._exit(0)` after 5 s.

The report and the session database are already flushed by the time `wapiti_main()` returns, so nothing is lost. This safety net is fully **decoupled from SQLAlchemy/aiosqlite internals**: it covers any teardown deadlock, not only the current aiosqlite one, and is unaffected by future changes to those libraries.

It also stops treating DB connection errors raised **while an attack task is being cancelled** as real bugs: `_attack_wrapper` now returns early instead of firing a crash report for every task torn down by the interruption (bug reporting is on by default, so an interrupted attack used to send several spurious reports).

## Tests

- `tests/cli/test_shutdown.py`: watchdog calls `os._exit(0)` after flushing streams, is disarmed on a clean shutdown, and fires when the teardown hangs.
- `tests/attack/test_active_scanner.py`: no crash report is sent when the current attack task was cancelled.

## Note

This supersedes #803, which used a monkey-patch of SQLAlchemy's aiosqlite connection termination. That patch targeted the base `AsyncAdapt_terminate` mixin, but the aiosqlite connection subclass overrides `_terminate_graceful_close`, so via MRO the patch never applied to the real code path (and it captured the abstract `NotImplementedError` stub). This PR drops that approach entirely. #803 can be closed in favor of this one.