### PR TITLE
Improve passive report readability: colored suppression summary + per-page cleartext-password dedup

### DIFF
--- a/tests/attack/passive/test_mod_unsecure_password.py
+++ b/tests/attack/passive/test_mod_unsecure_password.py
@@ -95,6 +95,25 @@ def test_module_unsecure_password_deduplication(module):
     assert len(vulns2) == 0  # Second time: deduplicated
 
 
+def test_module_unsecure_password_dedup_ignores_query_string(module):
+    """The same page reached with different query strings is reported only once."""
+    html = """<form action="/login" method="post">
+                 <input type="password" name="pwd" />
+              </form>"""
+
+    req1, resp1 = create_mock_objects("http://example.com/Login.asp?RetURL=%2FDefault.asp", html)
+    req2, resp2 = create_mock_objects("http://example.com/Login.asp?RetURL=%2FSearch.asp", html)
+
+    vulns1 = list(module.analyze(req1, resp1))
+    assert len(vulns1) == 1
+    # Dedup ignores the query string, but the exact URL is still displayed.
+    assert vulns1[0].info.endswith(req1.url)
+    assert "RetURL=%2FDefault.asp" in vulns1[0].info
+
+    vulns2 = list(module.analyze(req2, resp2))
+    assert len(vulns2) == 0  # Same page, different query string -> suppressed
+
+
 def test_module_unsecure_password_multiple_fields(module):
     """If a form has multiple password fields, each should be reported."""
     html = """<form action="/register" method="post">

--- a/tests/attack/passive/test_passive_scanner.py
+++ b/tests/attack/passive/test_passive_scanner.py
@@ -28,8 +28,8 @@ def test_import_error_is_handled(mock_log_error, _, mock_persister):
 
 
 @patch("pathlib.Path.glob", return_value=[])
-@patch("wapitiCore.attack.passive_scanner.logging.info")
-def test_log_summary_reports_only_modules_with_suppressed_findings(mock_log_info, _, mock_persister):
+@patch("wapitiCore.attack.passive_scanner.log_blue")
+def test_log_summary_reports_only_modules_with_suppressed_findings(mock_log_blue, _, mock_persister):
     """Only modules that actually suppressed alerts are logged."""
     scanner = PassiveScanner(persister=mock_persister)
 
@@ -41,9 +41,30 @@ def test_log_summary_reports_only_modules_with_suppressed_findings(mock_log_info
 
     scanner.log_summary()
 
-    mock_log_info.assert_called_once_with(
-        "%s similar alerts were suppressed by module %s", 3, "noisy"
+    # A header plus exactly one detail line for the only noisy module.
+    mock_log_blue.assert_any_call(
+        "    {0}: {1} similar alert(s) suppressed", "noisy", 3
     )
+    detail_calls = [
+        call for call in mock_log_blue.call_args_list
+        if call.args and call.args[0].startswith("    {0}")
+    ]
+    assert len(detail_calls) == 1
+
+
+@patch("pathlib.Path.glob", return_value=[])
+@patch("wapitiCore.attack.passive_scanner.log_blue")
+def test_log_summary_stays_silent_when_nothing_suppressed(mock_log_blue, _, mock_persister):
+    """No output at all (not even a header) when no alert was suppressed."""
+    scanner = PassiveScanner(persister=mock_persister)
+
+    silent = MagicMock()
+    silent.suppressed_findings = 0
+    scanner._modules = {"silent": silent}
+
+    scanner.log_summary()
+
+    mock_log_blue.assert_not_called()
 
 
 @patch("pathlib.Path.glob", return_value=[Path("mod_broken.py")])

--- a/wapitiCore/attack/modules/passive/mod_unsecure_password.py
+++ b/wapitiCore/attack/modules/passive/mod_unsecure_password.py
@@ -25,7 +25,11 @@ class ModuleUnsecurePassword(PassiveModule):
             if form.url.startswith("http://"):
                 for field in form.fields:
                     if field.tag_type == "password":
-                        form_identifier = (form.url, form.method.upper(), field.name)
+                        # Deduplicate on the page URL without its query string:
+                        # crawled variants differing only by parameters (e.g.
+                        # ?RetURL=...) point to the very same form and must not
+                        # flood the report. The exact URL is still displayed.
+                        form_identifier = (request.path, form.method.upper(), field.name)
 
                         if not self.should_report(form_identifier):
                             continue

--- a/wapitiCore/attack/passive_scanner.py
+++ b/wapitiCore/attack/passive_scanner.py
@@ -5,7 +5,7 @@ from typing import Dict
 from wapitiCore.attack.active_scanner import module_to_class_name
 from wapitiCore.attack.attack import Attack
 from wapitiCore.attack.modules.core import ModuleActivationSettings
-from wapitiCore.main.log import logging
+from wapitiCore.main.log import log_blue, logging
 from wapitiCore.model.vulnerability import VulnerabilityInstance
 from wapitiCore.net import Request, Response
 from wapitiCore.net.sql_persister import SqlPersister
@@ -59,12 +59,20 @@ class PassiveScanner:
         reports the volume that was silently dropped, mirroring the way the active
         scanner surfaces its ``network_errors`` counter.
         """
-        for module_name, module_instance in self._modules.items():
-            suppressed = getattr(module_instance, "suppressed_findings", 0)
-            if suppressed:
-                logging.info(
-                    "%s similar alerts were suppressed by module %s", suppressed, module_name
-                )
+        suppressed_by_module = {
+            module_name: getattr(module_instance, "suppressed_findings", 0)
+            for module_name, module_instance in self._modules.items()
+        }
+        suppressed_by_module = {
+            module_name: count for module_name, count in suppressed_by_module.items() if count
+        }
+        if not suppressed_by_module:
+            return
+
+        log_blue("")
+        log_blue("[*] Some similar passive alerts were suppressed to keep the report readable:")
+        for module_name, suppressed in suppressed_by_module.items():
+            log_blue("    {0}: {1} similar alert(s) suppressed", module_name, suppressed)
 
     async def _record_vulnerability_instance(self, vuln_instance: VulnerabilityInstance, module: str):
         await self._persister.add_payload(


### PR DESCRIPTION
## Context

Two small readability improvements to passive scanning output, both aimed at reducing near-identical noise in the report/logs.

## Changes

### 1. Colored end-of-crawl suppression summary
`PassiveScanner.log_summary()` reported the alerts suppressed by each module through a bare `logging.info("%s ...")`. That line stays **uncolored** under `--color` (INFO has no level color and no `color_name` was set) and used none of the `[*]`-prefixed section conventions of the rest of the output.

It now groups the counters under a single `[*]` header and emits each line via `log_blue`, so the block participates in the color scheme like the other informational lines. It stays completely silent when nothing was suppressed.

Before:
```
28 similar alerts were suppressed by module unsecure_password
```
After:
```
[*] Some similar passive alerts were suppressed to keep the report readable:
    unsecure_password: 28 similar alert(s) suppressed
```

### 2. Per-page dedup for cleartext password findings
`unsecure_password` keyed its per-key alert cap on the full form URL, **query string included**. A single login form reached with varying parameters (e.g. `?RetURL=...`) produced a distinct finding per variant, flooding the report with dozens of identical "Cleartext transmission ..." lines:

```
Cleartext transmission ... from URL http://.../Login.asp?RetURL=%2FDefault.asp
Cleartext transmission ... from URL http://.../Login.asp?RetURL=%2FSearch.asp
Cleartext transmission ... from URL http://.../Login.asp?RetURL=%2Fshowforum.asp%3Fid%3D0
... (dozens more)
```

The deduplication key is now `request.path` (the page URL without its query string). The **exact URL is still displayed** in the log line and the finding info, so no information about the actual request is lost.

## Tests
- New test: same page reached with different query strings is reported once, and the exact URL is still shown.
- New test: `log_summary` stays silent when nothing was suppressed.
- Updated the existing `log_summary` test for the new colored output.
- Full passive test suite passes (106 tests); pylint 10/10 on touched files.