### PR TITLE
Prepare release 3.3.1: changelog and version bump

### DIFF
--- a/VERSION
+++ b/VERSION
@@ -1,1 +1,1 @@
-Wapiti 3.3.0
+Wapiti 3.3.1

--- a/doc/ChangeLog_Wapiti
+++ b/doc/ChangeLog_Wapiti
@@ -1,3 +1,32 @@
+27/07/2026
+    Wapiti 3.3.1
+    Security: fix a stored XSS in the HTML report, target-controlled login form field names were rendered unescaped (CWE-79)
+    Modules: new passive module stacktrace_disclosure, detecting leaked stack traces for Python, PHP, Java, .NET (YSOD), Node.js, Ruby and Go
+    Modules: mod_csp now detects unknown directives and checks frame-ancestors and form-action
+    Modules: mod_sql boolean-based detection made robust to dynamic pages and rate-limiting, added an OR-based technique
+    Modules: mod_ssrf reports timeouts and HTTP 500 anomalies
+    Modules: mod_buster warns once per host when the server rate-limits the scan
+    Modules: faster DNS verification in mod_log4shell
+    Attack: new PassiveModule base class with a per-key alert cap and a suppression counter shared by all passive modules
+    Attack: csp and http_headers now report distinct postures per host instead of a single finding for the whole site (#617)
+    Report: number of alerts suppressed by passive modules is now reported per vulnerability category (txt, markdown, html, json, xml)
+    Core: apply a read timeout so a stalled response can no longer hang the scan (#797)
+    Core: cap repeated parameter occurrences in crawled URLs (#252)
+    Core: in headless mode, seed hosts uncovered by the interception layer so host-level modules (ssl, http_headers...) still run
+    Core: passive deduplication state is persisted and restored across --resume-crawl
+    Core: update dependencies (aiosqlite, mitmproxy) and dev tooling
+    CLI: fix a hang on Ctrl+C during an attack (#802)
+    Fixes: mod_buster no longer reports soft 404s, catch-all redirections and 5xx responses as discovered pages
+    Fixes: mod_methods logs the tested path and no longer emits empty findings
+    Fixes: fix a RuntimeError in mod_xxe when an OOB-vulnerable parameter is skipped
+    Fixes: reduced false positives in the inconsistent_redirection, information_disclosure and stacktrace_disclosure passive modules
+    Fixes: cleartext password findings are deduplicated per page instead of per URL, no longer flooding reports
+    Fixes: fix cookie domain mismatch for dotless local hostnames
+    Fixes: fix an IndexError on root URLs without a trailing slash
+    Fixes: fix XSS attribute parsing on Python 3.12+ / 3.13+
+    Fixes: silence the BeautifulSoup XMLParsedAsHTMLWarning during parsing
+    doc: fix dead OWASP WSTG, OWASP and KeyCDN reference links
+
 13/05/2026
     Wapiti 3.3.0
     Modules: new mod_printer to detect HP and EPSON printers

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "wapiti3"
-version = "3.3.0"
+version = "3.3.1"
 description = "A web application vulnerability scanner"
 readme  = "README.rst"
 requires-python = ">=3.12,<3.15"

--- a/tests/integration/test_mod_crlf/assertions/crlf.json
+++ b/tests/integration/test_mod_crlf/assertions/crlf.json
@@ -7,7 +7,7 @@
                 "info": "CRLF Injection via injection in the parameter user-agent",
                 "parameter": "user-agent",
                 "module": "crlf",
-                "http_request": "GET /index.php?user-agent=http%3A%2F%2Fwww.google.fr%0D%0Awapiti%3A%203.3.0%20version HTTP/1.1\nhost: crlf\nconnection: keep-alive\nuser-agent: Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:128.0) Gecko/20100101 Firefox/128.0\naccept-language: en-US\naccept-encoding: gzip, deflate, br\naccept: text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,*/*;q=0.8",
+                "http_request": "GET /index.php?user-agent=http%3A%2F%2Fwww.google.fr%0D%0Awapiti%3A%203.3.1%20version HTTP/1.1\nhost: crlf\nconnection: keep-alive\nuser-agent: Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:128.0) Gecko/20100101 Firefox/128.0\naccept-language: en-US\naccept-encoding: gzip, deflate, br\naccept: text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,*/*;q=0.8",
                 "wstg": [
                     "WSTG-INPV-15"
                 ]

--- a/wapitiCore/__init__.py
+++ b/wapitiCore/__init__.py
@@ -19,4 +19,4 @@
 # along with this program; if not, write to the Free Software
 # Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 parser_name = "html.parser"
-WAPITI_VERSION = "3.3.0"
+WAPITI_VERSION = "3.3.1"

--- a/wapitiCore/attack/mod_crlf.py
+++ b/wapitiCore/attack/mod_crlf.py
@@ -39,7 +39,7 @@ class ModuleCrlf(Attack):
     MSG_VULN = "CRLF Injection"
     do_get = True
     do_post = True
-    payloads = [PayloadInfo(payload="http://www.google.fr\r\nwapiti: 3.3.0 version")]
+    payloads = [PayloadInfo(payload="http://www.google.fr\r\nwapiti: 3.3.1 version")]
     parallelize_attacks = True
 
     def __init__(self, crawler, persister, attack_options, crawler_configuration):
@@ -51,7 +51,7 @@ class ModuleCrlf(Attack):
 
         for mutated_request, parameter, _payload in self.mutator.mutate(
                 request,
-                str_to_payloadinfo(["http://www.google.fr\r\nwapiti: 3.3.0 version"]),
+                str_to_payloadinfo(["http://www.google.fr\r\nwapiti: 3.3.1 version"]),
         ):
             log_verbose(f"[¨] {mutated_request.url}")
 


### PR DESCRIPTION
## Summary

Release preparation for **Wapiti 3.3.1**. No functional change: every commit of this release is already on `master`, this PR only documents them and bumps the version.

- `doc/ChangeLog_Wapiti`: new `27/07/2026 — Wapiti 3.3.1` entry covering the 41 commits merged since the `3.3.0` tag
- Version bumped to `3.3.1` in `VERSION`, `pyproject.toml` and `wapitiCore/__init__.py`
- `mod_crlf`: the injected payload embeds the version string (`wapiti: 3.3.1 version`), bumped along with its integration assertion — same as the previous release commit `6374b6b`

## Release highlights

- **Security**: stored XSS in the HTML report — the auto-detected login form field names come from the scanned target and were rendered unescaped by the Mako template (CWE-79)
- **New module**: `stacktrace_disclosure` passive module (Python, PHP, Java, .NET/YSOD, Node.js, Ruby, Go)
- **Passive scan rework**: `PassiveModule` base class with a per-key alert cap, suppression counters surfaced in the console and in every report format, distinct CSP/header postures reported per host (#617), state persisted across `--resume-crawl`
- **Robustness**: read timeout so a stalled response can no longer hang a scan (#797), no more hang on Ctrl+C during an attack (#802), capped repeated parameter occurrences while crawling (#252), host seeding in headless mode so host-level modules still run
- **False positives**: `mod_buster` (soft 404s, catch-all redirects, 5xx), `mod_methods` (empty findings), `mod_sql`, and the `inconsistent_redirection` / `information_disclosure` / `unsecure_password` passive modules

## Test plan

- `pytest tests/attack/test_mod_crlf.py tests/reports/` → 26 passed (the report fixtures and the CRLF payload are the version-sensitive spots)
- The `test_mod_crlf` integration assertion was updated in the same commit as the payload, so the Docker integration job stays green

Manpages need no update: they carry no version number, and no CLI option changed since 3.3.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
