### PR TITLE
feat(passive): surface suppressed passive alerts in reports

### DIFF
--- a/tests/attack/passive/test_base.py
+++ b/tests/attack/passive/test_base.py
@@ -23,3 +23,40 @@ def test_limit_allows_several_occurrences_before_suppressing():
     assert module.should_report("k") is False
 
     assert module.suppressed_findings == 1
+
+
+class _FindingA:
+    @staticmethod
+    def name():
+        return "Category A"
+
+
+class _FindingB:
+    @staticmethod
+    def name():
+        return "Category B"
+
+
+def test_suppressions_are_tallied_per_finding_category():
+    module = PassiveModule()
+
+    # First occurrence of each key is reported, subsequent ones are suppressed
+    # and counted against the finding class category.
+    assert module.should_report("a", _FindingA) is True
+    assert module.should_report("a", _FindingA) is False
+    assert module.should_report("a", _FindingA) is False
+    assert module.should_report("b", _FindingB) is True
+    assert module.should_report("b", _FindingB) is False
+
+    assert module.suppressed_findings == 3
+    assert dict(module.suppressed_by_category) == {"Category A": 2, "Category B": 1}
+
+
+def test_suppressions_without_category_only_bump_the_total():
+    module = PassiveModule()
+
+    assert module.should_report("k") is True
+    assert module.should_report("k") is False
+
+    assert module.suppressed_findings == 1
+    assert dict(module.suppressed_by_category) == {}

--- a/tests/attack/passive/test_base.py
+++ b/tests/attack/passive/test_base.py
@@ -60,3 +60,36 @@ def test_suppressions_without_category_only_bump_the_total():
 
     assert module.suppressed_findings == 1
     assert dict(module.suppressed_by_category) == {}
+
+
+def test_state_round_trip_preserves_dedup_and_counters():
+    module = PassiveModule()
+
+    module.should_report("a", _FindingA)  # reported, occurrences[a] = 1
+    module.should_report("a", _FindingA)  # suppressed
+    module.should_report("b", _FindingB)  # reported
+
+    state = module.get_state()
+
+    # A fresh module loaded with that state must behave as the original: the
+    # already-seen keys stay capped and the counters are preserved.
+    restored = PassiveModule()
+    restored.load_state(state)
+
+    assert restored.suppressed_findings == 1
+    assert dict(restored.suppressed_by_category) == {"Category A": 1}
+    # Key "a" already reached LIMIT -> still suppressed (no duplicate alert on resume)
+    assert restored.should_report("a", _FindingA) is False
+    # Key "b" reported once -> now capped too
+    assert restored.should_report("b", _FindingB) is False
+    assert restored.suppressed_findings == 3
+
+
+def test_load_state_tolerates_missing_keys():
+    module = PassiveModule()
+    module.load_state({})
+
+    assert dict(module._occurrences) == {}
+    assert module.suppressed_findings == 0
+    assert dict(module.suppressed_by_category) == {}
+    assert module.should_report("fresh") is True

--- a/tests/attack/passive/test_base.py
+++ b/tests/attack/passive/test_base.py
@@ -1,3 +1,5 @@
+import json
+
 from wapitiCore.attack.modules.passive.base import PassiveModule
 
 
@@ -59,7 +61,7 @@ def test_suppressions_without_category_only_bump_the_total():
     assert module.should_report("k") is False
 
     assert module.suppressed_findings == 1
-    assert dict(module.suppressed_by_category) == {}
+    assert not module.suppressed_by_category
 
 
 def test_state_round_trip_preserves_dedup_and_counters():
@@ -85,11 +87,33 @@ def test_state_round_trip_preserves_dedup_and_counters():
     assert restored.suppressed_findings == 3
 
 
+def test_state_round_trip_through_json_with_tuple_keys():
+    # Most modules deduplicate on tuple keys (e.g. (host, header, ...)), which JSON
+    # cannot use as object keys. The state must survive a real serialize/deserialize.
+    module = PassiveModule()
+    module.should_report(("example.com", "CSP", "Missing"), _FindingA)  # reported
+    module.should_report(("example.com", "CSP", "Missing"), _FindingA)  # suppressed
+    module.should_report("plain-string-key", _FindingB)  # reported
+
+    # Persistence path: get_state -> json blob -> back to a dict -> load_state
+    restored = PassiveModule()
+    restored.load_state(json.loads(json.dumps(module.get_state())))
+
+    assert restored.suppressed_findings == 1
+    assert dict(restored.suppressed_by_category) == {"Category A": 1}
+    # The tuple key is hashable again and still matches -> stays capped, no duplicate
+    assert restored.should_report(("example.com", "CSP", "Missing"), _FindingA) is False
+    # A plain string key round-trips as a string, not a tuple
+    assert restored.should_report("plain-string-key", _FindingB) is False
+    assert restored.suppressed_findings == 3
+
+
 def test_load_state_tolerates_missing_keys():
     module = PassiveModule()
     module.load_state({})
 
-    assert dict(module._occurrences) == {}
     assert module.suppressed_findings == 0
-    assert dict(module.suppressed_by_category) == {}
+    assert not module.suppressed_by_category
+    # Empty state behaves like a fresh module: nothing already capped.
     assert module.should_report("fresh") is True
+    assert module.should_report("fresh") is False

--- a/tests/attack/passive/test_passive_scanner.py
+++ b/tests/attack/passive/test_passive_scanner.py
@@ -1,5 +1,6 @@
 import types
-from unittest.mock import MagicMock, patch, ANY
+from collections import defaultdict
+from unittest.mock import AsyncMock, MagicMock, patch, ANY
 from pathlib import Path
 
 import pytest
@@ -65,6 +66,50 @@ def test_log_summary_stays_silent_when_nothing_suppressed(mock_log_blue, _, mock
     scanner.log_summary()
 
     mock_log_blue.assert_not_called()
+
+
+@patch("pathlib.Path.glob", return_value=[])
+def test_suppressed_by_category_aggregates_modules(_, mock_persister):
+    """Per-module category counters are summed into a single per-category breakdown."""
+    scanner = PassiveScanner(persister=mock_persister)
+
+    first = MagicMock()
+    first.suppressed_by_category = defaultdict(int, {"CSP": 2, "HSTS": 1})
+    second = MagicMock()
+    second.suppressed_by_category = defaultdict(int, {"CSP": 3})
+    scanner._modules = {"csp": first, "https_redirect": second}
+
+    assert scanner.suppressed_by_category() == {"CSP": 5, "HSTS": 1}
+
+
+@pytest.mark.asyncio
+@patch("pathlib.Path.glob", return_value=[])
+async def test_persist_suppressed_findings_writes_non_empty_counts(_, mock_persister):
+    mock_persister.set_suppressed_findings = AsyncMock()
+    scanner = PassiveScanner(persister=mock_persister)
+
+    module = MagicMock()
+    module.suppressed_by_category = defaultdict(int, {"CSP": 4})
+    scanner._modules = {"csp": module}
+
+    await scanner.persist_suppressed_findings()
+
+    mock_persister.set_suppressed_findings.assert_awaited_once_with({"CSP": 4})
+
+
+@pytest.mark.asyncio
+@patch("pathlib.Path.glob", return_value=[])
+async def test_persist_suppressed_findings_skips_when_nothing_suppressed(_, mock_persister):
+    mock_persister.set_suppressed_findings = AsyncMock()
+    scanner = PassiveScanner(persister=mock_persister)
+
+    module = MagicMock()
+    module.suppressed_by_category = defaultdict(int)
+    scanner._modules = {"csp": module}
+
+    await scanner.persist_suppressed_findings()
+
+    mock_persister.set_suppressed_findings.assert_not_awaited()
 
 
 @patch("pathlib.Path.glob", return_value=[Path("mod_broken.py")])

--- a/tests/attack/passive/test_passive_scanner.py
+++ b/tests/attack/passive/test_passive_scanner.py
@@ -1,5 +1,4 @@
 import types
-from collections import defaultdict
 from unittest.mock import AsyncMock, MagicMock, patch, ANY
 from pathlib import Path
 
@@ -69,47 +68,78 @@ def test_log_summary_stays_silent_when_nothing_suppressed(mock_log_blue, _, mock
 
 
 @patch("pathlib.Path.glob", return_value=[])
-def test_suppressed_by_category_aggregates_modules(_, mock_persister):
-    """Per-module category counters are summed into a single per-category breakdown."""
+def test_get_state_snapshots_every_module(_, mock_persister):
     scanner = PassiveScanner(persister=mock_persister)
 
     first = MagicMock()
-    first.suppressed_by_category = defaultdict(int, {"CSP": 2, "HSTS": 1})
+    first.get_state.return_value = {"occurrences": {"a": 1}}
     second = MagicMock()
-    second.suppressed_by_category = defaultdict(int, {"CSP": 3})
+    second.get_state.return_value = {"occurrences": {}}
     scanner._modules = {"csp": first, "https_redirect": second}
 
-    assert scanner.suppressed_by_category() == {"CSP": 5, "HSTS": 1}
+    assert scanner.get_state() == {
+        "csp": {"occurrences": {"a": 1}},
+        "https_redirect": {"occurrences": {}},
+    }
+
+
+@patch("pathlib.Path.glob", return_value=[])
+def test_load_state_dispatches_and_ignores_unknown_modules(_, mock_persister):
+    scanner = PassiveScanner(persister=mock_persister)
+
+    csp = MagicMock()
+    scanner._modules = {"csp": csp}
+
+    scanner.load_state({"csp": {"occurrences": {"a": 1}}, "gone": {"occurrences": {}}})
+
+    csp.load_state.assert_called_once_with({"occurrences": {"a": 1}})
 
 
 @pytest.mark.asyncio
 @patch("pathlib.Path.glob", return_value=[])
-async def test_persist_suppressed_findings_writes_non_empty_counts(_, mock_persister):
-    mock_persister.set_suppressed_findings = AsyncMock()
+async def test_persist_state_writes_full_snapshot_unconditionally(_, mock_persister):
+    mock_persister.set_passive_scanner_state = AsyncMock()
     scanner = PassiveScanner(persister=mock_persister)
 
     module = MagicMock()
-    module.suppressed_by_category = defaultdict(int, {"CSP": 4})
+    module.get_state.return_value = {"occurrences": {"a": 1}, "suppressed_findings": 0}
     scanner._modules = {"csp": module}
 
-    await scanner.persist_suppressed_findings()
+    await scanner.persist_state()
 
-    mock_persister.set_suppressed_findings.assert_awaited_once_with({"CSP": 4})
+    mock_persister.set_passive_scanner_state.assert_awaited_once_with(
+        {"csp": {"occurrences": {"a": 1}, "suppressed_findings": 0}}
+    )
 
 
 @pytest.mark.asyncio
 @patch("pathlib.Path.glob", return_value=[])
-async def test_persist_suppressed_findings_skips_when_nothing_suppressed(_, mock_persister):
-    mock_persister.set_suppressed_findings = AsyncMock()
+async def test_restore_state_loads_stored_snapshot(_, mock_persister):
+    mock_persister.get_passive_scanner_state = AsyncMock(
+        return_value={"csp": {"occurrences": {"a": 1}}}
+    )
     scanner = PassiveScanner(persister=mock_persister)
 
     module = MagicMock()
-    module.suppressed_by_category = defaultdict(int)
     scanner._modules = {"csp": module}
 
-    await scanner.persist_suppressed_findings()
+    await scanner.restore_state()
 
-    mock_persister.set_suppressed_findings.assert_not_awaited()
+    module.load_state.assert_called_once_with({"occurrences": {"a": 1}})
+
+
+@pytest.mark.asyncio
+@patch("pathlib.Path.glob", return_value=[])
+async def test_restore_state_is_a_noop_without_stored_state(_, mock_persister):
+    mock_persister.get_passive_scanner_state = AsyncMock(return_value={})
+    scanner = PassiveScanner(persister=mock_persister)
+
+    module = MagicMock()
+    scanner._modules = {"csp": module}
+
+    await scanner.restore_state()
+
+    module.load_state.assert_not_called()
 
 
 @patch("pathlib.Path.glob", return_value=[Path("mod_broken.py")])

--- a/tests/reports/data/report.html
+++ b/tests/reports/data/report.html
@@ -28,229 +28,305 @@
                         <td class="small">
                             Backup file
                         </td>
-                        <td class="small text-centered">0</td>
+                        <td class="small text-centered">
+                            0
+                        </td>
                     </tr>
                     <tr>
                         <td class="small">
                             Cleartext Submission of Password
                         </td>
-                        <td class="small text-centered">0</td>
+                        <td class="small text-centered">
+                            0
+                        </td>
                     </tr>
                     <tr>
                         <td class="small">
                             Weak credentials
                         </td>
-                        <td class="small text-centered">0</td>
+                        <td class="small text-centered">
+                            0
+                        </td>
                     </tr>
                     <tr>
                         <td class="small">
                             CRLF Injection
                         </td>
-                        <td class="small text-centered">0</td>
+                        <td class="small text-centered">
+                            0
+                        </td>
                     </tr>
                     <tr>
                         <td class="small">
                             Content Security Policy Configuration
                         </td>
-                        <td class="small text-centered">0</td>
+                        <td class="small text-centered">
+                            0
+                        </td>
                     </tr>
                     <tr>
                         <td class="small">
                             Cross Site Request Forgery
                         </td>
-                        <td class="small text-centered">0</td>
+                        <td class="small text-centered">
+                            0
+                        </td>
                     </tr>
                     <tr>
                         <td class="small">
                             CVE-2024-55591
                         </td>
-                        <td class="small text-centered">0</td>
+                        <td class="small text-centered">
+                            0
+                        </td>
                     </tr>
                     <tr>
                         <td class="small">
                             Potentially dangerous file
                         </td>
-                        <td class="small text-centered">0</td>
+                        <td class="small text-centered">
+                            0
+                        </td>
                     </tr>
                     <tr>
                         <td class="small">
                             Command execution
                         </td>
-                        <td class="small text-centered">0</td>
+                        <td class="small text-centered">
+                            0
+                        </td>
                     </tr>
                     <tr>
                         <td class="small">
                             Path Traversal
                         </td>
-                        <td class="small text-centered">0</td>
+                        <td class="small text-centered">
+                            0
+                        </td>
                     </tr>
                     <tr>
                         <td class="small">
                             Fingerprint web application framework
                         </td>
-                        <td class="small text-centered">0</td>
+                        <td class="small text-centered">
+                            0
+                        </td>
                     </tr>
                     <tr>
                         <td class="small">
                             Fingerprint web server
                         </td>
-                        <td class="small text-centered">0</td>
+                        <td class="small text-centered">
+                            0
+                        </td>
                     </tr>
                     <tr>
                         <td class="small">
                             Htaccess Bypass
                         </td>
-                        <td class="small text-centered">0</td>
+                        <td class="small text-centered">
+                            0
+                        </td>
                     </tr>
                     <tr>
                         <td class="small">
                             HTML Injection
                         </td>
-                        <td class="small text-centered">0</td>
+                        <td class="small text-centered">
+                            0
+                        </td>
                     </tr>
                     <tr>
                         <td class="small">
                             Clickjacking Protection
                         </td>
-                        <td class="small text-centered">0</td>
+                        <td class="small text-centered">
+                            0
+                        </td>
                     </tr>
                     <tr>
                         <td class="small">
                             HTTP Strict Transport Security (HSTS)
                         </td>
-                        <td class="small text-centered">0</td>
+                        <td class="small text-centered">
+                            0
+                        </td>
                     </tr>
                     <tr>
                         <td class="small">
                             MIME Type Confusion
                         </td>
-                        <td class="small text-centered">0</td>
+                        <td class="small text-centered">
+                            0
+                        </td>
                     </tr>
                     <tr>
                         <td class="small">
                             HttpOnly Flag cookie
                         </td>
-                        <td class="small text-centered">0</td>
+                        <td class="small text-centered">
+                            0
+                        </td>
                     </tr>
                     <tr>
                         <td class="small">
                             Unencrypted Channels
                         </td>
-                        <td class="small text-centered">0</td>
+                        <td class="small text-centered">
+                            0
+                        </td>
                     </tr>
                     <tr>
                         <td class="small">
                             Inconsistent Redirection
                         </td>
-                        <td class="small text-centered">0</td>
+                        <td class="small text-centered">
+                            0
+                        </td>
                     </tr>
                     <tr>
                         <td class="small">
                             Information Disclosure - Full Path
                         </td>
-                        <td class="small text-centered">0</td>
+                        <td class="small text-centered">
+                            0
+                        </td>
                     </tr>
                     <tr>
                         <td class="small">
                             LDAP Injection
                         </td>
-                        <td class="small text-centered">0</td>
+                        <td class="small text-centered">
+                            0
+                        </td>
                     </tr>
                     <tr>
                         <td class="small">
                             Log4Shell
                         </td>
-                        <td class="small text-centered">0</td>
+                        <td class="small text-centered">
+                            0
+                        </td>
                     </tr>
                     <tr>
                         <td class="small">
                             NS takeover
                         </td>
-                        <td class="small text-centered">0</td>
+                        <td class="small text-centered">
+                            0
+                        </td>
                     </tr>
                     <tr>
                         <td class="small">
                             Open Redirect
                         </td>
-                        <td class="small text-centered">0</td>
+                        <td class="small text-centered">
+                            0
+                        </td>
                     </tr>
                     <tr>
                         <td class="small">
                             <a href="#vuln_type_25">Reflected Cross Site Scripting</a>
                         </td>
-                        <td class="small text-centered">1</td>
+                        <td class="small text-centered">
+                            1
+                        </td>
                     </tr>
                     <tr>
                         <td class="small">
                             Secure Flag cookie
                         </td>
-                        <td class="small text-centered">0</td>
+                        <td class="small text-centered">
+                            0
+                        </td>
                     </tr>
                     <tr>
                         <td class="small">
                             Spring4Shell
                         </td>
-                        <td class="small text-centered">0</td>
+                        <td class="small text-centered">
+                            0
+                        </td>
                     </tr>
                     <tr>
                         <td class="small">
                             SQL Injection
                         </td>
-                        <td class="small text-centered">0</td>
+                        <td class="small text-centered">
+                            0
+                        </td>
                     </tr>
                     <tr>
                         <td class="small">
                             TLS/SSL misconfigurations
                         </td>
-                        <td class="small text-centered">0</td>
+                        <td class="small text-centered">
+                            0
+                        </td>
                     </tr>
                     <tr>
                         <td class="small">
                             Server Side Request Forgery
                         </td>
-                        <td class="small text-centered">0</td>
+                        <td class="small text-centered">
+                            0
+                        </td>
                     </tr>
                     <tr>
                         <td class="small">
                             Stack Trace Disclosure
                         </td>
-                        <td class="small text-centered">0</td>
+                        <td class="small text-centered">
+                            0
+                        </td>
                     </tr>
                     <tr>
                         <td class="small">
                             Stored HTML Injection
                         </td>
-                        <td class="small text-centered">0</td>
+                        <td class="small text-centered">
+                            0
+                        </td>
                     </tr>
                     <tr>
                         <td class="small">
                             Stored Cross Site Scripting
                         </td>
-                        <td class="small text-centered">0</td>
+                        <td class="small text-centered">
+                            0
+                        </td>
                     </tr>
                     <tr>
                         <td class="small">
                             Subdomain takeover
                         </td>
-                        <td class="small text-centered">0</td>
+                        <td class="small text-centered">
+                            0
+                        </td>
                     </tr>
                     <tr>
                         <td class="small">
                             Blind SQL Injection
                         </td>
-                        <td class="small text-centered">0</td>
+                        <td class="small text-centered">
+                            0
+                        </td>
                     </tr>
                     <tr>
                         <td class="small">
                             Unrestricted File Upload
                         </td>
-                        <td class="small text-centered">0</td>
+                        <td class="small text-centered">
+                            0
+                        </td>
                     </tr>
                     <tr>
                         <td class="small">
                             Vulnerable software
                         </td>
-                        <td class="small text-centered">0</td>
+                        <td class="small text-centered">
+                            0
+                        </td>
                     </tr>
                     <tr>
                         <td class="small">

--- a/tests/reports/data/report.json
+++ b/tests/reports/data/report.json
@@ -614,5 +614,6 @@
     "auth": null,
     "crawled_pages_nbr": 123456,
     "detailed_report_level": 0
-  }
+  },
+  "suppressed_findings": {}
 }

--- a/tests/reports/data/report_level1.html
+++ b/tests/reports/data/report_level1.html
@@ -28,229 +28,305 @@
                         <td class="small">
                             Backup file
                         </td>
-                        <td class="small text-centered">0</td>
+                        <td class="small text-centered">
+                            0
+                        </td>
                     </tr>
                     <tr>
                         <td class="small">
                             Cleartext Submission of Password
                         </td>
-                        <td class="small text-centered">0</td>
+                        <td class="small text-centered">
+                            0
+                        </td>
                     </tr>
                     <tr>
                         <td class="small">
                             Weak credentials
                         </td>
-                        <td class="small text-centered">0</td>
+                        <td class="small text-centered">
+                            0
+                        </td>
                     </tr>
                     <tr>
                         <td class="small">
                             CRLF Injection
                         </td>
-                        <td class="small text-centered">0</td>
+                        <td class="small text-centered">
+                            0
+                        </td>
                     </tr>
                     <tr>
                         <td class="small">
                             Content Security Policy Configuration
                         </td>
-                        <td class="small text-centered">0</td>
+                        <td class="small text-centered">
+                            0
+                        </td>
                     </tr>
                     <tr>
                         <td class="small">
                             Cross Site Request Forgery
                         </td>
-                        <td class="small text-centered">0</td>
+                        <td class="small text-centered">
+                            0
+                        </td>
                     </tr>
                     <tr>
                         <td class="small">
                             CVE-2024-55591
                         </td>
-                        <td class="small text-centered">0</td>
+                        <td class="small text-centered">
+                            0
+                        </td>
                     </tr>
                     <tr>
                         <td class="small">
                             Potentially dangerous file
                         </td>
-                        <td class="small text-centered">0</td>
+                        <td class="small text-centered">
+                            0
+                        </td>
                     </tr>
                     <tr>
                         <td class="small">
                             Command execution
                         </td>
-                        <td class="small text-centered">0</td>
+                        <td class="small text-centered">
+                            0
+                        </td>
                     </tr>
                     <tr>
                         <td class="small">
                             Path Traversal
                         </td>
-                        <td class="small text-centered">0</td>
+                        <td class="small text-centered">
+                            0
+                        </td>
                     </tr>
                     <tr>
                         <td class="small">
                             Fingerprint web application framework
                         </td>
-                        <td class="small text-centered">0</td>
+                        <td class="small text-centered">
+                            0
+                        </td>
                     </tr>
                     <tr>
                         <td class="small">
                             Fingerprint web server
                         </td>
-                        <td class="small text-centered">0</td>
+                        <td class="small text-centered">
+                            0
+                        </td>
                     </tr>
                     <tr>
                         <td class="small">
                             Htaccess Bypass
                         </td>
-                        <td class="small text-centered">0</td>
+                        <td class="small text-centered">
+                            0
+                        </td>
                     </tr>
                     <tr>
                         <td class="small">
                             HTML Injection
                         </td>
-                        <td class="small text-centered">0</td>
+                        <td class="small text-centered">
+                            0
+                        </td>
                     </tr>
                     <tr>
                         <td class="small">
                             Clickjacking Protection
                         </td>
-                        <td class="small text-centered">0</td>
+                        <td class="small text-centered">
+                            0
+                        </td>
                     </tr>
                     <tr>
                         <td class="small">
                             HTTP Strict Transport Security (HSTS)
                         </td>
-                        <td class="small text-centered">0</td>
+                        <td class="small text-centered">
+                            0
+                        </td>
                     </tr>
                     <tr>
                         <td class="small">
                             MIME Type Confusion
                         </td>
-                        <td class="small text-centered">0</td>
+                        <td class="small text-centered">
+                            0
+                        </td>
                     </tr>
                     <tr>
                         <td class="small">
                             HttpOnly Flag cookie
                         </td>
-                        <td class="small text-centered">0</td>
+                        <td class="small text-centered">
+                            0
+                        </td>
                     </tr>
                     <tr>
                         <td class="small">
                             Unencrypted Channels
                         </td>
-                        <td class="small text-centered">0</td>
+                        <td class="small text-centered">
+                            0
+                        </td>
                     </tr>
                     <tr>
                         <td class="small">
                             Inconsistent Redirection
                         </td>
-                        <td class="small text-centered">0</td>
+                        <td class="small text-centered">
+                            0
+                        </td>
                     </tr>
                     <tr>
                         <td class="small">
                             Information Disclosure - Full Path
                         </td>
-                        <td class="small text-centered">0</td>
+                        <td class="small text-centered">
+                            0
+                        </td>
                     </tr>
                     <tr>
                         <td class="small">
                             LDAP Injection
                         </td>
-                        <td class="small text-centered">0</td>
+                        <td class="small text-centered">
+                            0
+                        </td>
                     </tr>
                     <tr>
                         <td class="small">
                             Log4Shell
                         </td>
-                        <td class="small text-centered">0</td>
+                        <td class="small text-centered">
+                            0
+                        </td>
                     </tr>
                     <tr>
                         <td class="small">
                             NS takeover
                         </td>
-                        <td class="small text-centered">0</td>
+                        <td class="small text-centered">
+                            0
+                        </td>
                     </tr>
                     <tr>
                         <td class="small">
                             Open Redirect
                         </td>
-                        <td class="small text-centered">0</td>
+                        <td class="small text-centered">
+                            0
+                        </td>
                     </tr>
                     <tr>
                         <td class="small">
                             <a href="#vuln_type_25">Reflected Cross Site Scripting</a>
                         </td>
-                        <td class="small text-centered">1</td>
+                        <td class="small text-centered">
+                            1
+                        </td>
                     </tr>
                     <tr>
                         <td class="small">
                             Secure Flag cookie
                         </td>
-                        <td class="small text-centered">0</td>
+                        <td class="small text-centered">
+                            0
+                        </td>
                     </tr>
                     <tr>
                         <td class="small">
                             Spring4Shell
                         </td>
-                        <td class="small text-centered">0</td>
+                        <td class="small text-centered">
+                            0
+                        </td>
                     </tr>
                     <tr>
                         <td class="small">
                             SQL Injection
                         </td>
-                        <td class="small text-centered">0</td>
+                        <td class="small text-centered">
+                            0
+                        </td>
                     </tr>
                     <tr>
                         <td class="small">
                             TLS/SSL misconfigurations
                         </td>
-                        <td class="small text-centered">0</td>
+                        <td class="small text-centered">
+                            0
+                        </td>
                     </tr>
                     <tr>
                         <td class="small">
                             Server Side Request Forgery
                         </td>
-                        <td class="small text-centered">0</td>
+                        <td class="small text-centered">
+                            0
+                        </td>
                     </tr>
                     <tr>
                         <td class="small">
                             Stack Trace Disclosure
                         </td>
-                        <td class="small text-centered">0</td>
+                        <td class="small text-centered">
+                            0
+                        </td>
                     </tr>
                     <tr>
                         <td class="small">
                             Stored HTML Injection
                         </td>
-                        <td class="small text-centered">0</td>
+                        <td class="small text-centered">
+                            0
+                        </td>
                     </tr>
                     <tr>
                         <td class="small">
                             Stored Cross Site Scripting
                         </td>
-                        <td class="small text-centered">0</td>
+                        <td class="small text-centered">
+                            0
+                        </td>
                     </tr>
                     <tr>
                         <td class="small">
                             Subdomain takeover
                         </td>
-                        <td class="small text-centered">0</td>
+                        <td class="small text-centered">
+                            0
+                        </td>
                     </tr>
                     <tr>
                         <td class="small">
                             Blind SQL Injection
                         </td>
-                        <td class="small text-centered">0</td>
+                        <td class="small text-centered">
+                            0
+                        </td>
                     </tr>
                     <tr>
                         <td class="small">
                             Unrestricted File Upload
                         </td>
-                        <td class="small text-centered">0</td>
+                        <td class="small text-centered">
+                            0
+                        </td>
                     </tr>
                     <tr>
                         <td class="small">
                             Vulnerable software
                         </td>
-                        <td class="small text-centered">0</td>
+                        <td class="small text-centered">
+                            0
+                        </td>
                     </tr>
                     <tr>
                         <td class="small">

--- a/tests/reports/data/report_level1.json
+++ b/tests/reports/data/report_level1.json
@@ -604,5 +604,6 @@
       }
     ],
     "detailed_report_level": 1
-  }
+  },
+  "suppressed_findings": {}
 }

--- a/tests/reports/data/report_level2.html
+++ b/tests/reports/data/report_level2.html
@@ -28,229 +28,305 @@
                         <td class="small">
                             Backup file
                         </td>
-                        <td class="small text-centered">0</td>
+                        <td class="small text-centered">
+                            0
+                        </td>
                     </tr>
                     <tr>
                         <td class="small">
                             Cleartext Submission of Password
                         </td>
-                        <td class="small text-centered">0</td>
+                        <td class="small text-centered">
+                            0
+                        </td>
                     </tr>
                     <tr>
                         <td class="small">
                             Weak credentials
                         </td>
-                        <td class="small text-centered">0</td>
+                        <td class="small text-centered">
+                            0
+                        </td>
                     </tr>
                     <tr>
                         <td class="small">
                             CRLF Injection
                         </td>
-                        <td class="small text-centered">0</td>
+                        <td class="small text-centered">
+                            0
+                        </td>
                     </tr>
                     <tr>
                         <td class="small">
                             Content Security Policy Configuration
                         </td>
-                        <td class="small text-centered">0</td>
+                        <td class="small text-centered">
+                            0
+                        </td>
                     </tr>
                     <tr>
                         <td class="small">
                             Cross Site Request Forgery
                         </td>
-                        <td class="small text-centered">0</td>
+                        <td class="small text-centered">
+                            0
+                        </td>
                     </tr>
                     <tr>
                         <td class="small">
                             CVE-2024-55591
                         </td>
-                        <td class="small text-centered">0</td>
+                        <td class="small text-centered">
+                            0
+                        </td>
                     </tr>
                     <tr>
                         <td class="small">
                             Potentially dangerous file
                         </td>
-                        <td class="small text-centered">0</td>
+                        <td class="small text-centered">
+                            0
+                        </td>
                     </tr>
                     <tr>
                         <td class="small">
                             Command execution
                         </td>
-                        <td class="small text-centered">0</td>
+                        <td class="small text-centered">
+                            0
+                        </td>
                     </tr>
                     <tr>
                         <td class="small">
                             Path Traversal
                         </td>
-                        <td class="small text-centered">0</td>
+                        <td class="small text-centered">
+                            0
+                        </td>
                     </tr>
                     <tr>
                         <td class="small">
                             Fingerprint web application framework
                         </td>
-                        <td class="small text-centered">0</td>
+                        <td class="small text-centered">
+                            0
+                        </td>
                     </tr>
                     <tr>
                         <td class="small">
                             Fingerprint web server
                         </td>
-                        <td class="small text-centered">0</td>
+                        <td class="small text-centered">
+                            0
+                        </td>
                     </tr>
                     <tr>
                         <td class="small">
                             Htaccess Bypass
                         </td>
-                        <td class="small text-centered">0</td>
+                        <td class="small text-centered">
+                            0
+                        </td>
                     </tr>
                     <tr>
                         <td class="small">
                             HTML Injection
                         </td>
-                        <td class="small text-centered">0</td>
+                        <td class="small text-centered">
+                            0
+                        </td>
                     </tr>
                     <tr>
                         <td class="small">
                             Clickjacking Protection
                         </td>
-                        <td class="small text-centered">0</td>
+                        <td class="small text-centered">
+                            0
+                        </td>
                     </tr>
                     <tr>
                         <td class="small">
                             HTTP Strict Transport Security (HSTS)
                         </td>
-                        <td class="small text-centered">0</td>
+                        <td class="small text-centered">
+                            0
+                        </td>
                     </tr>
                     <tr>
                         <td class="small">
                             MIME Type Confusion
                         </td>
-                        <td class="small text-centered">0</td>
+                        <td class="small text-centered">
+                            0
+                        </td>
                     </tr>
                     <tr>
                         <td class="small">
                             HttpOnly Flag cookie
                         </td>
-                        <td class="small text-centered">0</td>
+                        <td class="small text-centered">
+                            0
+                        </td>
                     </tr>
                     <tr>
                         <td class="small">
                             Unencrypted Channels
                         </td>
-                        <td class="small text-centered">0</td>
+                        <td class="small text-centered">
+                            0
+                        </td>
                     </tr>
                     <tr>
                         <td class="small">
                             Inconsistent Redirection
                         </td>
-                        <td class="small text-centered">0</td>
+                        <td class="small text-centered">
+                            0
+                        </td>
                     </tr>
                     <tr>
                         <td class="small">
                             Information Disclosure - Full Path
                         </td>
-                        <td class="small text-centered">0</td>
+                        <td class="small text-centered">
+                            0
+                        </td>
                     </tr>
                     <tr>
                         <td class="small">
                             LDAP Injection
                         </td>
-                        <td class="small text-centered">0</td>
+                        <td class="small text-centered">
+                            0
+                        </td>
                     </tr>
                     <tr>
                         <td class="small">
                             Log4Shell
                         </td>
-                        <td class="small text-centered">0</td>
+                        <td class="small text-centered">
+                            0
+                        </td>
                     </tr>
                     <tr>
                         <td class="small">
                             NS takeover
                         </td>
-                        <td class="small text-centered">0</td>
+                        <td class="small text-centered">
+                            0
+                        </td>
                     </tr>
                     <tr>
                         <td class="small">
                             Open Redirect
                         </td>
-                        <td class="small text-centered">0</td>
+                        <td class="small text-centered">
+                            0
+                        </td>
                     </tr>
                     <tr>
                         <td class="small">
                             <a href="#vuln_type_25">Reflected Cross Site Scripting</a>
                         </td>
-                        <td class="small text-centered">1</td>
+                        <td class="small text-centered">
+                            1
+                        </td>
                     </tr>
                     <tr>
                         <td class="small">
                             Secure Flag cookie
                         </td>
-                        <td class="small text-centered">0</td>
+                        <td class="small text-centered">
+                            0
+                        </td>
                     </tr>
                     <tr>
                         <td class="small">
                             Spring4Shell
                         </td>
-                        <td class="small text-centered">0</td>
+                        <td class="small text-centered">
+                            0
+                        </td>
                     </tr>
                     <tr>
                         <td class="small">
                             SQL Injection
                         </td>
-                        <td class="small text-centered">0</td>
+                        <td class="small text-centered">
+                            0
+                        </td>
                     </tr>
                     <tr>
                         <td class="small">
                             TLS/SSL misconfigurations
                         </td>
-                        <td class="small text-centered">0</td>
+                        <td class="small text-centered">
+                            0
+                        </td>
                     </tr>
                     <tr>
                         <td class="small">
                             Server Side Request Forgery
                         </td>
-                        <td class="small text-centered">0</td>
+                        <td class="small text-centered">
+                            0
+                        </td>
                     </tr>
                     <tr>
                         <td class="small">
                             Stack Trace Disclosure
                         </td>
-                        <td class="small text-centered">0</td>
+                        <td class="small text-centered">
+                            0
+                        </td>
                     </tr>
                     <tr>
                         <td class="small">
                             Stored HTML Injection
                         </td>
-                        <td class="small text-centered">0</td>
+                        <td class="small text-centered">
+                            0
+                        </td>
                     </tr>
                     <tr>
                         <td class="small">
                             Stored Cross Site Scripting
                         </td>
-                        <td class="small text-centered">0</td>
+                        <td class="small text-centered">
+                            0
+                        </td>
                     </tr>
                     <tr>
                         <td class="small">
                             Subdomain takeover
                         </td>
-                        <td class="small text-centered">0</td>
+                        <td class="small text-centered">
+                            0
+                        </td>
                     </tr>
                     <tr>
                         <td class="small">
                             Blind SQL Injection
                         </td>
-                        <td class="small text-centered">0</td>
+                        <td class="small text-centered">
+                            0
+                        </td>
                     </tr>
                     <tr>
                         <td class="small">
                             Unrestricted File Upload
                         </td>
-                        <td class="small text-centered">0</td>
+                        <td class="small text-centered">
+                            0
+                        </td>
                     </tr>
                     <tr>
                         <td class="small">
                             Vulnerable software
                         </td>
-                        <td class="small text-centered">0</td>
+                        <td class="small text-centered">
+                            0
+                        </td>
                     </tr>
                     <tr>
                         <td class="small">

--- a/tests/reports/data/report_level2.json
+++ b/tests/reports/data/report_level2.json
@@ -622,5 +622,6 @@
       }
     ],
     "detailed_report_level": 2
-  }
+  },
+  "suppressed_findings": {}
 }

--- a/tests/reports/test_reports.py
+++ b/tests/reports/test_reports.py
@@ -316,6 +316,55 @@ def test_html_report_escapes_target_controlled_data():
     assert "&lt;script&gt;alert(&#39;XSS&#39;)&lt;/script&gt;" in report
 
 
+@pytest.mark.parametrize("report_format", ["txt", "md", "json", "xml", "html"])
+def test_reports_surface_suppressed_passive_findings(report_format):
+    """A non-zero suppression count for a category is reflected in the report."""
+    category = "Content Security Policy Configuration"
+    report_gen = GENERATORS[report_format]()
+
+    report_gen.set_report_info(
+        "http://perdu.com", "folder", gmtime(0), "WAPITI_VERSION", None, None, 1, 0
+    )
+    for vul in vulnerabilities:
+        report_gen.add_vulnerability_type(
+            vul.name(), vul.description(), vul.solution(),
+            flatten_references(vul.references()), vul.wstg_code()
+        )
+
+    request = Request("http://perdu.com/")
+    response = Response(
+        httpx.Response(status_code=200, headers=httpx.Headers([["Content-Type", "text/html"]]), text="x"),
+        url="http://perdu.com/"
+    )
+    report_gen.add_vulnerability(
+        category=category, level=1, request=request, response=response,
+        parameter="", info="No CSP", module="csp", wstg=["WSTG-CONF-12"]
+    )
+    report_gen.set_suppressed_findings({category: 7})
+
+    if report_format == "html":
+        with tempfile.TemporaryDirectory() as temp_dir:
+            report_gen.generate_report(temp_dir)
+            with open(report_gen.final_path, encoding="utf-8") as report_fd:
+                content = report_fd.read()
+    else:
+        temp_file = tempfile.NamedTemporaryFile(delete=False, mode="w", encoding="utf-8")
+        temp_file.close()
+        report_gen.generate_report(temp_file.name)
+        with open(temp_file.name, encoding="utf-8") as report_fd:
+            content = report_fd.read()
+        os.remove(temp_file.name)
+
+    if report_format == "json":
+        generated = json.loads(content)
+        assert generated["suppressed_findings"] == {category: 7}
+    elif report_format == "xml":
+        assert 'suppressed="7"' in content
+    else:
+        assert "7" in content
+        assert "suppressed" in content.lower()
+
+
 def test_level_to_css_class():
     assert level_to_css_class(CRITICAL_LEVEL) == "severity-critical"
     assert level_to_css_class(HIGH_LEVEL) == "severity-high"

--- a/tests/web/test_persister.py
+++ b/tests/web/test_persister.py
@@ -258,3 +258,29 @@ async def test_raw_post():
     payload = [__ async for __ in persister.get_payloads()][0]
     assert naughty_json == payload.evil_request
     assert payload.parameter == "z"
+
+
+@pytest.mark.asyncio
+async def test_suppressed_findings_round_trip():
+    try:
+        os.unlink("/tmp/suppressed.db")
+    except FileNotFoundError:
+        pass
+
+    persister = SqlPersister("/tmp/suppressed.db")
+    await persister.create()
+
+    # No suppressed findings stored yet
+    assert await persister.get_suppressed_findings() == {}
+
+    await persister.set_suppressed_findings({"Content Security Policy Configuration": 5, "HSTS": 2})
+    assert await persister.get_suppressed_findings() == {
+        "Content Security Policy Configuration": 5,
+        "HSTS": 2,
+    }
+
+    # Writing again overwrites the previous value (upsert on the key)
+    await persister.set_suppressed_findings({"HSTS": 3})
+    assert await persister.get_suppressed_findings() == {"HSTS": 3}
+
+    await persister.close()

--- a/tests/web/test_persister.py
+++ b/tests/web/test_persister.py
@@ -301,10 +301,12 @@ async def test_passive_scanner_state_round_trip():
     # No state stored yet
     assert await persister.get_passive_scanner_state() == {}
 
+    # Mirrors PassiveModule.get_state: occurrences is a list of [key, count] pairs,
+    # and composite keys are lists (JSON has no tuple) — this must survive the blob.
     state = {
-        "csp": {"occurrences": {"a": 1, "b": 1}, "suppressed_findings": 2,
+        "csp": {"occurrences": [[["example.com", "CSP", "Missing"], 1]], "suppressed_findings": 2,
                 "suppressed_by_category": {"CSP": 2}},
-        "https_redirect": {"occurrences": {"example.com": 1}, "suppressed_findings": 0,
+        "https_redirect": {"occurrences": [["example.com", 1]], "suppressed_findings": 0,
                             "suppressed_by_category": {}},
     }
     await persister.set_passive_scanner_state(state)

--- a/tests/web/test_persister.py
+++ b/tests/web/test_persister.py
@@ -261,7 +261,7 @@ async def test_raw_post():
 
 
 @pytest.mark.asyncio
-async def test_suppressed_findings_round_trip():
+async def test_suppressed_findings_derived_from_passive_state():
     try:
         os.unlink("/tmp/suppressed.db")
     except FileNotFoundError:
@@ -270,17 +270,48 @@ async def test_suppressed_findings_round_trip():
     persister = SqlPersister("/tmp/suppressed.db")
     await persister.create()
 
-    # No suppressed findings stored yet
+    # No passive state stored yet -> nothing suppressed
     assert await persister.get_suppressed_findings() == {}
 
-    await persister.set_suppressed_findings({"Content Security Policy Configuration": 5, "HSTS": 2})
+    # The report's per-category totals are aggregated across every module's own
+    # suppressed_by_category, all read from the single persisted passive state.
+    await persister.set_passive_scanner_state({
+        "csp": {"suppressed_by_category": {"Content Security Policy Configuration": 5, "HSTS": 1}},
+        "https_redirect": {"suppressed_by_category": {"HSTS": 1}},
+        "cookie_flags": {"occurrences": {"x": 1}},  # no suppressions -> contributes nothing
+    })
     assert await persister.get_suppressed_findings() == {
         "Content Security Policy Configuration": 5,
         "HSTS": 2,
     }
 
+    await persister.close()
+
+
+@pytest.mark.asyncio
+async def test_passive_scanner_state_round_trip():
+    try:
+        os.unlink("/tmp/passive_state.db")
+    except FileNotFoundError:
+        pass
+
+    persister = SqlPersister("/tmp/passive_state.db")
+    await persister.create()
+
+    # No state stored yet
+    assert await persister.get_passive_scanner_state() == {}
+
+    state = {
+        "csp": {"occurrences": {"a": 1, "b": 1}, "suppressed_findings": 2,
+                "suppressed_by_category": {"CSP": 2}},
+        "https_redirect": {"occurrences": {"example.com": 1}, "suppressed_findings": 0,
+                            "suppressed_by_category": {}},
+    }
+    await persister.set_passive_scanner_state(state)
+    assert await persister.get_passive_scanner_state() == state
+
     # Writing again overwrites the previous value (upsert on the key)
-    await persister.set_suppressed_findings({"HSTS": 3})
-    assert await persister.get_suppressed_findings() == {"HSTS": 3}
+    await persister.set_passive_scanner_state({"csp": {"occurrences": {"c": 1}}})
+    assert await persister.get_passive_scanner_state() == {"csp": {"occurrences": {"c": 1}}}
 
     await persister.close()

--- a/wapitiCore/attack/modules/passive/base.py
+++ b/wapitiCore/attack/modules/passive/base.py
@@ -40,17 +40,27 @@ class PassiveModule:
         self._occurrences: dict = defaultdict(int)
         # Number of alerts dropped because their key already reached LIMIT.
         self.suppressed_findings: int = 0
+        # Same count, but broken down per vulnerability category (finding class
+        # name) so the report can annotate the right summary line and section.
+        self.suppressed_by_category: dict = defaultdict(int)
 
-    def should_report(self, key: Any) -> bool:
+    def should_report(self, key: Any, finding_class=None) -> bool:
         """Return True for the first :attr:`LIMIT` occurrences of a key, then False.
 
         A single decision drives both logging and persistence: when it returns
         False the caller must emit nothing (no log line, no finding) — the alert
         is only counted as suppressed. This guarantees logs and report never
         diverge.
+
+        ``finding_class`` is the vulnerability class the caller would have
+        emitted; when provided, suppressions are also tallied per category
+        (``finding_class.name()``) so the report can surface them where the
+        matching findings live.
         """
         if self._occurrences[key] >= self.LIMIT:
             self.suppressed_findings += 1
+            if finding_class is not None:
+                self.suppressed_by_category[finding_class.name()] += 1
             return False
 
         self._occurrences[key] += 1

--- a/wapitiCore/attack/modules/passive/base.py
+++ b/wapitiCore/attack/modules/passive/base.py
@@ -66,5 +66,27 @@ class PassiveModule:
         self._occurrences[key] += 1
         return True
 
+    def get_state(self) -> dict:
+        """Serializable snapshot of the anti-flood state.
+
+        A resumed crawl (``--resume-crawl``) re-instantiates every module with an
+        empty state. Without restoring this snapshot the module would treat keys it
+        already capped during the interrupted run as unseen and re-emit duplicate
+        alerts, while the suppression counters would restart from zero. The
+        deduplication keys are the callers' identifiers (hashes, hosts, strings) so
+        the whole snapshot is JSON-friendly.
+        """
+        return {
+            "occurrences": dict(self._occurrences),
+            "suppressed_findings": self.suppressed_findings,
+            "suppressed_by_category": dict(self.suppressed_by_category),
+        }
+
+    def load_state(self, state: dict) -> None:
+        """Restore a snapshot previously produced by :meth:`get_state`."""
+        self._occurrences = defaultdict(int, state.get("occurrences", {}))
+        self.suppressed_findings = state.get("suppressed_findings", 0)
+        self.suppressed_by_category = defaultdict(int, state.get("suppressed_by_category", {}))
+
     def analyze(self, request: Request, response: Response) -> Generator[VulnerabilityInstance, Any, None]:
         raise NotImplementedError

--- a/wapitiCore/attack/modules/passive/base.py
+++ b/wapitiCore/attack/modules/passive/base.py
@@ -72,19 +72,27 @@ class PassiveModule:
         A resumed crawl (``--resume-crawl``) re-instantiates every module with an
         empty state. Without restoring this snapshot the module would treat keys it
         already capped during the interrupted run as unseen and re-emit duplicate
-        alerts, while the suppression counters would restart from zero. The
-        deduplication keys are the callers' identifiers (hashes, hosts, strings) so
-        the whole snapshot is JSON-friendly.
+        alerts, while the suppression counters would restart from zero.
+
+        Deduplication keys are frequently tuples (e.g. ``(host, header, ...)``),
+        which JSON cannot use as object keys. Occurrences are therefore stored as a
+        list of ``[key, count]`` pairs — a tuple key becomes a JSON array and is
+        turned back into a tuple in :meth:`load_state`.
         """
         return {
-            "occurrences": dict(self._occurrences),
+            "occurrences": [[key, count] for key, count in self._occurrences.items()],
             "suppressed_findings": self.suppressed_findings,
             "suppressed_by_category": dict(self.suppressed_by_category),
         }
 
     def load_state(self, state: dict) -> None:
         """Restore a snapshot previously produced by :meth:`get_state`."""
-        self._occurrences = defaultdict(int, state.get("occurrences", {}))
+        occurrences: dict = defaultdict(int)
+        for key, count in state.get("occurrences", []):
+            # JSON has no tuple type: composite keys come back as lists and must be
+            # turned back into (hashable) tuples to match the keys modules generate.
+            occurrences[tuple(key) if isinstance(key, list) else key] = count
+        self._occurrences = occurrences
         self.suppressed_findings = state.get("suppressed_findings", 0)
         self.suppressed_by_category = defaultdict(int, state.get("suppressed_by_category", {}))
 

--- a/wapitiCore/attack/modules/passive/mod_cookie_flags.py
+++ b/wapitiCore/attack/modules/passive/mod_cookie_flags.py
@@ -105,7 +105,7 @@ class ModuleCookieFlags(PassiveModule):
             # HttpOnly check
             if not httponly_flag:
                 identifier = (cookie_name, cookie_domain, "HttpOnly")
-                if self.should_report(identifier):
+                if self.should_report(identifier, HttpOnlyFinding):
                     log_red(INFO_COOKIE_HTTPONLY.format(cookie_name, request.url))
                     yield VulnerabilityInstance(
                         finding_class=HttpOnlyFinding,
@@ -118,7 +118,7 @@ class ModuleCookieFlags(PassiveModule):
             # Secure flag check
             if not secure_flag:
                 identifier = (cookie_name, cookie_domain, "Secure")
-                if self.should_report(identifier):
+                if self.should_report(identifier, SecureCookieFinding):
                     log_red(INFO_COOKIE_SECURE.format(cookie_name, request.url))
                     yield VulnerabilityInstance(
                         finding_class=SecureCookieFinding,

--- a/wapitiCore/attack/modules/passive/mod_csp.py
+++ b/wapitiCore/attack/modules/passive/mod_csp.py
@@ -77,7 +77,7 @@ class ModuleCsp(PassiveModule):
         if not csp_header_value:
             identifier = (request.netloc, "CSP", "Missing", posture)
 
-            if self.should_report(identifier):
+            if self.should_report(identifier, CspFinding):
                 log_red(MSG_NO_CSP.format(request.url))
                 yield VulnerabilityInstance(
                     finding_class=CspFinding,
@@ -91,7 +91,7 @@ class ModuleCsp(PassiveModule):
 
             for directive in find_unknown_directives(csp_dict):
                 identifier = (request.netloc, directive, "Unknown", posture)
-                if self.should_report(identifier):
+                if self.should_report(identifier, CspFinding):
                     info = MSG_CSP_UNKNOWN.format(directive, request.url)
                     log_red(info)
                     yield VulnerabilityInstance(
@@ -119,7 +119,7 @@ class ModuleCsp(PassiveModule):
 
                 if info:
                     identifier = (request.netloc, policy_name, "Unsafe" if result == 0 else "Missing", posture)
-                    if self.should_report(identifier):
+                    if self.should_report(identifier, CspFinding):
                         log_red(info)
                         yield VulnerabilityInstance(
                             finding_class=CspFinding,

--- a/wapitiCore/attack/modules/passive/mod_http_headers.py
+++ b/wapitiCore/attack/modules/passive/mod_http_headers.py
@@ -93,7 +93,7 @@ class ModuleHttpHeaders(PassiveModule):
             # once per (netloc, header), as before.
             identifier = (target, header_name, "not_set", "")
 
-            if self.should_report(identifier):
+            if self.should_report(identifier, finding_class):
                 log_red(f"{finding_info} on {request.url}")
                 return VulnerabilityInstance(
                     finding_class=finding_class,
@@ -108,7 +108,7 @@ class ModuleHttpHeaders(PassiveModule):
             # for the same header each surface, while identical ones are deduplicated.
             posture = response.headers[header_name].strip().lower()
             identifier = (target, header_name, "invalid_value", posture)
-            if self.should_report(identifier):
+            if self.should_report(identifier, finding_class):
                 log_orange(f"{finding_info} on {request.url}")
                 return VulnerabilityInstance(
                     finding_class=finding_class,

--- a/wapitiCore/attack/modules/passive/mod_https_redirect.py
+++ b/wapitiCore/attack/modules/passive/mod_https_redirect.py
@@ -85,7 +85,7 @@ class ModuleHttpsRedirect(PassiveModule):
                 finding_type = "no_redirect"
 
             identifier = (host, sensitive_reason, finding_type)
-            if self.should_report(identifier):
+            if self.should_report(identifier, HstsFinding):
                 # Report the vulnerability based on the type of redirection
                 if finding_type == "redirect_to_https":
                     full_info = self.MSG_SENSITIVE_REDIRECT_TO_HTTPS.format(reason=sensitive_reason, url=request.url)
@@ -107,7 +107,7 @@ class ModuleHttpsRedirect(PassiveModule):
                 )
         elif "html" in response.headers.get("content-type", "html").lower():
             # Non-sensitive case, check for general lack of HTTPS redirection
-            if self.should_report(host):
+            if self.should_report(host, HstsFinding):
                 if not response.is_redirect or urlparse(response.redirection_url).scheme != "https":
                     log_orange(f"Host {host} serves HTTP content without redirecting to HTTPS.")
                     yield VulnerabilityInstance(

--- a/wapitiCore/attack/modules/passive/mod_inconsistent_redirection.py
+++ b/wapitiCore/attack/modules/passive/mod_inconsistent_redirection.py
@@ -67,7 +67,7 @@ class ModuleInconsistentRedirection(PassiveModule):
             return
 
         # Deduplicate with response MD5
-        if not self.should_report(response.md5):
+        if not self.should_report(response.md5, InconsistentRedirectionFinding):
             return
 
         log_orange(

--- a/wapitiCore/attack/modules/passive/mod_information_disclosure.py
+++ b/wapitiCore/attack/modules/passive/mod_information_disclosure.py
@@ -87,7 +87,7 @@ class ModuleInformationDisclosure(PassiveModule):
             if not _is_realistic_path(evidence):
                 continue
 
-            if not self.should_report(evidence.rstrip(".")):
+            if not self.should_report(evidence.rstrip("."), InformationDisclosureFinding):
                 continue
 
             log_orange(f"Potential full path disclosure in {request.url}: {evidence}")

--- a/wapitiCore/attack/modules/passive/mod_stacktrace_disclosure.py
+++ b/wapitiCore/attack/modules/passive/mod_stacktrace_disclosure.py
@@ -122,7 +122,7 @@ class ModuleStacktraceDisclosure(PassiveModule):
                 evidence = evidence[:150] + "..."
 
             key = (label, evidence)
-            if not self.should_report(key):
+            if not self.should_report(key, StacktraceDisclosureFinding):
                 continue
 
             log_orange(

--- a/wapitiCore/attack/modules/passive/mod_unsecure_password.py
+++ b/wapitiCore/attack/modules/passive/mod_unsecure_password.py
@@ -31,7 +31,7 @@ class ModuleUnsecurePassword(PassiveModule):
                         # flood the report. The exact URL is still displayed.
                         form_identifier = (request.path, form.method.upper(), field.name)
 
-                        if not self.should_report(form_identifier):
+                        if not self.should_report(form_identifier, CleartextPasswordSubmissionFinding):
                             continue
 
                         log_red(

--- a/wapitiCore/attack/passive_scanner.py
+++ b/wapitiCore/attack/passive_scanner.py
@@ -1,3 +1,4 @@
+from collections import defaultdict
 from importlib import import_module
 from pathlib import Path
 from typing import Dict
@@ -73,6 +74,31 @@ class PassiveScanner:
         log_blue("[*] Some similar passive alerts were suppressed to keep the report readable:")
         for module_name, suppressed in suppressed_by_module.items():
             log_blue("    {0}: {1} similar alert(s) suppressed", module_name, suppressed)
+
+    def suppressed_by_category(self) -> Dict[str, int]:
+        """Total number of suppressed alerts, broken down per vulnerability category.
+
+        Aggregates every module's ``suppressed_by_category`` counter. The report
+        is organized per category (finding class), not per module, so this is the
+        breakdown a report needs to annotate the right summary line and section.
+        """
+        totals: Dict[str, int] = defaultdict(int)
+        for module_instance in self._modules.values():
+            for category, count in getattr(module_instance, "suppressed_by_category", {}).items():
+                totals[category] += count
+        return dict(totals)
+
+    async def persist_suppressed_findings(self):
+        """Store the per-category suppression counts so the report survives the crawl.
+
+        The report is generated in a later, possibly decoupled step (e.g. a resumed
+        scan with ``--skip-crawl``, or regenerating a report from the ``.db`` file),
+        when the in-memory module counters are gone. Persisting them keeps the
+        information available to every report format.
+        """
+        counts = self.suppressed_by_category()
+        if counts:
+            await self._persister.set_suppressed_findings(counts)
 
     async def _record_vulnerability_instance(self, vuln_instance: VulnerabilityInstance, module: str):
         await self._persister.add_payload(

--- a/wapitiCore/attack/passive_scanner.py
+++ b/wapitiCore/attack/passive_scanner.py
@@ -1,4 +1,3 @@
-from collections import defaultdict
 from importlib import import_module
 from pathlib import Path
 from typing import Dict
@@ -75,30 +74,41 @@ class PassiveScanner:
         for module_name, suppressed in suppressed_by_module.items():
             log_blue("    {0}: {1} similar alert(s) suppressed", module_name, suppressed)
 
-    def suppressed_by_category(self) -> Dict[str, int]:
-        """Total number of suppressed alerts, broken down per vulnerability category.
+    def get_state(self) -> Dict[str, dict]:
+        """Snapshot every module's anti-flood state, keyed by module name."""
+        return {
+            module_name: module_instance.get_state()
+            for module_name, module_instance in self._modules.items()
+        }
 
-        Aggregates every module's ``suppressed_by_category`` counter. The report
-        is organized per category (finding class), not per module, so this is the
-        breakdown a report needs to annotate the right summary line and section.
+    def load_state(self, state: Dict[str, dict]):
+        """Restore a snapshot produced by :meth:`get_state` into the loaded modules.
+
+        Unknown module names in the snapshot (e.g. a module removed since the
+        interrupted run) are ignored so a resume never fails on a stale state.
         """
-        totals: Dict[str, int] = defaultdict(int)
-        for module_instance in self._modules.values():
-            for category, count in getattr(module_instance, "suppressed_by_category", {}).items():
-                totals[category] += count
-        return dict(totals)
+        for module_name, module_state in state.items():
+            module_instance = self._modules.get(module_name)
+            if module_instance is not None:
+                module_instance.load_state(module_state)
 
-    async def persist_suppressed_findings(self):
-        """Store the per-category suppression counts so the report survives the crawl.
+    async def persist_state(self):
+        """Store the passive scanner state so both the resume and the report survive the crawl.
 
-        The report is generated in a later, possibly decoupled step (e.g. a resumed
-        scan with ``--skip-crawl``, or regenerating a report from the ``.db`` file),
-        when the in-memory module counters are gone. Persisting them keeps the
-        information available to every report format.
+        This is the single source of truth for everything the passive scanner
+        accumulates: the per-key occurrence counts (so a resumed crawl keeps
+        deduplicating instead of re-reporting already-seen alerts) and the
+        per-category suppression counters (which the report derives from this same
+        state, see ``SqlPersister.get_suppressed_findings``). Written unconditionally
+        so the occurrence counts survive even when nothing was suppressed yet.
         """
-        counts = self.suppressed_by_category()
-        if counts:
-            await self._persister.set_suppressed_findings(counts)
+        await self._persister.set_passive_scanner_state(self.get_state())
+
+    async def restore_state(self):
+        """Reload the passive scanner state persisted by a previous (interrupted) crawl."""
+        state = await self._persister.get_passive_scanner_state()
+        if state:
+            self.load_state(state)
 
     async def _record_vulnerability_instance(self, vuln_instance: VulnerabilityInstance, module: str):
         await self._persister.add_payload(

--- a/wapitiCore/controller/wapiti.py
+++ b/wapitiCore/controller/wapiti.py
@@ -167,6 +167,8 @@ class Wapiti:
             detailed_report_level=self.detailed_report_level
         )
 
+        self.report_gen.set_suppressed_findings(await self.persister.get_suppressed_findings())
+
         for vul in vulnerabilities:
             self.report_gen.add_vulnerability_type(
                 vul.name(),
@@ -310,6 +312,7 @@ class Wapiti:
             await run_explorer(explorer)
 
         self._passive_scanner.log_summary()
+        await self._passive_scanner.persist_suppressed_findings()
 
     async def write_report(self):
         if not self.output_file:

--- a/wapitiCore/controller/wapiti.py
+++ b/wapitiCore/controller/wapiti.py
@@ -197,6 +197,11 @@ class Wapiti:
             )
 
     async def load_scan_state(self):
+        # Restore the passive scanner's per-module deduplication state so a resumed
+        # crawl (--resume-crawl) keeps capping alerts instead of re-reporting keys it
+        # already saw during the interrupted run. A no-op for a fresh scan (empty state).
+        await self._passive_scanner.restore_state()
+
         async for request in self.persister.get_to_browse():
             self._start_urls.append(request)
         async for request, __ in self.persister.get_links():
@@ -312,7 +317,10 @@ class Wapiti:
             await run_explorer(explorer)
 
         self._passive_scanner.log_summary()
-        await self._passive_scanner.persist_suppressed_findings()
+        # Persist the full anti-flood state: the occurrence counts so a later
+        # --resume-crawl keeps deduplicating from where this crawl stopped, and the
+        # per-category suppression counters the report derives from the same state.
+        await self._passive_scanner.persist_state()
 
     async def write_report(self):
         if not self.output_file:

--- a/wapitiCore/net/sql_persister.py
+++ b/wapitiCore/net/sql_persister.py
@@ -199,6 +199,36 @@ class SqlPersister:
             self.root_url = value
             return value
 
+    SUPPRESSED_FINDINGS_KEY = "suppressed_findings"
+
+    async def set_suppressed_findings(self, counts: Dict[str, int]):
+        """Store, per vulnerability category, how many similar passive alerts were suppressed.
+
+        Kept in the generic ``scan_infos`` key/value table as a single JSON blob so
+        the report can surface it even when generated in a separate step. Overwrites
+        any previous value for this scan (upsert on the key).
+        """
+        async with self._engine.begin() as conn:
+            await conn.execute(
+                self.scan_infos.delete().where(self.scan_infos.c.key == self.SUPPRESSED_FINDINGS_KEY)
+            )
+            await conn.execute(self.scan_infos.insert().values(
+                key=self.SUPPRESSED_FINDINGS_KEY,
+                value=json.dumps(counts)
+            ))
+
+    async def get_suppressed_findings(self) -> Dict[str, int]:
+        """Return the per-category suppressed-alert counts, or an empty dict if none were stored."""
+        statement = select(self.scan_infos).where(
+            self.scan_infos.c.key == self.SUPPRESSED_FINDINGS_KEY
+        ).limit(1)
+        async with self._engine.begin() as conn:
+            result = await conn.execute(statement)
+            row = result.fetchone()
+            if row is None:
+                return {}
+            return json.loads(row.value)
+
     async def set_to_browse(self, to_browse: Sequence[Request]):
         await self.save_requests([(request, None) for request in to_browse])
 

--- a/wapitiCore/net/sql_persister.py
+++ b/wapitiCore/net/sql_persister.py
@@ -199,28 +199,46 @@ class SqlPersister:
             self.root_url = value
             return value
 
-    SUPPRESSED_FINDINGS_KEY = "suppressed_findings"
+    async def get_suppressed_findings(self) -> Dict[str, int]:
+        """Return the per-category count of suppressed passive alerts.
 
-    async def set_suppressed_findings(self, counts: Dict[str, int]):
-        """Store, per vulnerability category, how many similar passive alerts were suppressed.
+        Derived from the persisted passive scanner state (the single source of
+        truth, see :meth:`get_passive_scanner_state`): every module records how many
+        alerts it suppressed per finding category, and the report — organized per
+        category, not per module — needs those totals aggregated across all modules.
+        Returns an empty dict when no passive state was stored.
+        """
+        state = await self.get_passive_scanner_state()
+        totals: Dict[str, int] = {}
+        for module_state in state.values():
+            for category, count in module_state.get("suppressed_by_category", {}).items():
+                totals[category] = totals.get(category, 0) + count
+        return totals
 
-        Kept in the generic ``scan_infos`` key/value table as a single JSON blob so
-        the report can surface it even when generated in a separate step. Overwrites
-        any previous value for this scan (upsert on the key).
+    PASSIVE_SCANNER_STATE_KEY = "passive_scanner_state"
+
+    async def set_passive_scanner_state(self, state: Dict[str, Any]):
+        """Persist the passive scanner's per-module anti-flood state.
+
+        Passive modules deduplicate alerts in memory (per-key occurrence counts and
+        suppression counters). A crawl interrupted and resumed with ``--resume-crawl``
+        restarts every module empty, so this snapshot is stored to let a resumed crawl
+        pick up where the previous one left off instead of re-reporting already-capped
+        alerts. Stored as a single JSON blob in ``scan_infos`` (upsert on the key).
         """
         async with self._engine.begin() as conn:
             await conn.execute(
-                self.scan_infos.delete().where(self.scan_infos.c.key == self.SUPPRESSED_FINDINGS_KEY)
+                self.scan_infos.delete().where(self.scan_infos.c.key == self.PASSIVE_SCANNER_STATE_KEY)
             )
             await conn.execute(self.scan_infos.insert().values(
-                key=self.SUPPRESSED_FINDINGS_KEY,
-                value=json.dumps(counts)
+                key=self.PASSIVE_SCANNER_STATE_KEY,
+                value=json.dumps(state)
             ))
 
-    async def get_suppressed_findings(self) -> Dict[str, int]:
-        """Return the per-category suppressed-alert counts, or an empty dict if none were stored."""
+    async def get_passive_scanner_state(self) -> Dict[str, Any]:
+        """Return the stored passive scanner state, or an empty dict if none was stored."""
         statement = select(self.scan_infos).where(
-            self.scan_infos.c.key == self.SUPPRESSED_FINDINGS_KEY
+            self.scan_infos.c.key == self.PASSIVE_SCANNER_STATE_KEY
         ).limit(1)
         async with self._engine.begin() as conn:
             result = await conn.execute(statement)

--- a/wapitiCore/report/htmlreportgenerator.py
+++ b/wapitiCore/report/htmlreportgenerator.py
@@ -111,6 +111,7 @@ class HTMLReportGenerator(JSONReportGenerator):
                     vulnerabilities=self._vulns,
                     anomalies=self._anomalies,
                     additionals=self._additionals,
+                    suppressed=self._suppressed,
                     flaws=self._flaw_types,
                     level_to_css_class=level_to_css_class,
                     detailed_report_level=self._infos["detailed_report_level"]

--- a/wapitiCore/report/jsonreportgenerator.py
+++ b/wapitiCore/report/jsonreportgenerator.py
@@ -64,7 +64,8 @@ class JSONReportGenerator(ReportGenerator):
             "vulnerabilities": self._vulns,
             "anomalies": self._anomalies,
             "additionals": self._additionals,
-            "infos": self._infos
+            "infos": self._infos,
+            "suppressed_findings": self._suppressed
         }
         with open(output_path, "w", encoding="utf-8") as json_report_file:
             json.dump(report_dict, json_report_file, indent=2, cls=BytesDump)

--- a/wapitiCore/report/markdownreportgenerator.py
+++ b/wapitiCore/report/markdownreportgenerator.py
@@ -47,7 +47,11 @@ class MarkdownReportGenerator(ReportGenerator):
             md_report_file.write("| Category | Count |\n")
             md_report_file.write("|---|---|\n")
             for category, vulnerabilities in self._vulns.items():
-                md_report_file.write(f"| {category} | {len(vulnerabilities)} |\n")
+                count = str(len(vulnerabilities))
+                suppressed = self._suppressed.get(category)
+                if suppressed:
+                    count += f" (+{suppressed} suppressed)"
+                md_report_file.write(f"| {category} | {count} |\n")
             md_report_file.write("\n---\n\n")
 
             for category, vulnerabilities in self._vulns.items():
@@ -63,6 +67,11 @@ class MarkdownReportGenerator(ReportGenerator):
                         md_report_file.write("\n**cURL command PoC**:\n\n")
                         md_report_file.write(f"```bash\n{curl_repr(vuln['request'])}\n```\n\n")
                         md_report_file.write("---\n\n")
+                    suppressed = self._suppressed.get(category)
+                    if suppressed:
+                        md_report_file.write(
+                            f"> {suppressed} more similar finding(s) were suppressed to keep the report readable.\n\n"
+                        )
             md_report_file.write("\n")
 
             md_report_file.write("## Summary of anomalies\n\n")

--- a/wapitiCore/report/reportgenerator.py
+++ b/wapitiCore/report/reportgenerator.py
@@ -38,6 +38,14 @@ class ReportGenerator:
         self._vulns = {}
         self._anomalies = {}
         self._additionals = {}
+        # Per-category count of passive alerts that were suppressed to avoid
+        # flooding the report (see PassiveModule.should_report). Keyed by the
+        # vulnerability category, matching the keys of self._vulns.
+        self._suppressed = {}
+
+    def set_suppressed_findings(self, counts):
+        """Record, per category, how many similar passive alerts were suppressed."""
+        self._suppressed = counts or {}
 
     # pylint: disable=too-many-positional-arguments
     def set_report_info(

--- a/wapitiCore/report/txtreportgenerator.py
+++ b/wapitiCore/report/txtreportgenerator.py
@@ -67,7 +67,9 @@ class TXTReportGenerator(ReportGenerator):
 
                 txt_report_file.write(title("Summary of vulnerabilities :"))
                 for category, vulnerabilities in self._vulns.items():
-                    txt_report_file.write(f"{category} : {len(vulnerabilities):>3}\n".rjust(NB_COLUMNS))
+                    suppressed = self._suppressed.get(category)
+                    suffix = f"  (+{suppressed} similar suppressed)" if suppressed else ""
+                    txt_report_file.write(f"{category} : {len(vulnerabilities):>3}{suffix}\n".rjust(NB_COLUMNS))
                 txt_report_file.write(separator)
 
                 for category, vulnerabilities in self._vulns.items():
@@ -86,6 +88,11 @@ class TXTReportGenerator(ReportGenerator):
                             txt_report_file.write(f"cURL command PoC : \"{curl_repr(vuln['request'])}\"")
                             txt_report_file.write("\n\n")
                             txt_report_file.write(center("*   *   *\n\n"))
+                        suppressed = self._suppressed.get(category)
+                        if suppressed:
+                            txt_report_file.write(
+                                f"{suppressed} more similar finding(s) were suppressed to keep the report readable.\n"
+                            )
                         txt_report_file.write(separator)
 
                 txt_report_file.write("\n")

--- a/wapitiCore/report/xmlreportgenerator.py
+++ b/wapitiCore/report/xmlreportgenerator.py
@@ -103,6 +103,9 @@ class XMLReportGenerator(JSONReportGenerator):
             # Child nodes with a description of the flaw type
             flaw_type_node = self._xml_doc.createElement(classification)
             flaw_type_node.setAttribute("name", flaw_type_name)
+            suppressed = self._suppressed.get(flaw_type_name)
+            if suppressed:
+                flaw_type_node.setAttribute("suppressed", str(suppressed))
             flaw_type_desc = self._xml_doc.createElement("description")
             flaw_type_desc.appendChild(self._xml_doc.createCDATASection(flaw_type["desc"]))
             flaw_type_node.appendChild(flaw_type_desc)

--- a/wapitiCore/report_template/report.html
+++ b/wapitiCore/report_template/report.html
@@ -45,7 +45,12 @@
                             ${vuln_name}
                             % endif
                         </td>
-                        <td class="small text-centered">${len(vulnerabilities[vuln_name])}</td>
+                        <td class="small text-centered">
+                            ${len(vulnerabilities[vuln_name])}
+                            % if suppressed.get(vuln_name):
+                            <span class="small" title="Similar findings hidden to keep the report readable">(+${suppressed[vuln_name]} suppressed)</span>
+                            % endif
+                        </td>
                     </tr>
                 % endfor
                 % for i, anomaly_name in enumerate(anomalies):
@@ -129,6 +134,9 @@
                         </section>
                     </div>
                     % endfor
+                    % if suppressed.get(vuln_name):
+                    <p class="small"><em>${suppressed[vuln_name]} more similar finding(s) were suppressed to keep the report readable.</em></p>
+                    % endif
 
                 <dl><dt>Solutions</dt><dd>${flaws[vuln_name]["sol"]}</dd></dl>
                 <h5>References</h5>


### PR DESCRIPTION
## Context

Passive modules cap how many similar alerts they emit per deduplication key (`PassiveModule.should_report`, `LIMIT`) to keep reports readable. Until now the number of dropped alerts was only logged once to the console after the crawl (`PassiveScanner.log_summary`); it never reached the reports, so a reader had no way to know findings had been trimmed.

This carries the suppression count into every report, **broken down per vulnerability category** so it lands right next to the findings it relates to (including the summary table).

## Changes

- `PassiveModule.should_report(key, finding_class)` now also tallies suppressions per category (`finding_class.name()`), alongside the existing per-module total. The 8 passive modules pass their finding class.
- `PassiveScanner` aggregates the per-category counts across modules and **persists** them (a JSON blob in the `scan_infos` key/value table) after the crawl, so the information survives a decoupled report step (`--skip-crawl`, or regenerating a report from the `.db` file).
- The controller feeds the persisted counts to the report generator.
- Reports render it per category:
  - **txt / markdown**: `(+N suppressed)` in the summary table + a note in the category section.
  - **html**: annotated summary cell + an italic note in the section.
  - **json**: top-level `suppressed_findings` object.
  - **xml**: a `suppressed` attribute on the vulnerability node.
- **CSV** is intentionally left unchanged: its schema is one row per emitted finding, with no aggregate section where a per-category count would fit.

## Tests

- Per-category counting (base), cross-module aggregation + persistence (scanner), persister round-trip, and per-format rendering of the suppression annotation.
- HTML/JSON golden fixtures regenerated (JSON gains a `suppressed_findings` key; HTML gains the summary-cell markup). txt/md/xml/csv output is unchanged when nothing was suppressed.
- `pylint --rcfile=.pylintrc` on the touched files: 10.00/10.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
